### PR TITLE
NETOBSERV-133: Fix logql injection from filters

### DIFF
--- a/pkg/handler/loki.go
+++ b/pkg/handler/loki.go
@@ -201,22 +201,22 @@ func processLineFilters(key string, values []string, lineFilters *strings.Builde
 			regexStr.WriteByte('|')
 		}
 		//match KEY + VALUE: "KEY":"[^\"]*VALUE" (ie: contains VALUE) or, if numeric, "KEY":VALUE
-		regexStr.WriteString(`\"`)
+		regexStr.WriteString(`"`)
 		regexStr.WriteString(key)
-		regexStr.WriteString(`\":`)
+		regexStr.WriteString(`":`)
 		if isNumeric(key) {
 			regexStr.WriteString(value)
 		} else {
-			regexStr.WriteString(`\"[^\"]*`)
+			regexStr.WriteString(`"[^"]*`)
 			regexStr.WriteString(value)
 		}
 	}
 
 	if regexStr.Len() > 0 {
 		//line match regex : |~"REGEX_EXPRESSION"
-		lineFilters.WriteString(`|~"`)
+		lineFilters.WriteString("|~`")
 		lineFilters.WriteString(regexStr.String())
-		lineFilters.WriteString(`"`)
+		lineFilters.WriteString("`")
 	}
 }
 

