### PR TITLE
NETOBSERV-159 fix several issues in LoQL builder

### DIFF
--- a/pkg/handler/loki_test.go
+++ b/pkg/handler/loki_test.go
@@ -1,0 +1,59 @@
+package handler
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessParamTwoPodsAndFlowDirection(t *testing.T) {
+	labelFilters := strings.Builder{}
+	lineFilters := strings.Builder{}
+	ipFilters := strings.Builder{}
+	extraArgs := strings.Builder{}
+	err := processParam("SrcPod", "test-pod-1,test-pod-2", &labelFilters, &lineFilters, &ipFilters, &extraArgs)
+	require.NoError(t, err)
+	err = processParam("FlowDirection", "0", &labelFilters, &lineFilters, &ipFilters, &extraArgs)
+	require.NoError(t, err)
+
+	assert.Empty(t, labelFilters.String())
+	assert.Empty(t, ipFilters.String())
+	assert.Empty(t, extraArgs.String())
+	assert.Equal(t, `|~"\"SrcPod\":\"[^\"]*test-pod-1|\"SrcPod\":\"[^\"]*test-pod-2"|~"\"FlowDirection\":0"`, lineFilters.String())
+}
+
+func TestProcessParamTwoNamespacesAndIP(t *testing.T) {
+	labelFilters := strings.Builder{}
+	lineFilters := strings.Builder{}
+	ipFilters := strings.Builder{}
+	extraArgs := strings.Builder{}
+	err := processParam("DstNamespace", "test-ns-1,test-ns-2", &labelFilters, &lineFilters, &ipFilters, &extraArgs)
+	require.NoError(t, err)
+	err = processParam("DstAddr", "10.0.40.0/16", &labelFilters, &lineFilters, &ipFilters, &extraArgs)
+	require.NoError(t, err)
+	err = processParam("SrcAddr", "10.0.40.0/16", &labelFilters, &lineFilters, &ipFilters, &extraArgs)
+	require.NoError(t, err)
+
+	assert.Equal(t, `,DstNamespace=~".*test-ns-1.*|.*test-ns-2.*"`, labelFilters.String())
+	assert.Equal(t, `|json|DstAddr=ip("10.0.40.0/16")|SrcAddr=ip("10.0.40.0/16")`, ipFilters.String())
+	assert.Empty(t, extraArgs.String())
+	assert.Empty(t, lineFilters.String())
+}
+
+func TestProcessParamPortAndLimit(t *testing.T) {
+	labelFilters := strings.Builder{}
+	lineFilters := strings.Builder{}
+	ipFilters := strings.Builder{}
+	extraArgs := strings.Builder{}
+	err := processParam("SrcPort", "80", &labelFilters, &lineFilters, &ipFilters, &extraArgs)
+	require.NoError(t, err)
+	err = processParam("limit", "500", &labelFilters, &lineFilters, &ipFilters, &extraArgs)
+	require.NoError(t, err)
+
+	assert.Empty(t, labelFilters.String())
+	assert.Empty(t, ipFilters.String())
+	assert.Equal(t, `&limit=500`, extraArgs.String())
+	assert.Equal(t, `|~"\"SrcPort\":80"`, lineFilters.String())
+}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -255,11 +255,11 @@ func TestLokiConfiguration_MultiTenant(t *testing.T) {
 
 func TestLokiFiltering(t *testing.T) {
 	var filters = map[string]map[string][]string{
-		"/api/loki/flows?SrcPod=test-pod":                                      {"query": []string{`{app="netobserv-flowcollector"}`, `|~"\"SrcPod\":[\"]{0,1}[^,]{0,}test-pod"`}},
-		"/api/loki/flows?DstPod=test-pod-2":                                    {"query": []string{`{app="netobserv-flowcollector"}`, `|~"\"DstPod\":[\"]{0,1}[^,]{0,}test-pod-2"`}},
-		"/api/loki/flows?Proto=6":                                              {"query": []string{`{app="netobserv-flowcollector"}`, `|~"\"Proto\":[\"]{0,1}[^,]{0,}6"`}},
+		"/api/loki/flows?SrcPod=test-pod":                                      {"query": []string{`{app="netobserv-flowcollector"}`, `|~"\"SrcPod\":\"[^\"]*test-pod"`}},
+		"/api/loki/flows?DstPod=test-pod-2":                                    {"query": []string{`{app="netobserv-flowcollector"}`, `|~"\"DstPod\":\"[^\"]*test-pod-2"`}},
+		"/api/loki/flows?Proto=6":                                              {"query": []string{`{app="netobserv-flowcollector"}`, `|~"\"Proto\":6"`}},
 		"/api/loki/flows?SrcNamespace=test-namespace":                          {"query": []string{`{app="netobserv-flowcollector",SrcNamespace=~".*test-namespace.*"}`}},
-		"/api/loki/flows?SrcPort=8080&SrcAddr=10.128.0.1&SrcNamespace=default": {"query": []string{`{app="netobserv-flowcollector",SrcNamespace=~".*default.*"}`, `|~"\"SrcPort\":[\"]{0,1}[^,]{0,}8080"`, `|json|SrcAddr=ip("10.128.0.1")`}},
+		"/api/loki/flows?SrcPort=8080&SrcAddr=10.128.0.1&SrcNamespace=default": {"query": []string{`{app="netobserv-flowcollector",SrcNamespace=~".*default.*"}`, `|~"\"SrcPort\":8080"`, `|json|SrcAddr=ip("10.128.0.1")`}},
 		"/api/loki/flows?startTime=1640991600":                                 {"query": []string{`{app="netobserv-flowcollector"}`}, "start": []string{"1640991600"}},
 		"/api/loki/flows?endTime=1641160800":                                   {"query": []string{`{app="netobserv-flowcollector"}`}, "end": []string{"1641160800"}},
 		"/api/loki/flows?startTime=1640991600&endTime=1641160800":              {"query": []string{`{app="netobserv-flowcollector"}`}, "start": []string{"1640991600"}, "end": []string{"1641160800"}},

--- a/web/src/utils/router.ts
+++ b/web/src/utils/router.ts
@@ -51,7 +51,7 @@ export const buildQueryArguments = (
   // we may want to decouple them in the future.
   const params: QueryArguments = {};
   _.each(filters, (f: Filter) => {
-    params[f.colId] = f.values.map(value => value.v);
+    params[f.colId] = f.values.map(value => value.v).join(SPLIT_FILTER_CHAR);
   });
   if (range) {
     if (typeof range === 'number') {


### PR DESCRIPTION
JIRA https://issues.redhat.com/browse/NETOBSERV-159

This is fixing a couple of things, in addition to the mentioned JIRA.

- back to using multiple values in query param as a single
  coma-separated string, because the other params were ignored in go on
parsing
- fix removing an extra "|" when several values per key are used (now
  use '|' instead of '||', which was a bug)
- fixed a case where empty regex was written
- rewrite regexp, hopefully easier to read, and dissociate the numeric
  case versus text case
- Add some unit tests on LogQL building