### PR TITLE
NETOBSERV-71 added toolbar with select column modal

### DIFF
--- a/web/locales/en/plugin__network-observability-plugin.json
+++ b/web/locales/en/plugin__network-observability-plugin.json
@@ -27,5 +27,6 @@
     "Unselect all": "Unselect all",
     "Restore default columns": "Restore default columns",
     "Selected columns will appear in the table.": "Selected columns will appear in the table.",
-    "Click and drag the items to reorder the columns in the table.": "Click and drag the items to reorder the columns in the table."
+    "Click and drag the items to reorder the columns in the table.": "Click and drag the items to reorder the columns in the table.",
+    "At least one column must be selected": "At least one column must be selected"
 }

--- a/web/locales/en/plugin__network-observability-plugin.json
+++ b/web/locales/en/plugin__network-observability-plugin.json
@@ -18,5 +18,14 @@
     "{{count}} hour": "{{count}} hour",
     "{{count}} hour_plural": "{{count}} hours",
     "{{count}} day": "{{count}} day",
-    "{{count}} day_plural": "{{count}} days"
+    "{{count}} day_plural": "{{count}} days",
+    "Manage columns": "Manage columns",
+    "Column management": "Column management",
+    "Save": "Save",
+    "Cancel": "Cancel",
+    "Select all": "Select all",
+    "Unselect all": "Unselect all",
+    "Restore default columns": "Restore default columns",
+    "Selected columns will appear in the table.": "Selected columns will appear in the table.",
+    "Click and drag the items to reorder the columns in the table.": "Click and drag the items to reorder the columns in the table."
 }

--- a/web/src/components/__tests-data__/columns.tsx
+++ b/web/src/components/__tests-data__/columns.tsx
@@ -1,14 +1,14 @@
 import { Column, ColumnsId } from '../netflow-table-header';
 
 export const ColumnsSample: Column[] = [
-    { id: ColumnsId.date, name: "Date & time" },
-    { id: ColumnsId.srcpod, name: "Src pod" },
-    { id: ColumnsId.dstpod, name: "Dst pod" },
-    { id: ColumnsId.srcnamespace, name: "Src namespace" },
-    { id: ColumnsId.dstnamespace, name: "Dst namespace" },
-    { id: ColumnsId.srcport, name: "Src port" },
-    { id: ColumnsId.dstport, name: "Dst port" },
-    { id: ColumnsId.protocol, name: "Protocol" },
-    { id: ColumnsId.bytes, name: "Bytes" },
-    { id: ColumnsId.packets, name: "Packets" },
+    { id: ColumnsId.date, name: "Date & time", isSelected: true, defaultOrder: 1 },
+    { id: ColumnsId.srcpod, name: "Src pod", isSelected: true, defaultOrder: 2 },
+    { id: ColumnsId.dstpod, name: "Dst pod", isSelected: true, defaultOrder: 3 },
+    { id: ColumnsId.srcnamespace, name: "Src namespace", isSelected: true, defaultOrder: 4 },
+    { id: ColumnsId.dstnamespace, name: "Dst namespace", isSelected: true, defaultOrder: 5 },
+    { id: ColumnsId.srcport, name: "Src port", isSelected: true, defaultOrder: 6 },
+    { id: ColumnsId.dstport, name: "Dst port", isSelected: true, defaultOrder: 7 },
+    { id: ColumnsId.protocol, name: "Protocol", isSelected: true, defaultOrder: 8 },
+    { id: ColumnsId.bytes, name: "Bytes", isSelected: true, defaultOrder: 9 },
+    { id: ColumnsId.packets, name: "Packets", isSelected: true, defaultOrder: 10 },
 ];

--- a/web/src/components/__tests__/columns-modal.spec.tsx
+++ b/web/src/components/__tests__/columns-modal.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 
 import ColumnsModal from "../columns-modal";
 import { ColumnsSample } from '../__tests-data__/columns'
@@ -17,5 +17,29 @@ describe("<ColumnsModal />", () => {
       <ColumnsModal {...props} />
     );
     expect(wrapper.find(ColumnsModal)).toBeTruthy();
+  });
+  it('should save once', () => {
+    const wrapper = mount(
+      <ColumnsModal {...props} />
+    );
+    const confirmButton = wrapper.find(".pf-c-button.pf-m-primary");
+    expect(confirmButton.length).toEqual(1);
+
+    confirmButton.at(0).simulate('click');
+    expect(props.setColumns).toHaveBeenCalledTimes(1);
+  });
+  it('should update columns selected on save', () => {
+    const wrapper = mount(
+      <ColumnsModal {...props} />
+    );
+    expect(props.setColumns).toHaveBeenNthCalledWith(1, props.columns);
+    //unselect first and second columns 
+    const updatedColumns = [...props.columns];
+    updatedColumns[0].isSelected = false;
+    updatedColumns[1].isSelected = false;
+    wrapper.find('[aria-labelledby="table-column-management-item-0"]').at(0).simulate('click');
+    wrapper.find('[aria-labelledby="table-column-management-item-1"]').at(0).simulate('click');
+    wrapper.find(".pf-c-button.pf-m-primary").at(0).simulate('click');
+    expect(props.setColumns).toHaveBeenNthCalledWith(2, updatedColumns);
   });
 });

