### PR TITLE
Fixed width columns

### DIFF
--- a/web/src/components/netflow-table/__tests__/netflow-table-header.spec.tsx
+++ b/web/src/components/netflow-table/__tests__/netflow-table-header.spec.tsx
@@ -13,7 +13,13 @@ const NetflowTableHeaderWrapper: React.FC<{
 }> = ({ onSort, sortIndex, sortDirection, columns }) => {
   return (
     <TableComposable aria-label="Misc table" variant="compact">
-      <NetflowTableHeader onSort={onSort} sortDirection={sortDirection} sortIndex={sortIndex} columns={columns} />
+      <NetflowTableHeader
+        onSort={onSort}
+        sortDirection={sortDirection}
+        sortIndex={sortIndex}
+        columns={columns}
+        tableWidth={100}
+      />
       <Tbody></Tbody>
     </TableComposable>
   );
@@ -23,7 +29,8 @@ describe('<NetflowTableHeader />', () => {
   const mocks = {
     onSort: jest.fn(),
     sortIndex: 0,
-    sortDirection: 'asc'
+    sortDirection: 'asc',
+    tableWidth: 100
   };
   it('should render component', async () => {
     const wrapper = mount(<NetflowTableHeaderWrapper {...mocks} columns={AllSelectedColumns} />);

--- a/web/src/components/netflow-table/netflow-table-header.tsx
+++ b/web/src/components/netflow-table/netflow-table-header.tsx
@@ -14,7 +14,8 @@ export const NetflowTableHeader: React.FC<{
   sortIndex: number;
   sortDirection: string;
   columns: Column[];
-}> = ({ onSort, sortIndex, sortDirection, columns }) => {
+  tableWidth: number;
+}> = ({ onSort, sortIndex, sortDirection, columns, tableWidth }) => {
   const [headersState, setHeadersState] = React.useState<HeadersState>({
     nestedHeaders: [],
     useNested: false,
@@ -38,11 +39,14 @@ export const NetflowTableHeader: React.FC<{
 
   const getTableHeader = React.useCallback(
     (c: Column, showBorder: boolean, isDoubleSpan = false) => {
+      // no-explicit-any disabled: short list of number expected in Th width, but actually any number works fine
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const width = Math.floor((100 * c.width) / tableWidth) as any;
       return (
         <Th
           hasRightBorder={showBorder}
           rowSpan={isDoubleSpan ? 2 : 1}
-          width={c.width}
+          width={width}
           key={c.id}
           sort={{
             sortBy: {

--- a/web/src/components/netflow-table/netflow-table.tsx
+++ b/web/src/components/netflow-table/netflow-table.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { TableComposable, Tbody, Td, Tr, InnerScrollContainer, OuterScrollContainer } from '@patternfly/react-table';
+import { TableComposable, Tbody, InnerScrollContainer, OuterScrollContainer } from '@patternfly/react-table';
 import {
   Bullseye,
   Button,
@@ -54,53 +54,38 @@ const NetflowTable: React.FC<{
     setActiveSortDirection(direction);
   };
 
-  let bodyContent;
   if (error) {
-    bodyContent = (
-      <Tr>
-        <Td colSpan={columns.length}>
-          <EmptyState data-test="error-state" variant={EmptyStateVariant.small}>
-            <Title headingLevel="h2" size="lg">
-              {t('Unable to get flows')}
-            </Title>
-            <EmptyStateBody>{error}</EmptyStateBody>
-          </EmptyState>
-        </Td>
-      </Tr>
+    return (
+      <EmptyState data-test="error-state" variant={EmptyStateVariant.small}>
+        <Title headingLevel="h2" size="lg">
+          {t('Unable to get flows')}
+        </Title>
+        <EmptyStateBody>{error}</EmptyStateBody>
+      </EmptyState>
     );
   } else if (_.isEmpty(flows)) {
     if (loading) {
-      bodyContent = (
-        <Tr>
-          <Td colSpan={columns.length}>
-            <Bullseye data-test="loading-contents">
-              <Spinner size="xl" />
-            </Bullseye>
-          </Td>
-        </Tr>
+      return (
+        <Bullseye data-test="loading-contents">
+          <Spinner size="xl" />
+        </Bullseye>
       );
     } else {
-      bodyContent = (
-        <Tr>
-          <Td colSpan={columns.length}>
-            <Bullseye data-test="no-results-found">
-              <EmptyState variant={EmptyStateVariant.small}>
-                <EmptyStateIcon icon={SearchIcon} />
-                <Title headingLevel="h2" size="lg">
-                  {t('No results found')}
-                </Title>
-                <EmptyStateBody>{t('Clear all filters and try again.')}</EmptyStateBody>
-                <Button data-test="clear-all-filters" variant="link" onClick={clearFilters}>
-                  {t('Clear all filters')}
-                </Button>
-              </EmptyState>
-            </Bullseye>
-          </Td>
-        </Tr>
+      return (
+        <Bullseye data-test="no-results-found">
+          <EmptyState variant={EmptyStateVariant.small}>
+            <EmptyStateIcon icon={SearchIcon} />
+            <Title headingLevel="h2" size="lg">
+              {t('No results found')}
+            </Title>
+            <EmptyStateBody>{t('Clear all filters and try again.')}</EmptyStateBody>
+            <Button data-test="clear-all-filters" variant="link" onClick={clearFilters}>
+              {t('Clear all filters')}
+            </Button>
+          </EmptyState>
+        </Bullseye>
       );
     }
-  } else {
-    bodyContent = getSortedFlows().map(f => <NetflowTableRow key={f.key} flow={f} columns={columns} size={size} />);
   }
 
   const width = columns.reduce((prev, cur) => prev + cur.width, 0);
@@ -119,7 +104,11 @@ const NetflowTable: React.FC<{
             columns={columns}
             tableWidth={width}
           />
-          <Tbody>{bodyContent}</Tbody>
+          <Tbody>
+            {getSortedFlows().map(f => (
+              <NetflowTableRow key={f.key} flow={f} columns={columns} size={size} />
+            ))}
+          </Tbody>
         </TableComposable>
       </InnerScrollContainer>
     </OuterScrollContainer>

--- a/web/src/components/netflow-table/netflow-table.tsx
+++ b/web/src/components/netflow-table/netflow-table.tsx
@@ -103,13 +103,19 @@ const NetflowTable: React.FC<{
     bodyContent = getSortedFlows().map(f => <NetflowTableRow key={f.key} flow={f} columns={columns} size={size} />);
   }
 
+  const width = columns.reduce((prev, cur) => prev + cur.width, 0);
+  if (width === 0) {
+    return null;
+  }
+
   return (
-    <TableComposable aria-label="Misc table" variant="compact">
+    <TableComposable aria-label="Misc table" variant="compact" style={{ minWidth: `${width}em` }}>
       <NetflowTableHeader
         onSort={onSort}
         sortDirection={activeSortDirection}
         sortIndex={activeSortIndex}
         columns={columns}
+        tableWidth={width}
       />
       <Tbody>{bodyContent}</Tbody>
     </TableComposable>

--- a/web/src/components/netflow-table/netflow-table.tsx
+++ b/web/src/components/netflow-table/netflow-table.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { TableComposable, Tbody, Td, Tr } from '@patternfly/react-table';
+import { TableComposable, Tbody, Td, Tr, InnerScrollContainer, OuterScrollContainer } from '@patternfly/react-table';
 import {
   Bullseye,
   Button,
@@ -109,16 +109,20 @@ const NetflowTable: React.FC<{
   }
 
   return (
-    <TableComposable aria-label="Misc table" variant="compact" style={{ minWidth: `${width}em` }}>
-      <NetflowTableHeader
-        onSort={onSort}
-        sortDirection={activeSortDirection}
-        sortIndex={activeSortIndex}
-        columns={columns}
-        tableWidth={width}
-      />
-      <Tbody>{bodyContent}</Tbody>
-    </TableComposable>
+    <OuterScrollContainer>
+      <InnerScrollContainer>
+        <TableComposable aria-label="Netflow table" variant="compact" style={{ minWidth: `${width}em` }} isStickyHeader>
+          <NetflowTableHeader
+            onSort={onSort}
+            sortDirection={activeSortDirection}
+            sortIndex={activeSortIndex}
+            columns={columns}
+            tableWidth={width}
+          />
+          <Tbody>{bodyContent}</Tbody>
+        </TableComposable>
+      </InnerScrollContainer>
+    </OuterScrollContainer>
   );
 };
 

--- a/web/src/components/netflow-traffic.css
+++ b/web/src/components/netflow-traffic.css
@@ -26,3 +26,10 @@ span.pf-c-button__icon.pf-m-start {
 .pf-c-empty-state__body {
     white-space: pre-line;
 }
+
+/*FIXME: remove this override if a better solution for scrolling content is found with the console team*/
+#pageSection {
+    display: flex;
+    flex-direction: column;
+    max-height: 88vh;
+}

--- a/web/src/utils/columns.ts
+++ b/web/src/utils/columns.ts
@@ -100,7 +100,8 @@ export const getDefaultColumns = (t: TFunction): Column[] => {
     },
     {
       id: ColumnsId.srcwkdkind,
-      name: t('Src kind'),
+      group: t('Source'),
+      name: t('Kind'),
       isSelected: false,
       filterType: FilterType.TEXT,
       value: f => f.fields.SrcWorkloadKind || '',
@@ -169,7 +170,8 @@ export const getDefaultColumns = (t: TFunction): Column[] => {
     },
     {
       id: ColumnsId.dstwkdkind,
-      name: t('Dst kind'),
+      group: t('Destination'),
+      name: t('Kind'),
       isSelected: false,
       filterType: FilterType.TEXT,
       value: f => f.fields.DstWorkloadKind || '',

--- a/web/src/utils/columns.ts
+++ b/web/src/utils/columns.ts
@@ -29,9 +29,6 @@ export enum ColumnsId {
   flowdir = 'FlowDirection'
 }
 
-//specific header width - Allowed values are limited, check TableComposable BaseCellProps with definition
-export type ColumnWidth = 10 | 15 | 20 | 25 | 30 | 35 | 40 | 45 | 50 | 60 | 70 | 80 | 90 | 100;
-
 export interface Column {
   id: ColumnsId;
   group?: string;
@@ -40,7 +37,8 @@ export interface Column {
   filterType: FilterType;
   value: (flow: Record) => string | number;
   sort(a: Record, b: Record, col: Column): number;
-  width: ColumnWidth;
+  // width in "em"
+  width: number;
 }
 
 export type ColumnGroup = {
@@ -78,7 +76,7 @@ export const getDefaultColumns = (t: TFunction): Column[] => {
       filterType: FilterType.NONE,
       value: f => f.timestamp,
       sort: (a, b, col) => compareNumbers(col.value(a) as number, col.value(b) as number),
-      width: 20
+      width: 15
     },
     {
       id: ColumnsId.srcpod,
@@ -88,7 +86,7 @@ export const getDefaultColumns = (t: TFunction): Column[] => {
       filterType: FilterType.TEXT,
       value: f => f.fields.SrcPod || '',
       sort: (a, b, col) => compareStrings(col.value(a) as string, col.value(b) as string),
-      width: 20
+      width: 15
     },
     {
       id: ColumnsId.srcwkd,
@@ -98,7 +96,7 @@ export const getDefaultColumns = (t: TFunction): Column[] => {
       filterType: FilterType.TEXT,
       value: f => f.labels.SrcWorkload || '',
       sort: (a, b, col) => compareStrings(col.value(a) as string, col.value(b) as string),
-      width: 20
+      width: 15
     },
     {
       id: ColumnsId.srcwkdkind,
@@ -117,7 +115,7 @@ export const getDefaultColumns = (t: TFunction): Column[] => {
       filterType: FilterType.TEXT,
       value: f => f.labels.SrcNamespace || '',
       sort: (a, b, col) => compareStrings(col.value(a) as string, col.value(b) as string),
-      width: 20
+      width: 15
     },
     {
       id: ColumnsId.srcaddr,
@@ -127,7 +125,7 @@ export const getDefaultColumns = (t: TFunction): Column[] => {
       filterType: FilterType.ADDRESS,
       value: f => f.fields.SrcAddr,
       sort: (a, b, col) => compareIPs(col.value(a) as string, col.value(b) as string),
-      width: 15
+      width: 10
     },
     {
       id: ColumnsId.srcport,
@@ -147,7 +145,7 @@ export const getDefaultColumns = (t: TFunction): Column[] => {
       filterType: FilterType.ADDRESS,
       value: f => f.fields.SrcHostIP || '',
       sort: (a, b, col) => compareIPs(col.value(a) as string, col.value(b) as string),
-      width: 15
+      width: 10
     },
     {
       id: ColumnsId.dstpod,
@@ -157,7 +155,7 @@ export const getDefaultColumns = (t: TFunction): Column[] => {
       filterType: FilterType.TEXT,
       value: f => f.fields.DstPod || '',
       sort: (a, b, col) => compareStrings(col.value(a) as string, col.value(b) as string),
-      width: 20
+      width: 15
     },
     {
       id: ColumnsId.dstwkd,
@@ -167,7 +165,7 @@ export const getDefaultColumns = (t: TFunction): Column[] => {
       filterType: FilterType.TEXT,
       value: f => f.labels.DstWorkload || '',
       sort: (a, b, col) => compareStrings(col.value(a) as string, col.value(b) as string),
-      width: 20
+      width: 15
     },
     {
       id: ColumnsId.dstwkdkind,
@@ -176,7 +174,7 @@ export const getDefaultColumns = (t: TFunction): Column[] => {
       filterType: FilterType.TEXT,
       value: f => f.fields.DstWorkloadKind || '',
       sort: (a, b, col) => compareStrings(col.value(a) as string, col.value(b) as string),
-      width: 30
+      width: 10
     },
     {
       id: ColumnsId.dstnamespace,
@@ -186,7 +184,7 @@ export const getDefaultColumns = (t: TFunction): Column[] => {
       filterType: FilterType.TEXT,
       value: f => f.labels.DstNamespace || '',
       sort: (a, b, col) => compareStrings(col.value(a) as string, col.value(b) as string),
-      width: 20
+      width: 15
     },
     {
       id: ColumnsId.dstaddr,
@@ -196,7 +194,7 @@ export const getDefaultColumns = (t: TFunction): Column[] => {
       filterType: FilterType.ADDRESS,
       value: f => f.fields.DstAddr,
       sort: (a, b, col) => compareIPs(col.value(a) as string, col.value(b) as string),
-      width: 15
+      width: 10
     },
     {
       id: ColumnsId.dstport,
@@ -216,7 +214,7 @@ export const getDefaultColumns = (t: TFunction): Column[] => {
       filterType: FilterType.ADDRESS,
       value: f => f.fields.DstHostIP || '',
       sort: (a, b, col) => compareIPs(col.value(a) as string, col.value(b) as string),
-      width: 15
+      width: 10
     },
     {
       id: ColumnsId.proto,
@@ -225,7 +223,7 @@ export const getDefaultColumns = (t: TFunction): Column[] => {
       filterType: FilterType.PROTOCOL,
       value: f => f.fields.Proto,
       sort: (a, b, col) => compareProtocols(col.value(a) as number, col.value(b) as number),
-      width: 15
+      width: 10
     },
     {
       id: ColumnsId.flowdir,
@@ -235,7 +233,7 @@ export const getDefaultColumns = (t: TFunction): Column[] => {
       filterType: FilterType.NONE,
       value: f => f.fields.FlowDirection,
       sort: (a, b, col) => compareNumbers(col.value(a) as number, col.value(b) as number),
-      width: 15
+      width: 10
     },
     {
       id: ColumnsId.bytes,
@@ -244,7 +242,7 @@ export const getDefaultColumns = (t: TFunction): Column[] => {
       filterType: FilterType.NONE,
       value: f => f.fields.Bytes,
       sort: (a, b, col) => compareNumbers(col.value(a) as number, col.value(b) as number),
-      width: 10
+      width: 5
     },
     {
       id: ColumnsId.packets,
@@ -253,7 +251,7 @@ export const getDefaultColumns = (t: TFunction): Column[] => {
       filterType: FilterType.NONE,
       value: f => f.fields.Packets,
       sort: (a, b, col) => compareNumbers(col.value(a) as number, col.value(b) as number),
-      width: 10
+      width: 5
     }
   ];
 };


### PR DESCRIPTION
With this change, the columns width are fixed, hence they can exceed the width of the page container (resulting in showing horizontal scroll). The goal is to avoid showing too small cells that are barely not visible, like here:

![Capture d’écran de 2022-01-19 09-01-46](https://user-images.githubusercontent.com/2153442/150498244-c2133f21-2101-4d71-9602-1ece18e3caa6.png)

Now, with fixed width:
![Capture d’écran de 2022-01-21 10-15-14](https://user-images.githubusercontent.com/2153442/150500191-49616ad6-b997-471f-b3e3-f644da0d4d6a.png)


@jpinsonneau @OlivierCazade @mariomac could you test it and give feedback if it works well for you , given your screen resolution? The idea is that the default columns should work for most resolutions.
Let me know also if you think this isn't the right approach (but in any case I'd like to fix the issue I was having with too small columns)