--- a/pkg/handler/loki.go
+++ b/pkg/handler/loki.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -129,6 +130,7 @@ func GetFlows(cfg LokiConfig) func(w http.ResponseWriter, r *http.Request) {
 }
 
 func processParam(key, value string, labelFilters, lineFilters, ipFilters, extraArgs *strings.Builder) error {
+	var err error
 	switch key {
 	case startTimeKey:
 		extraArgs.WriteString(startParam)
@@ -137,10 +139,7 @@ func processParam(key, value string, labelFilters, lineFilters, ipFilters, extra
 		extraArgs.WriteString(endParam)
 		extraArgs.WriteString(value)
 	case timeRangeKey:
-		err := selectTimeRange(value, extraArgs)
-		if err != nil {
-			return err
-		}
+		err = selectTimeRange(value, extraArgs)
 	case limitKey:
 		extraArgs.WriteString(limitParam)
 		extraArgs.WriteString(value)
@@ -151,10 +150,10 @@ func processParam(key, value string, labelFilters, lineFilters, ipFilters, extra
 		} else if isIPAddress(key) {
 			processIPFilters(key, values, ipFilters)
 		} else {
-			processLineFilters(key, values, lineFilters)
+			err = processLineFilters(key, values, lineFilters)
 		}
 	}
-	return nil
+	return err
 }
 
 func processLabelFilters(key string, values []string, labelFilters *strings.Builder) {
@@ -194,11 +193,14 @@ func processIPFilters(key string, values []string, ipFilters *strings.Builder) {
 	}
 }
 
-func processLineFilters(key string, values []string, lineFilters *strings.Builder) {
+func processLineFilters(key string, values []string, lineFilters *strings.Builder) error {
 	regexStr := strings.Builder{}
 	for i, value := range values {
 		if i > 0 {
 			regexStr.WriteByte('|')
+		}
+		if strings.Contains(value, "`") {
+			return errors.New("backquote not authorized in flows requests")
 		}
 		//match KEY + VALUE: "KEY":"[^\"]*VALUE" (ie: contains VALUE) or, if numeric, "KEY":VALUE
 		regexStr.WriteString(`"`)
@@ -218,6 +220,7 @@ func processLineFilters(key string, values []string, lineFilters *strings.Builde
 		lineFilters.WriteString(regexStr.String())
 		lineFilters.WriteString("`")
 	}
+	return nil
 }
 
 func selectTimeRange(param string, extraArgs *strings.Builder) error {

--- a/pkg/handler/loki_test.go
+++ b/pkg/handler/loki_test.go
@@ -57,3 +57,12 @@ func TestProcessParamPortAndLimit(t *testing.T) {
 	assert.Equal(t, `&limit=500`, extraArgs.String())
 	assert.Equal(t, "|~`\"SrcPort\":80`", lineFilters.String())
 }
+
+func TestProcessParamBackquoteUnpermitted(t *testing.T) {
+	labelFilters := strings.Builder{}
+	lineFilters := strings.Builder{}
+	ipFilters := strings.Builder{}
+	extraArgs := strings.Builder{}
+	err := processParam("SrcPod", "test-p`od-1", &labelFilters, &lineFilters, &ipFilters, &extraArgs)
+	require.Error(t, err)
+}

--- a/pkg/handler/loki_test.go
+++ b/pkg/handler/loki_test.go
@@ -21,7 +21,7 @@ func TestProcessParamTwoPodsAndFlowDirection(t *testing.T) {
 	assert.Empty(t, labelFilters.String())
 	assert.Empty(t, ipFilters.String())
 	assert.Empty(t, extraArgs.String())
-	assert.Equal(t, `|~"\"SrcPod\":\"[^\"]*test-pod-1|\"SrcPod\":\"[^\"]*test-pod-2"|~"\"FlowDirection\":0"`, lineFilters.String())
+	assert.Equal(t, "|~`\"SrcPod\":\"[^\"]*test-pod-1|\"SrcPod\":\"[^\"]*test-pod-2`|~`\"FlowDirection\":0`", lineFilters.String())
 }
 
 func TestProcessParamTwoNamespacesAndIP(t *testing.T) {
@@ -55,5 +55,5 @@ func TestProcessParamPortAndLimit(t *testing.T) {
 	assert.Empty(t, labelFilters.String())
 	assert.Empty(t, ipFilters.String())
 	assert.Equal(t, `&limit=500`, extraArgs.String())
-	assert.Equal(t, `|~"\"SrcPort\":80"`, lineFilters.String())
+	assert.Equal(t, "|~`\"SrcPort\":80`", lineFilters.String())
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -255,11 +255,11 @@ func TestLokiConfiguration_MultiTenant(t *testing.T) {
 
 func TestLokiFiltering(t *testing.T) {
 	var filters = map[string]map[string][]string{
-		"/api/loki/flows?SrcPod=test-pod":                                      {"query": []string{`{app="netobserv-flowcollector"}`, `|~"\"SrcPod\":\"[^\"]*test-pod"`}},
-		"/api/loki/flows?DstPod=test-pod-2":                                    {"query": []string{`{app="netobserv-flowcollector"}`, `|~"\"DstPod\":\"[^\"]*test-pod-2"`}},
-		"/api/loki/flows?Proto=6":                                              {"query": []string{`{app="netobserv-flowcollector"}`, `|~"\"Proto\":6"`}},
+		"/api/loki/flows?SrcPod=test-pod":                                      {"query": []string{`{app="netobserv-flowcollector"}`, "|~`\"SrcPod\":\"[^\"]*test-pod`"}},
+		"/api/loki/flows?DstPod=test-pod-2":                                    {"query": []string{`{app="netobserv-flowcollector"}`, "|~`\"DstPod\":\"[^\"]*test-pod-2`"}},
+		"/api/loki/flows?Proto=6":                                              {"query": []string{`{app="netobserv-flowcollector"}`, "|~`\"Proto\":6`"}},
 		"/api/loki/flows?SrcNamespace=test-namespace":                          {"query": []string{`{app="netobserv-flowcollector",SrcNamespace=~".*test-namespace.*"}`}},
-		"/api/loki/flows?SrcPort=8080&SrcAddr=10.128.0.1&SrcNamespace=default": {"query": []string{`{app="netobserv-flowcollector",SrcNamespace=~".*default.*"}`, `|~"\"SrcPort\":8080"`, `|json|SrcAddr=ip("10.128.0.1")`}},
+		"/api/loki/flows?SrcPort=8080&SrcAddr=10.128.0.1&SrcNamespace=default": {"query": []string{`{app="netobserv-flowcollector",SrcNamespace=~".*default.*"}`, "|~`\"SrcPort\":8080`", `|json|SrcAddr=ip("10.128.0.1")`}},
 		"/api/loki/flows?startTime=1640991600":                                 {"query": []string{`{app="netobserv-flowcollector"}`}, "start": []string{"1640991600"}},
 		"/api/loki/flows?endTime=1641160800":                                   {"query": []string{`{app="netobserv-flowcollector"}`}, "end": []string{"1641160800"}},
 		"/api/loki/flows?startTime=1640991600&endTime=1641160800":              {"query": []string{`{app="netobserv-flowcollector"}`}, "start": []string{"1640991600"}, "end": []string{"1641160800"}},


### PR DESCRIPTION
I first tried to address this issue escaping special characters, but there are many different special characters and many different case to handle making this approach quit complex.

According to [grafana doc ](https://grafana.com/docs/loki/latest/logql/log_queries/), backtick can be used to avoid escaping all other characters. Then I disallowed backtick from flows requests to prevent injection using backticks.