--- a/web/src/components/__tests__/columns-modal.spec.tsx
+++ b/web/src/components/__tests__/columns-modal.spec.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { shallow } from 'enzyme';
+
+import ColumnsModal from "../columns-modal";
+import { ColumnsSample } from '../__tests-data__/columns'
+
+describe("<ColumnsModal />", () => {
+  const props = {
+    isModalOpen: true,
+    setModalOpen: jest.fn(),
+    columns: ColumnsSample,
+    setColumns: jest.fn(),
+    id: "columns-modal",
+  }
+  it('should render component', () => {
+    const wrapper = shallow(
+      <ColumnsModal {...props} />
+    );
+    expect(wrapper.find(ColumnsModal)).toBeTruthy();
+  });
+});

--- a/web/src/components/__tests__/columns-modal.spec.tsx
+++ b/web/src/components/__tests__/columns-modal.spec.tsx
@@ -37,8 +37,10 @@ describe("<ColumnsModal />", () => {
     const updatedColumns = [...props.columns];
     updatedColumns[0].isSelected = false;
     updatedColumns[1].isSelected = false;
-    wrapper.find('[aria-labelledby="table-column-management-item-0"]').at(0).simulate('click');
-    wrapper.find('[aria-labelledby="table-column-management-item-1"]').at(0).simulate('click');
+    wrapper.find('[aria-labelledby="table-column-management-item-0"]').last()
+      .simulate('change', { target: { id: updatedColumns[0].name } });
+    wrapper.find('[aria-labelledby="table-column-management-item-1"]').last()
+      .simulate('change', { target: { id: updatedColumns[1].name } });
     wrapper.find(".pf-c-button.pf-m-primary").at(0).simulate('click');
     expect(props.setColumns).toHaveBeenNthCalledWith(2, updatedColumns);
   });

--- a/web/src/components/__tests__/netflow-traffic.spec.tsx
+++ b/web/src/components/__tests__/netflow-traffic.spec.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
-import { shallow, render, mount } from 'enzyme';
 import { useResolvedExtensions } from '@openshift-console/dynamic-plugin-sdk';
+import { mount, render, shallow } from 'enzyme';
+import * as React from 'react';
 import { getFlows } from '../../api/routes';
 import NetflowTraffic from "../netflow-traffic";
 import { extensionsMock } from "../__tests-data__/extensions";
@@ -45,5 +45,12 @@ describe("<NetflowTraffic />", () => {
     //should have called getFlow twice after click
     wrapper.find('#refresh-button').at(0).simulate('click');
     expect(getFlowsMock).toHaveBeenCalledTimes(2);
+  });
+  it('should render toolbar components', () => {
+    const cheerio = render(
+      <NetflowTraffic />
+    );
+    expect(cheerio.find('#filter-toolbar').length).toEqual(1);
+    expect(cheerio.find('#manage-columns-button').length).toEqual(1);
   });
 });

--- a/web/src/components/columns-modal.css
+++ b/web/src/components/columns-modal.css
@@ -1,0 +1,25 @@
+/* align right popup buttons*/
+
+.footer {
+    margin-left: auto;
+}
+
+
+/* vertical align drag icon*/
+
+.pf-c-data-list__cell {
+    margin-top: auto;
+    margin-bottom: auto;
+}
+
+
+/* vertical align label*/
+
+button.pf-c-data-list__item-draggable-button {
+    margin-top: auto;
+    margin-bottom: auto;
+}
+
+label {
+    margin-bottom: auto;
+}

