### PR TITLE
NETOBSERV-121 removed deployment tab

### DIFF
--- a/web/console-extensions.json
+++ b/web/console-extensions.json
@@ -62,19 +62,5 @@
       "name": "%plugin_network-observability-plugin~Network Traffic%",
       "href": "netflow"
     }
-  },
-  {
-    "type": "console.page/resource/tab",
-    "properties": {
-      "model": {
-        "group": "apps",
-        "kind": "Deployment"
-      },
-      "component": {
-        "$codeRef": "netflowTab.default"
-      },
-      "name": "%plugin_network-observability-plugin~Network Traffic%",
-      "href": "netflow"
-    }
   }
 ]


### PR DESCRIPTION
Following QE feedbacks, it appear there is regression in console side on latests nightly 4.10 builds

The deployment tab makes the console crash so this PR remove our tab from the `console-extensions.json` file until a fix is done on `console` side

Ensure your browser cache is cleared to apply this change.