### PR TITLE
NETOBSERV-121 restore deployment tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,14 @@ make serve
 (It's the same as running ./http-server.sh)
 
 Make sure you are logged in your OpenShift cluster before with the CLI (`oc login -u kubeadmin` ...)
-You need also to have a local clone of the [console repository](https://github.com/openshift/console).
-Then, start the console bridge with this local plugin, with:
 
+You need also to have a local copy of [console repository](https://github.com/openshift/console)
+Build it once using:
+```bash
+./build.sh
+```
+
+Then, start the console bridge with this local plugin, with:
 ```bash
 CONSOLE=/path/to/console make bridge
 ```

--- a/web/console-extensions.json
+++ b/web/console-extensions.json
@@ -62,5 +62,19 @@
       "name": "%plugin_network-observability-plugin~Network Traffic%",
       "href": "netflow"
     }
+  },
+  {
+    "type": "console.page/resource/tab",
+    "properties": {
+      "model": {
+        "group": "apps",
+        "kind": "Deployment"
+      },
+      "component": {
+        "$codeRef": "netflowTab.default"
+      },
+      "name": "%plugin_network-observability-plugin~Network Traffic%",
+      "href": "netflow"
+    }
   }
 ]

--- a/web/webpack.config.ts
+++ b/web/webpack.config.ts
@@ -82,6 +82,8 @@ if (process.env.NODE_ENV === 'production') {
   config.output.chunkFilename = '[name]-chunk-[chunkhash].min.js';
   config.optimization.chunkIds = 'deterministic';
   config.optimization.minimize = true;
+  // Causes error in --mode=production due to scope hoisting
+  config.optimization.concatenateModules = false;
 }
 
 export default config;


### PR DESCRIPTION
Modules concatenation in production mode was crashing console application before calling plugin code

Different versions of dependencies between console and plugins are the root cause of this issue

Disabling `concatenateModules` option solve versions issues by keeping dependencies separated between the two projects