--- a/web/src/components/columns-modal.tsx
+++ b/web/src/components/columns-modal.tsx
@@ -1,0 +1,186 @@
+import * as React from 'react';
+import {
+    Button,
+    DataList,
+    DataListControl,
+    DataListItem,
+    DataListItemRow,
+    DataListDragButton,
+    DataListCheck,
+    DataListCell,
+    DragDrop,
+    Draggable,
+    Droppable,
+    Modal,
+    DataListItemCells,
+    Text,
+    TextContent,
+    TextVariants,
+} from '@patternfly/react-core';
+import { useTranslation } from "react-i18next";
+import { Column } from './netflow-table-header';
+import * as _ from 'lodash';
+import "./columns-modal.css";
+
+export const ColumnsModal: React.FC<{
+    isModalOpen: boolean;
+    setModalOpen: (v: boolean) => void;
+    columns: Column[];
+    setColumns: (v: Column[]) => void;
+    id?: string,
+}> = ({ id, isModalOpen, setModalOpen, columns, setColumns }) => {
+    const [updatedColumns, setUpdatedColumns] = React.useState<Column[]>([]);
+    const [isAllSelected, setAllSelected] = React.useState<boolean>(false);
+    const { t } = useTranslation("plugin__network-observability-plugin");
+
+    React.useEffect(() => {
+        setUpdatedColumns([...columns]);
+    }, [columns]);
+
+    React.useEffect(() => {
+        let allSelected = true;
+        _.forEach(updatedColumns, (col: Column) => {
+            if (!col.isSelected) {
+                allSelected = false;
+                return false
+            }
+        });
+        setAllSelected(allSelected);
+    }, [updatedColumns]);
+
+    const onDrop = React.useCallback(
+        (source, dest) => {
+            if (dest) {
+                const result = [...updatedColumns];
+                const [removed] = result.splice(source.index, 1);
+                result.splice(dest.index, 0, removed);
+                setUpdatedColumns(result)
+                return true;
+            }
+        },
+        [updatedColumns, setUpdatedColumns],
+    );
+
+    const onCheck = React.useCallback(
+        (checked, event) => {
+            if (event?.target?.id) {
+                const result = [...updatedColumns];
+                const selectedColumn = result.find((col) => col.name === event.target.id);
+                if (selectedColumn) {
+                    selectedColumn.isSelected = !selectedColumn.isSelected;
+                    setUpdatedColumns(result)
+                }
+            }
+        },
+        [updatedColumns, setUpdatedColumns],
+    );
+
+    const onReset = React.useCallback(
+        () => {
+            const result = _.sortBy(updatedColumns, (col: Column) => col.defaultOrder);
+            _.forEach(result, (col: Column) => {
+                col.isSelected = true;
+            });
+            setUpdatedColumns(result);
+        },
+        [updatedColumns, setUpdatedColumns],
+    );
+
+    const onSelectAll = React.useCallback(
+        () => {
+            const result = [...updatedColumns];
+            _.forEach(result, (col: Column) => {
+                col.isSelected = !isAllSelected;
+            });
+            setUpdatedColumns(result);
+        },
+        [updatedColumns, setUpdatedColumns, isAllSelected],
+    );
+
+    const onSave = React.useCallback(
+        () => {
+            setColumns(updatedColumns);
+            setModalOpen(false);
+        },
+        [updatedColumns, setColumns, setModalOpen],
+    );
+
+    const draggableItems = (updatedColumns.map((column, i) =>
+        <Draggable key={i} hasNoWrapper>
+            <DataListItem
+                key={"data-list-item-" + i}
+                aria-labelledby={"table-column-management-item" + i}
+                className="data-list-item"
+                id={"data-" + i}>
+                <DataListItemRow key={"data-list-item-row-" + i}>
+                    <DataListControl>
+                        <DataListDragButton
+                            aria-label="Reorder"
+                            aria-labelledby={"table-column-management-item" + i} />
+                        <DataListCheck
+                            aria-labelledby={"table-column-management-item-" + i}
+                            checked={column.isSelected}
+                            id={column.name}
+                            onChange={onCheck} />
+                    </DataListControl>
+                    <DataListItemCells
+                        dataListCells={[
+                            <DataListCell key={"data-list-cell-" + i}>
+                                <label htmlFor={column.name}>
+                                    {column.name}
+                                </label>
+                            </DataListCell>
+                        ]} />
+                </DataListItemRow>
+            </DataListItem>
+        </Draggable>
+    ));
+
+    return (
+        <Modal
+            id={id}
+            title={t('Manage columns')}
+            isOpen={isModalOpen}
+            className={'modal-dialog'}
+            onClose={() => setModalOpen(false)}
+            description={
+                <TextContent>
+                    <Text component={TextVariants.p}>
+                        {t('Selected columns will appear in the table.')}&nbsp;
+                        {t('Click and drag the items to reorder the columns in the table.')}
+                    </Text>
+                    <Button isInline onClick={onSelectAll} variant="link">
+                        {isAllSelected ? t('Unselect all') : t('Select all')}
+                    </Button>
+                </TextContent>
+            }
+            footer={
+                <div className="footer">
+                    <Button key="reset" variant="link" onClick={() => onReset()}>
+                        {t('Restore default columns')}
+                    </Button>
+                    <Button key="cancel" variant="link" onClick={() => setModalOpen(false)}>
+                        {t('Cancel')}
+                    </Button>
+                    <Button key="confirm" variant="primary" onClick={() => onSave()}>
+                        {t('Save')}
+                    </Button>
+                </div>
+            }>
+            <div className="co-m-form-row">
+                <DragDrop onDrop={onDrop}>
+                    <Droppable hasNoWrapper>
+                        <DataList
+                            aria-label="Table column management"
+                            id="table-column-management"
+                            isCompact>
+                            {draggableItems}
+                        </DataList>
+                    </Droppable>
+                </DragDrop>
+            </div>
+        </Modal>
+    );
+};
+
+export default ColumnsModal;

