### PR TITLE
NETOBSERV-120 table row stripping

### DIFF
--- a/web/src/components/netflow-table/netflow-table-row.css
+++ b/web/src/components/netflow-table/netflow-table-row.css
@@ -53,3 +53,8 @@ span.co-resource-item.co-resource-item--inline.l,
 .netflow-table-tooltip:hover {
   display: none !important;
 }
+
+/* table stripping from pf-color-black-150 value */
+tr:nth-child(even) {
+  background-color: #f5f5f5;
+}


### PR DESCRIPTION
Add table row stripping using `pf-color-black-150`

I can't see it when my screen is in comfort mode (low luminosity) but it's clearly visible using normal contrast / luminosity. We can move to `pf-color-black-100` if you feel it's too dark.

![image](https://user-images.githubusercontent.com/91894519/149770389-51facbbd-44c7-4550-b8da-3cab330115d3.png)
