### PR TITLE
Dockerfile now use npm ci to prevent lock file modifications

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,10 @@ RUN mkdir web && chown $USER: web
 COPY web/package.json web/
 COPY web/package-lock.json web/
 COPY Makefile Makefile
-RUN make install-frontend
+RUN NPM_INSTALL=ci make install-frontend
 COPY web web
 
-RUN make build-frontend
+RUN NPM_INSTALL=ci make build-frontend
 
 FROM registry.access.redhat.com/ubi8/go-toolset:1.16.7-5 as go-builder
 ARG VERSION=""

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ VERSION ?= latest
 IMAGE ?= quay.io/${USER}/network-observability-console-plugin:${VERSION}
 GOLANGCI_LINT_VERSION = v1.42.1
 COVERPROFILE = coverage.out
+NPM_INSTALL ?= install
 
 ifeq (,$(shell which podman 2>/dev/null))
 OCI_BIN ?= docker
@@ -23,7 +24,7 @@ vendors:
 .PHONY: install-frontend
 install-frontend:
 	@echo "### Installing frontend dependencies"
-	cd web && npm install
+	cd web && npm ${NPM_INSTALL}
 
 .PHONY: fmt-backend
 fmt-backend:


### PR DESCRIPTION
Dockerfile now use npm ci to prevent lock file modifications.