### PR TITLE
Fix sort on refresh

### DIFF
--- a/web/src/components/__tests__/netflow-table.spec.tsx
+++ b/web/src/components/__tests__/netflow-table.spec.tsx
@@ -7,6 +7,7 @@ import { NetflowTableHeader } from '../netflow-table-header';
 
 import { ColumnsSample } from '../__tests-data__/columns';
 import { FlowsSample } from '../__tests-data__/flows';
+import { Td } from '@patternfly/react-table';
 
 const errorStateQuery = `EmptyState[data-test="error-state"]`;
 const loadingContentsQuery = `Bullseye[data-test="loading-contents"]`;
@@ -23,11 +24,9 @@ jest.mock('@openshift-console/dynamic-plugin-sdk', () => {
 
 describe('<NetflowTable />', () => {
   const mocks = {
-    setFlows: null,
     clearFilters: null
   };
   beforeEach(() => {
-    mocks.setFlows = jest.fn();
     mocks.clearFilters = jest.fn();
   });
 
@@ -57,8 +56,15 @@ describe('<NetflowTable />', () => {
       return node.type() === 'button' && node.text() === 'Date & time';
     });
     button.simulate('click');
-    const expected = [FlowsSample[2], FlowsSample[0], FlowsSample[1]];
-    expect(mocks.setFlows).toHaveBeenCalledWith(expected);
+    const expectedDateText =
+      new Date(FlowsSample[2].value.timestamp).toDateString() +
+      ' ' +
+      new Date(FlowsSample[2].value.timestamp).toLocaleTimeString();
+    expect(wrapper.find(NetflowTableRow).find(Td).at(0).text()).toBe(expectedDateText);
+    const expectedSrcAddress = FlowsSample[2].value.IPFIX.SrcAddr;
+    expect(wrapper.find(NetflowTableRow).at(0).text()).toContain(expectedSrcAddress);
+    const expectedDstAddress = FlowsSample[2].value.IPFIX.DstAddr;
+    expect(wrapper.find(NetflowTableRow).at(0).text()).toContain(expectedDstAddress);
   });
   it('should render a spinning slide and then the netflow rows', async () => {
     const wrapper = mount(<NetflowTable loading={true} flows={[]} columns={ColumnsSample} {...mocks} />);

--- a/web/src/components/netflow-table.tsx
+++ b/web/src/components/netflow-table.tsx
@@ -4,8 +4,7 @@ import { ParsedStream } from '../api/loki';
 import { NetflowTableHeader } from './netflow-table-header';
 import NetflowTableRow from './netflow-table-row';
 import * as _ from 'lodash';
-import protocols from 'protocol-numbers';
-import { ipCompare } from '../utils/ip';
+
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import {
   Bullseye,
@@ -18,8 +17,7 @@ import {
   Title
 } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
-import { Column, ColumnsId, getFlowValueFromColumnId } from '../utils/columns';
-import { comparePort } from '../utils/port';
+import { Column } from '../utils/columns';
 
 const NetflowTable: React.FC<{
   flows: ParsedStream[];
@@ -41,37 +39,9 @@ const NetflowTable: React.FC<{
     if (activeSortIndex < 0 || activeSortIndex >= columns.length) {
       return flows;
     } else {
-      return flows.sort((a, b): number => {
-        const isDesc = activeSortDirection === 'desc';
-        const f1Value = getFlowValueFromColumnId(isDesc ? a : b, columns[activeSortIndex].id);
-        const f2Value = getFlowValueFromColumnId(isDesc ? b : a, columns[activeSortIndex].id);
-        switch (columns[activeSortIndex].id) {
-          case ColumnsId.srcport:
-          case ColumnsId.dstport: {
-            return comparePort(f1Value, f2Value);
-          }
-          case ColumnsId.srcaddr:
-          case ColumnsId.dstaddr: {
-            return ipCompare(f1Value as string, f2Value as string);
-          }
-          case ColumnsId.proto: {
-            return protocols[f1Value].name.localeCompare(protocols[f2Value].name);
-          }
-          default: {
-            //at least one value must be set, else we can't sort
-            if (f1Value != null || f2Value != null) {
-              if (typeof f1Value == 'string' || typeof f2Value == 'string') {
-                return String(f1Value).localeCompare(String(f2Value));
-              } else if (typeof f1Value == 'number' || typeof f2Value == 'number') {
-                return Number(f1Value) - Number(f2Value);
-              } else {
-                console.error("can't sort values", f1Value, f2Value, typeof f1Value, typeof f2Value);
-              }
-            }
-          }
-        }
-        return 0;
-      });
+      return flows.sort((a: ParsedStream, b: ParsedStream) =>
+        columns[activeSortIndex].sort(a, b, activeSortDirection === 'desc')
+      );
     }
   };
 

--- a/web/src/components/netflow-table.tsx
+++ b/web/src/components/netflow-table.tsx
@@ -6,7 +6,6 @@ import NetflowTableRow from './netflow-table-row';
 import * as _ from 'lodash';
 import protocols from 'protocol-numbers';
 import { ipCompare } from '../utils/ip';
-import { comparePort } from '../utils/port';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import {
   Bullseye,
@@ -19,16 +18,16 @@ import {
   Title
 } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
-import { Column, ColumnsId } from '../utils/columns';
+import { Column, ColumnsId, getFlowValueFromColumnId } from '../utils/columns';
+import { comparePort } from '../utils/port';
 
 const NetflowTable: React.FC<{
   flows: ParsedStream[];
-  setFlows: React.Dispatch<React.SetStateAction<ParsedStream[]>>;
   columns: Column[];
   clearFilters: () => void;
   loading?: boolean;
   error?: string;
-}> = ({ flows, setFlows, columns, error, loading, clearFilters }) => {
+}> = ({ flows, columns, error, loading, clearFilters }) => {
   const { t } = useTranslation('plugin__network-observability-plugin');
 
   // index of the currently active column
@@ -37,71 +36,49 @@ const NetflowTable: React.FC<{
   // sort direction of the currently active column
   const [activeSortDirection, setActiveSortDirection] = React.useState<string>('asc');
 
-  //Sort handler
+  // sort function
+  const getSortedFlows = () => {
+    if (activeSortIndex < 0 || activeSortIndex >= columns.length) {
+      return flows;
+    } else {
+      return flows.sort((a, b): number => {
+        const isDesc = activeSortDirection === 'desc';
+        const f1Value = getFlowValueFromColumnId(isDesc ? a : b, columns[activeSortIndex].id);
+        const f2Value = getFlowValueFromColumnId(isDesc ? b : a, columns[activeSortIndex].id);
+        switch (columns[activeSortIndex].id) {
+          case ColumnsId.srcport:
+          case ColumnsId.dstport: {
+            return comparePort(f1Value, f2Value);
+          }
+          case ColumnsId.srcaddr:
+          case ColumnsId.dstaddr: {
+            return ipCompare(f1Value as string, f2Value as string);
+          }
+          case ColumnsId.proto: {
+            return protocols[f1Value].name.localeCompare(protocols[f2Value].name);
+          }
+          default: {
+            //at least one value must be set, else we can't sort
+            if (f1Value != null || f2Value != null) {
+              if (typeof f1Value == 'string' || typeof f2Value == 'string') {
+                return String(f1Value).localeCompare(String(f2Value));
+              } else if (typeof f1Value == 'number' || typeof f2Value == 'number') {
+                return Number(f1Value) - Number(f2Value);
+              } else {
+                console.error("can't sort values", f1Value, f2Value, typeof f1Value, typeof f2Value);
+              }
+            }
+          }
+        }
+        return 0;
+      });
+    }
+  };
+
+  // sort handler
   const onSort = (event: React.MouseEvent, index: number, direction: string) => {
     setActiveSortIndex(index);
     setActiveSortDirection(direction);
-    // sorts the rows
-    const updatedFlows = flows.sort((a, b): number => {
-      let flow1: ParsedStream;
-      let flow2: ParsedStream;
-      if (direction === 'desc') {
-        flow1 = a;
-        flow2 = b;
-      } else {
-        flow1 = b;
-        flow2 = a;
-      }
-      switch (columns[index].id) {
-        case ColumnsId.timestamp: {
-          return flow1.value.timestamp - flow2.value.timestamp;
-        }
-        case ColumnsId.srcpod: {
-          const flow1PodName = flow1.value.IPFIX.SrcPod ? flow1.value.IPFIX.SrcPod : '';
-          const flow2PodName = flow2.value.IPFIX.SrcPod ? flow2.value.IPFIX.SrcPod : '';
-          return flow1PodName.localeCompare(flow2PodName);
-        }
-        case ColumnsId.dstpod: {
-          const flow1PodName = flow1.value.IPFIX.DstPod ? flow1.value.IPFIX.DstPod : '';
-          const flow2PodName = flow2.value.IPFIX.DstPod ? flow2.value.IPFIX.DstPod : '';
-          return flow1PodName.localeCompare(flow2PodName);
-        }
-        case ColumnsId.srcnamespace: {
-          const flow1NsName = flow1.labels['SrcNamespace'] ? flow1.labels['SrcNamespace'] : '';
-          const flow2NsName = flow2.labels['SrcNamespace'] ? flow2.labels['SrcNamespace'] : '';
-          return flow1NsName.localeCompare(flow2NsName);
-        }
-        case ColumnsId.dstnamespace: {
-          const flow1NsName = flow1.labels['DstNamespace'] ? flow1.labels['DstNamespace'] : '';
-          const flow2NsName = flow2.labels['DstNamespace'] ? flow2.labels['DstNamespace'] : '';
-          return flow1NsName.localeCompare(flow2NsName);
-        }
-        case ColumnsId.srcport: {
-          return comparePort(flow1.value.IPFIX.SrcPort, flow2.value.IPFIX.SrcPort);
-        }
-        case ColumnsId.dstport: {
-          return comparePort(flow1.value.IPFIX.DstPort, flow2.value.IPFIX.DstPort);
-        }
-        case ColumnsId.srcaddr: {
-          return ipCompare(flow1.value.IPFIX.SrcAddr, flow2.value.IPFIX.SrcAddr);
-        }
-        case ColumnsId.dstaddr: {
-          return ipCompare(flow1.value.IPFIX.DstAddr, flow2.value.IPFIX.DstAddr);
-        }
-        case ColumnsId.proto: {
-          return protocols[flow1.value.IPFIX.Proto].name.localeCompare(protocols[flow2.value.IPFIX.Proto].name);
-        }
-        case ColumnsId.bytes: {
-          return flow1.value.IPFIX.Bytes - flow2.value.IPFIX.Bytes;
-        }
-        case ColumnsId.packets: {
-          return flow1.value.IPFIX.Packets - flow2.value.IPFIX.Packets;
-        }
-      }
-      console.log('Unknown column');
-      return 0;
-    });
-    setFlows(updatedFlows);
   };
 
   let bodyContent;
@@ -150,7 +127,7 @@ const NetflowTable: React.FC<{
       );
     }
   } else {
-    bodyContent = flows.map((f, i) => <NetflowTableRow key={i} flow={f} columns={columns} />);
+    bodyContent = getSortedFlows().map((f, i) => <NetflowTableRow key={i} flow={f} columns={columns} />);
   }
 
   return (

--- a/web/src/components/netflow-traffic.tsx
+++ b/web/src/components/netflow-traffic.tsx
@@ -104,7 +104,6 @@ export const NetflowTraffic: React.FC = () => {
         loading={loading}
         error={error}
         flows={flows}
-        setFlows={setFlows}
         clearFilters={clearFilters}
         columns={columns.filter(col => col.isSelected)}
       />


### PR DESCRIPTION
Fix sort when `setFlows` is called

- Sort result is kept locally in table component to avoid render of other components that don't take order in count
- uses `getFlowValueFromColumnId` to simplify code