### PR TITLE
NETOBSERV-117: show spinning icon when filters are added/deleted

### DIFF
--- a/web/src/components/__tests__/filters-toolbar.spec.tsx
+++ b/web/src/components/__tests__/filters-toolbar.spec.tsx
@@ -21,10 +21,12 @@ describe('<FiltersToolbar />', () => {
     columns: ColumnsSample,
     filters: [] as Filter[],
     setFilters: null,
+    clearFilters: null,
     id: 'filter-toolbar'
   };
   beforeEach(() => {
     props.setFilters = jest.fn();
+    props.clearFilters = jest.fn();
   });
   it('should render component', async () => {
     const wrapper = shallow(<FiltersToolbar {...props} />);
@@ -146,12 +148,13 @@ describe('<FiltersToolbar />', () => {
     wrapper.setProps(props);
 
     //clear all filters
+    expect(props.clearFilters).not.toHaveBeenCalled();
     const button = wrapper
       .findWhere(node => {
         return node.type() === 'button' && node.text() === 'Clear all filters';
       })
       .at(0);
     button.simulate('click');
-    expect(props.setFilters).toHaveBeenNthCalledWith(7, []);
+    expect(props.clearFilters).toHaveBeenCalledTimes(1);
   });
 });

--- a/web/src/components/__tests__/netflow-table.spec.tsx
+++ b/web/src/components/__tests__/netflow-table.spec.tsx
@@ -11,6 +11,7 @@ import { FlowsSample } from '../__tests-data__/flows';
 const errorStateQuery = `EmptyState[data-test="error-state"]`;
 const loadingContentsQuery = `Bullseye[data-test="loading-contents"]`;
 const noResultsFoundQuery = `Bullseye[data-test="no-results-found"]`;
+const clearFiltersQuery = `Button[data-test="clear-all-filters"]`;
 
 jest.mock('@openshift-console/dynamic-plugin-sdk', () => {
   return {
@@ -21,38 +22,46 @@ jest.mock('@openshift-console/dynamic-plugin-sdk', () => {
 });
 
 describe('<NetflowTable />', () => {
-  const setFlows = jest.fn();
+  const mocks = {
+    setFlows: null,
+    clearFilters: null
+  };
+  beforeEach(() => {
+    mocks.setFlows = jest.fn();
+    mocks.clearFilters = jest.fn();
+  });
+
   it('should render component', async () => {
     const flows = FlowsSample.slice(0, FlowsSample.length);
-    const wrapper = shallow(<NetflowTable flows={flows} setFlows={setFlows} columns={ColumnsSample} />);
+    const wrapper = shallow(<NetflowTable flows={flows} columns={ColumnsSample} {...mocks} />);
     expect(wrapper.find(NetflowTable)).toBeTruthy();
     expect(wrapper.find(NetflowTableHeader)).toHaveLength(1);
   });
   it('should have table rows', async () => {
     const flows = FlowsSample.slice(0, FlowsSample.length);
-    const wrapper = shallow(<NetflowTable flows={flows} setFlows={setFlows} columns={ColumnsSample} />);
+    const wrapper = shallow(<NetflowTable flows={flows} columns={ColumnsSample} {...mocks} />);
     expect(wrapper.find(NetflowTable)).toBeTruthy();
     expect(wrapper.find(NetflowTableRow)).toHaveLength(FlowsSample.length);
   });
   it('should only render given row', async () => {
     const flows = FlowsSample.slice(0, 2);
-    const wrapper = shallow(<NetflowTable flows={flows} setFlows={setFlows} columns={ColumnsSample} />);
+    const wrapper = shallow(<NetflowTable flows={flows} columns={ColumnsSample} {...mocks} />);
     expect(wrapper.find(NetflowTable)).toBeTruthy();
     expect(wrapper.find(NetflowTableRow)).toHaveLength(flows.length);
   });
   it('should sort rows on click', async () => {
     const flows = FlowsSample.slice(0, FlowsSample.length);
-    const wrapper = mount(<NetflowTable flows={flows} setFlows={setFlows} columns={ColumnsSample} />);
+    const wrapper = mount(<NetflowTable flows={flows} columns={ColumnsSample} {...mocks} />);
     expect(wrapper.find(NetflowTable)).toBeTruthy();
     const button = wrapper.findWhere(node => {
       return node.type() === 'button' && node.text() === 'Date & time';
     });
     button.simulate('click');
     const expected = [FlowsSample[2], FlowsSample[0], FlowsSample[1]];
-    expect(setFlows).toHaveBeenCalledWith(expected);
+    expect(mocks.setFlows).toHaveBeenCalledWith(expected);
   });
   it('should render a spinning slide and then the netflow rows', async () => {
-    const wrapper = mount(<NetflowTable loading={true} flows={[]} setFlows={setFlows} columns={ColumnsSample} />);
+    const wrapper = mount(<NetflowTable loading={true} flows={[]} columns={ColumnsSample} {...mocks} />);
     expect(wrapper.find(NetflowTable)).toBeTruthy();
     expect(wrapper.find(loadingContentsQuery)).toHaveLength(1);
     wrapper.setProps({
@@ -66,7 +75,7 @@ describe('<NetflowTable />', () => {
     expect(wrapper.find(NetflowTableRow)).toHaveLength(FlowsSample.length);
   });
   it('should render a spinning slide and then a NoResultsFound message if no flows are found', async () => {
-    const wrapper = mount(<NetflowTable loading={true} flows={[]} setFlows={setFlows} columns={ColumnsSample} />);
+    const wrapper = mount(<NetflowTable loading={true} flows={[]} columns={ColumnsSample} {...mocks} />);
     expect(wrapper.find(NetflowTable)).toBeTruthy();
     expect(wrapper.find(loadingContentsQuery)).toHaveLength(1);
     wrapper.setProps({
@@ -76,9 +85,16 @@ describe('<NetflowTable />', () => {
     expect(wrapper.find(loadingContentsQuery)).toHaveLength(0);
     expect(wrapper.find(noResultsFoundQuery)).toHaveLength(1);
     expect(wrapper.find(errorStateQuery)).toHaveLength(0);
+
+    // it should have a 'clear all filters' link that clears the filters when it is clicked
+    expect(mocks.clearFilters).not.toHaveBeenCalled();
+    const clearAll = wrapper.find(clearFiltersQuery);
+    expect(clearAll).toHaveLength(1);
+    clearAll.simulate('click');
+    expect(mocks.clearFilters).toHaveBeenCalledTimes(1);
   });
   it('should render a spinning slide and then an should show an ErrorState on error', async () => {
-    const wrapper = mount(<NetflowTable loading={true} flows={[]} setFlows={setFlows} columns={ColumnsSample} />);
+    const wrapper = mount(<NetflowTable loading={true} flows={[]} columns={ColumnsSample} {...mocks} />);
     expect(wrapper.find(NetflowTable)).toBeTruthy();
     expect(wrapper.find(loadingContentsQuery)).toHaveLength(1);
     wrapper.setProps({

--- a/web/src/components/filters-toolbar.tsx
+++ b/web/src/components/filters-toolbar.tsx
@@ -46,8 +46,9 @@ export const FiltersToolbar: React.FC<{
   columns: Column[];
   filters: Filter[];
   setFilters: (v: Filter[]) => void;
+  clearFilters: () => void;
   id?: string;
-}> = ({ id, children, columns, filters, setFilters }) => {
+}> = ({ id, children, columns, filters, setFilters, clearFilters }) => {
   const { t } = useTranslation('plugin__network-observability-plugin');
   const searchInputRef = React.useRef(null);
   const autocompleteRef = React.useRef(null);
@@ -480,13 +481,6 @@ export const FiltersToolbar: React.FC<{
     }
   };
 
-  const clearAll = () => {
-    if (!_.isEmpty(filters)) {
-      removeQueryArguments(filters.map(f => f.colId));
-    }
-    setFilters([]);
-  };
-
   React.useEffect(() => {
     resetFilterValue();
   }, [selectedFilterColumn, resetFilterValue]);
@@ -536,7 +530,7 @@ export const FiltersToolbar: React.FC<{
   }, [protocolOptions]);
 
   return (
-    <Toolbar id={id} clearAllFilters={() => clearAll()} clearFiltersButtonText={t('Clear all filters')}>
+    <Toolbar id={id} clearAllFilters={() => clearFilters()} clearFiltersButtonText={t('Clear all filters')}>
       <ToolbarContent>
         <Fragment>
           <ToolbarItem className="co-filter-search">

--- a/web/src/components/netflow-table.tsx
+++ b/web/src/components/netflow-table.tsx
@@ -25,9 +25,10 @@ const NetflowTable: React.FC<{
   flows: ParsedStream[];
   setFlows: React.Dispatch<React.SetStateAction<ParsedStream[]>>;
   columns: Column[];
+  clearFilters: () => void;
   loading?: boolean;
   error?: string;
-}> = ({ flows, setFlows, columns, error, loading }) => {
+}> = ({ flows, setFlows, columns, error, loading, clearFilters }) => {
   const { t } = useTranslation('plugin__network-observability-plugin');
 
   // index of the currently active column
@@ -139,8 +140,9 @@ const NetflowTable: React.FC<{
                   {t('No results found')}
                 </Title>
                 <EmptyStateBody>{t('Clear all filters and try again.')}</EmptyStateBody>
-                {/*TODO: take onClick action after task NETOBSERV-74 is completed*/}
-                <Button variant="link">{t('Clear all filters')}</Button>
+                <Button data-test="clear-all-filters" variant="link" onClick={clearFilters}>
+                  {t('Clear all filters')}
+                </Button>
               </EmptyState>
             </Bullseye>
           </Td>

--- a/web/src/components/netflow-traffic.tsx
+++ b/web/src/components/netflow-traffic.tsx
@@ -13,6 +13,7 @@ import { FiltersToolbar } from './filters-toolbar';
 import NetflowTable from './netflow-table';
 import './netflow-traffic.css';
 import { RefreshDropdown } from './refresh-dropdown';
+import { removeQueryArguments } from '../utils/router';
 
 export const NetflowTraffic: React.FC = () => {
   const [extensions] = useResolvedExtensions<ModelFeatureFlag>(isModelFeatureFlag);
@@ -47,6 +48,21 @@ export const NetflowTraffic: React.FC = () => {
   }, [filters]);
   usePoll(tick, interval);
 
+  // updates table filters and clears up the table for proper visualization of the
+  // updating process
+  const updateTableFilters = (f: Filter[]) => {
+    setFilters(f);
+    setFlows([]);
+    setLoading(true);
+  };
+
+  const clearFilters = () => {
+    if (!_.isEmpty(filters)) {
+      removeQueryArguments(filters.map(f => f.colId));
+    }
+    updateTableFilters([]);
+  };
+
   React.useEffect(() => {
     tick();
   }, [filters, tick]);
@@ -66,7 +82,13 @@ export const NetflowTraffic: React.FC = () => {
           />
         </div>
       </h1>
-      <FiltersToolbar id="filter-toolbar" columns={columns} filters={filters} setFilters={setFilters}>
+      <FiltersToolbar
+        id="filter-toolbar"
+        columns={columns}
+        filters={filters}
+        setFilters={updateTableFilters}
+        clearFilters={clearFilters}
+      >
         <Tooltip content={t('Manage columns')}>
           <Button
             id="manage-columns-button"
@@ -83,6 +105,7 @@ export const NetflowTraffic: React.FC = () => {
         error={error}
         flows={flows}
         setFlows={setFlows}
+        clearFilters={clearFilters}
         columns={columns.filter(col => col.isSelected)}
       />
       <ColumnsModal


### PR DESCRIPTION
When filters are added/deleted/cleared, it should show the spinning icon in the table.

This PR also enables the "clear all filters" button in the "no results found" message:

![image](https://user-images.githubusercontent.com/939550/148075028-08dee56c-93d2-4fb6-ad56-9624dc299dd6.png)
