### PR TITLE
NETOBSERV-119 Changed port sort behavior to have numerical port last

### DIFF
--- a/web/src/components/netflow-table.tsx
+++ b/web/src/components/netflow-table.tsx
@@ -5,7 +5,7 @@ import { Column, ColumnsId, NetflowTableHeader } from './netflow-table-header';
 import NetflowTableRow from './netflow-table-row';
 import protocols from 'protocol-numbers';
 import { ipCompare } from '../utils/ip';
-import { formatPort } from '../utils/port';
+import { comparePort } from '../utils/port';
 
 const NetflowTable: React.FC<{
   flows: ParsedStream[];
@@ -58,10 +58,10 @@ const NetflowTable: React.FC<{
           return flow1NsName.localeCompare(flow2NsName);
         }
         case ColumnsId.srcport: {
-          return formatPort(flow1.value.IPFIX.SrcPort).localeCompare(formatPort(flow2.value.IPFIX.SrcPort));
+          return comparePort(flow1.value.IPFIX.SrcPort, flow2.value.IPFIX.SrcPort);
         }
         case ColumnsId.dstport: {
-          return formatPort(flow1.value.IPFIX.DstPort).localeCompare(formatPort(flow2.value.IPFIX.DstPort));
+          return comparePort(flow1.value.IPFIX.DstPort, flow2.value.IPFIX.DstPort);
         }
         case ColumnsId.srcaddr: {
           return ipCompare(flow1.value.IPFIX.SrcAddr, flow2.value.IPFIX.SrcAddr);

--- a/web/src/utils/__tests__/port.spec.ts
+++ b/web/src/utils/__tests__/port.spec.ts
@@ -1,4 +1,4 @@
-import { formatPort } from '../port';
+import { formatPort, comparePort } from '../port';
 
 describe('formatport', () => {
   it('should format port', () => {
@@ -6,3 +6,21 @@ describe('formatport', () => {
     expect(formatPort(32876)).toEqual('32876');
   });
 });
+
+describe('comparePort', () => {
+  it('should order known ports first compared to an unknown port', () => {
+    expect(comparePort(443, 73282)).toBeLessThan(0);
+    expect(comparePort(8282, 80)).toBeGreaterThan(0);
+  });
+  it('should order known ports alphabetically', () => {
+    expect(comparePort(53, 80)).toBeLessThan(0);
+    expect(comparePort(123, 80)).toBeGreaterThan(0);
+  });
+  it('should order unknown ports numerically', () => {
+    expect(comparePort(34890, 17239)).toBeGreaterThan(0);
+    expect(comparePort(9756, 17239)).toBeLessThan(0);
+    expect(comparePort(45392, 45392)).toEqual(0);
+  });
+});
+
+// toBeGreaterThan

--- a/web/src/utils/port.ts
+++ b/web/src/utils/port.ts
@@ -9,3 +9,20 @@ export const formatPort = p => {
     return String(p);
   }
 };
+
+// This sort is ordering first the port with a known service
+// then order numerically the other port
+export const comparePort = (p1, p2) => {
+  const s1 = getService(p1);
+  const s2 = getService(p2);
+  if (s1 && s2) {
+    return formatPort(p1).localeCompare(formatPort(p2));
+  }
+  if (s1) {
+    return -1;
+  }
+  if (s2) {
+    return 1;
+  }
+  return p1 - p2;
+};


### PR DESCRIPTION
Modifications based on Steven review:
https://github.com/netobserv/network-observability-console-plugin/pull/25#discussion_r773316416