### PR TITLE
NETOBSERV-98: specify loki tenant id

### DIFF
--- a/cmd/plugin-backend.go
+++ b/cmd/plugin-backend.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/netobserv/network-observability-console-plugin/pkg/handler"
 	"github.com/netobserv/network-observability-console-plugin/pkg/server"
 )
 
@@ -23,12 +24,13 @@ var (
 	corsHeaders = flag.String("cors-headers", "Origin, X-Requested-With, Content-Type, Accept", "CORS allowed headers (default: Origin, X-Requested-With, Content-Type, Accept)")
 	corsMaxAge  = flag.String("cors-max-age", "", "CORS allowed max age (default: unset)")
 	// todo: default value temporarily kept to make it work with older versions of the NOO. Remove default and force setup of loki url
-	lokiURL     = flag.String("loki", "http://localhost:3100", "URL of the loki querier host")
-	lokiTimeout = flag.Duration("loki-timeout", 10*time.Second, "Timeout of the Loki query to retrieve logs")
-	logLevel    = flag.String("loglevel", "info", "log level (default: info)")
-	versionFlag = flag.Bool("v", false, "print version")
-	appVersion  = fmt.Sprintf("%s %s", app, version)
-	log         = logrus.WithField("module", "main")
+	lokiURL      = flag.String("loki", "http://localhost:3100", "URL of the loki querier host")
+	lokiTimeout  = flag.Duration("loki-timeout", 10*time.Second, "Timeout of the Loki query to retrieve logs")
+	lokiTenantID = flag.String("loki-tenant-id", "", "Tenant organization ID for multi-tenant-loki (submitted as the X-Scope-OrgID HTTP header)")
+	logLevel     = flag.String("loglevel", "info", "log level (default: info)")
+	versionFlag  = flag.Bool("v", false, "print version")
+	appVersion   = fmt.Sprintf("%s %s", app, version)
+	log          = logrus.WithField("module", "main")
 )
 
 func main() {
@@ -61,7 +63,10 @@ func main() {
 		CORSAllowMethods: *corsMethods,
 		CORSAllowHeaders: *corsHeaders,
 		CORSMaxAge:       *corsMaxAge,
-		LokiURL:          lURL,
-		LokiTimeout:      *lokiTimeout,
+		Loki: handler.LokiConfig{
+			URL:      lURL,
+			Timeout:  *lokiTimeout,
+			TenantID: *lokiTenantID,
+		},
 	})
 }

--- a/pkg/httpclient/http_client.go
+++ b/pkg/httpclient/http_client.go
@@ -7,22 +7,35 @@ import (
 	"time"
 )
 
-func HTTPGet(url string, timeout time.Duration) ([]byte, int, error) {
+type HTTPClient struct {
+	client  http.Client
+	headers map[string][]string
+}
+
+func NewHTTPClient(timeout time.Duration, overrideHeaders map[string][]string) HTTPClient {
+	transport := &http.Transport{
+		DialContext:     (&net.Dialer{Timeout: timeout}).DialContext,
+		IdleConnTimeout: timeout,
+	}
+
+	return HTTPClient{
+		client:  http.Client{Transport: transport, Timeout: timeout},
+		headers: overrideHeaders,
+	}
+}
+
+func (hc *HTTPClient) Get(url string) ([]byte, int, error) {
 	// TODO: manage authentication / TLS
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, 0, err
 	}
-
-	transport := &http.Transport{
-		DialContext:     (&net.Dialer{Timeout: timeout}).DialContext,
-		IdleConnTimeout: timeout,
+	for k, v := range hc.headers {
+		req.Header[k] = v
 	}
 
-	client := http.Client{Transport: transport, Timeout: timeout}
-
-	resp, err := client.Do(req)
+	resp, err := hc.client.Do(req)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -11,7 +11,7 @@ import (
 func setupRoutes(cfg *Config) *mux.Router {
 	r := mux.NewRouter()
 	r.HandleFunc("/api/status", handler.Status)
-	r.HandleFunc("/api/loki/flows", handler.GetFlows(cfg.LokiURL, cfg.LokiTimeout))
+	r.HandleFunc("/api/loki/flows", handler.GetFlows(cfg.Loki))
 	r.PathPrefix("/").Handler(http.FileServer(http.Dir("./web/dist/")))
 	return r
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4,10 +4,11 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
-	"net/url"
 	"time"
 
 	"github.com/sirupsen/logrus"
+
+	"github.com/netobserv/network-observability-console-plugin/pkg/handler"
 )
 
 var slog = logrus.WithField("module", "server")
@@ -20,8 +21,7 @@ type Config struct {
 	CORSAllowMethods string
 	CORSAllowHeaders string
 	CORSMaxAge       string
-	LokiURL          *url.URL
-	LokiTimeout      time.Duration
+	Loki             handler.LokiConfig
 }
 
 func Start(cfg *Config) {


### PR DESCRIPTION
For multi-tenant Loki setups, this PR allows specifying the `loki-tenant-id` CLI argument, which will forward this value to loki as the `X-Scope-OrgID` header.

More details of this header: https://grafana.com/docs/loki/latest/operations/multi-tenancy/