--- a/web/src/components/columns-modal.tsx
+++ b/web/src/components/columns-modal.tsx
@@ -16,6 +16,7 @@ import {
     Text,
     TextContent,
     TextVariants,
+    Tooltip,
 } from '@patternfly/react-core';
 import { useTranslation } from "react-i18next";
 import { Column } from './netflow-table-header';
@@ -30,6 +31,7 @@ export const ColumnsModal: React.FC<{
     id?: string,
 }> = ({ id, isModalOpen, setModalOpen, columns, setColumns }) => {
     const [updatedColumns, setUpdatedColumns] = React.useState<Column[]>([]);
+    const [isSaveDisabled, setSaveDisabled] = React.useState<boolean>(true);
     const [isAllSelected, setAllSelected] = React.useState<boolean>(false);
     const { t } = useTranslation("plugin__network-observability-plugin");
 
@@ -46,6 +48,7 @@ export const ColumnsModal: React.FC<{
             }
         });
         setAllSelected(allSelected);
+        setSaveDisabled(_.isEmpty(updatedColumns.filter((col) => col.isSelected)));
     }, [updatedColumns]);
 
     const onDrop = React.useCallback(
@@ -105,6 +108,7 @@ export const ColumnsModal: React.FC<{
         [updatedColumns, setColumns, setModalOpen],
     );
 
+
     const draggableItems = (updatedColumns.map((column, i) =>
         <Draggable key={i} hasNoWrapper>
             <DataListItem
@@ -162,9 +166,17 @@ export const ColumnsModal: React.FC<{
                     <Button key="cancel" variant="link" onClick={() => setModalOpen(false)}>
                         {t('Cancel')}
                     </Button>
-                    <Button key="confirm" variant="primary" onClick={() => onSave()}>
-                        {t('Save')}
-                    </Button>
+                    <Tooltip
+                        content={t('At least one column must be selected')}
+                        isVisible={isSaveDisabled}>
+                        <Button
+                            isDisabled={isSaveDisabled}
+                            key="confirm"
+                            variant="primary"
+                            onClick={() => onSave()}>
+                            {t('Save')}
+                        </Button>
+                    </Tooltip>
                 </div>
             }>
             <div className="co-m-form-row">

--- a/web/src/components/columns-modal.tsx
+++ b/web/src/components/columns-modal.tsx
@@ -36,7 +36,7 @@ export const ColumnsModal: React.FC<{
     const { t } = useTranslation("plugin__network-observability-plugin");
 
     React.useEffect(() => {
-        setUpdatedColumns([...columns]);
+        setUpdatedColumns(_.cloneDeep(columns));
     }, [columns]);
 
     React.useEffect(() => {

--- a/web/src/components/netflow-table-header.tsx
+++ b/web/src/components/netflow-table-header.tsx
@@ -25,6 +25,8 @@ export enum ColumnsId {
 export interface Column {
   id: number;
   name: string;
+  isSelected: boolean;
+  defaultOrder: number;
 }
 
 export const NetflowTableHeader: React.FC<{


### PR DESCRIPTION
Added toolbar with manage columns icon button. This toolbar will be used for filters also
- Popup allow you to select / reorder columns
- Refresh is done on save
- You can select / unselect all
- Reset action restore default order / selection
- At least one column must be selected

| ![image](https://user-images.githubusercontent.com/91894519/145969871-273c772a-a3cb-4d07-bb60-f6025651e386.png)|![image](https://user-images.githubusercontent.com/91894519/145970078-ce6fd40b-a0e6-4007-b395-51b0ba39bb50.png)|![image](https://user-images.githubusercontent.com/91894519/145970014-13c896d5-f5a7-4324-80d2-99997518ac75.png)|
| ------------- | ------------- |------------- |

![image](https://user-images.githubusercontent.com/91894519/145977580-f535706a-0a38-415c-8a00-ea7413f904e0.png)


