### PR TITLE
Fix displaying some errors (e.g. plain text response)

### DIFF
--- a/web/src/components/netflow-traffic.tsx
+++ b/web/src/components/netflow-traffic.tsx
@@ -35,6 +35,7 @@ import {
 } from '../utils/local-storage-hook';
 import { Filter } from '../utils/filters';
 import { QueryOptions } from '../model/query-options';
+import { getHTTPErrorDetails } from '../utils/errors';
 
 export const NetflowTraffic: React.FC = () => {
   const [extensions] = useResolvedExtensions<ModelFeatureFlag>(isModelFeatureFlag);
@@ -66,12 +67,7 @@ export const NetflowTraffic: React.FC = () => {
         .then(setFlows)
         .catch(err => {
           setFlows([]);
-          let errorMessage = String(err);
-          if (err?.response?.data) {
-            Object.keys(err.response.data).forEach((key: string) => {
-              errorMessage += `\n${key}: ${String(err.response.data[key])}`;
-            });
-          }
+          const errorMessage = getHTTPErrorDetails(err);
           setError(errorMessage);
         })
         .finally(() => {

--- a/web/src/utils/__tests__/errors.spec.ts
+++ b/web/src/utils/__tests__/errors.spec.ts
@@ -1,0 +1,42 @@
+import { getHTTPErrorDetails } from '../errors';
+
+type Response = { data: { [key: string]: string } };
+class CustomError extends Error {
+  constructor(code: number, public msg: string, public response: Response) {
+    super(`[${code}] ${msg}`);
+  }
+}
+
+describe('getHTTPErrorDetails', () => {
+  it('should build error from JSON', () => {
+    const err = {
+      response: {
+        data: {
+          message: 'there was an error',
+          code: 'ABCD'
+        }
+      }
+    };
+    expect(getHTTPErrorDetails(err)).toEqual('message: there was an error\ncode: ABCD');
+  });
+  it('should build error from thrown Error', () => {
+    const err = new Error('there was an error [code=ABCD]');
+    expect(getHTTPErrorDetails(err)).toEqual('Error: there was an error [code=ABCD]');
+  });
+  it('should build error from plain text', () => {
+    const err = {
+      response: {
+        data: 'there was an error'
+      }
+    };
+    expect(getHTTPErrorDetails(err)).toEqual('there was an error');
+  });
+  it('should build error from CustomError', () => {
+    const err = new CustomError(404, 'not found', { data: { details: 'file xyz not found on server' } });
+    expect(getHTTPErrorDetails(err)).toEqual('Error: [404] not found\ndetails: file xyz not found on server');
+  });
+  it('should build error from unexpected response', () => {
+    const err = 'unexpected response';
+    expect(getHTTPErrorDetails(err)).toEqual('unexpected response');
+  });
+});

--- a/web/src/utils/errors.ts
+++ b/web/src/utils/errors.ts
@@ -1,0 +1,16 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const getHTTPErrorDetails = (err: any) => {
+  if (err?.response?.data) {
+    const header = err.toString === Object.prototype.toString ? '' : `${err}\n`;
+    if (typeof err.response.data === 'object') {
+      return (
+        header +
+        Object.keys(err.response.data)
+          .map(key => `${key}: ${String(err.response.data[key])}`)
+          .join('\n')
+      );
+    }
+    return header + String(err.response.data);
+  }
+  return String(err);
+};


### PR DESCRIPTION
E.g. with "not found" as plain text:
![Capture d’écran de 2022-01-20 19-08-15](https://user-images.githubusercontent.com/2153442/150396702-ec4e2a2e-5873-480f-b317-318826b29e37.png)

