### PR TITLE
Fix Deployment filters, add more tabs...

### DIFF
--- a/web/console-extensions.json
+++ b/web/console-extensions.json
@@ -76,5 +76,33 @@
       "name": "%plugin_network-observability-plugin~Network Traffic%",
       "href": "netflow"
     }
+  },
+  {
+    "type": "console.page/resource/tab",
+    "properties": {
+      "model": {
+        "group": "apps",
+        "kind": "StatefulSet"
+      },
+      "component": {
+        "$codeRef": "netflowTab.default"
+      },
+      "name": "%plugin_network-observability-plugin~Network Traffic%",
+      "href": "netflow"
+    }
+  },
+  {
+    "type": "console.page/resource/tab",
+    "properties": {
+      "model": {
+        "group": "apps",
+        "kind": "DaemonSet"
+      },
+      "component": {
+        "$codeRef": "netflowTab.default"
+      },
+      "name": "%plugin_network-observability-plugin~Network Traffic%",
+      "href": "netflow"
+    }
   }
 ]

--- a/web/src/components/netflow-tab.tsx
+++ b/web/src/components/netflow-tab.tsx
@@ -11,9 +11,7 @@ export const NetflowTab: React.FC<PageComponentProps> = ({ obj }) => {
 
   let forcedFilters: Filter[];
   switch (obj?.kind) {
-    case 'Deployment':
     case 'Pod':
-    case 'Service':
       forcedFilters = [
         {
           /*TODO : set SRC and DST filters after implementing OR logic NETOBSERV-73*/
@@ -23,6 +21,46 @@ export const NetflowTab: React.FC<PageComponentProps> = ({ obj }) => {
         {
           /*TODO : set SRC and DST filters after implementing OR logic NETOBSERV-73*/
           colId: ColumnsId.srcnamespace,
+          values: [{ v: obj!.metadata!.namespace as string }]
+        }
+      ];
+      break;
+    case 'Deployment':
+    case 'StatefulSet':
+    case 'DaemonSet':
+    case 'Job':
+    case 'CronJob':
+      forcedFilters = [
+        {
+          /*TODO : set SRC and DST filters after implementing OR logic NETOBSERV-73*/
+          colId: ColumnsId.srcwkdkind,
+          values: [{ v: obj!.kind }]
+        },
+        {
+          /*TODO : set SRC and DST filters after implementing OR logic NETOBSERV-73*/
+          colId: ColumnsId.srcwkd,
+          values: [{ v: obj!.metadata!.name as string }]
+        },
+        {
+          /*TODO : set SRC and DST filters after implementing OR logic NETOBSERV-73*/
+          colId: ColumnsId.srcnamespace,
+          values: [{ v: obj!.metadata!.namespace as string }]
+        }
+      ];
+      break;
+    case 'Service':
+      // NOTE: Services are always on the destination side
+      forcedFilters = [
+        {
+          colId: ColumnsId.dstwkdkind,
+          values: [{ v: 'Service' }]
+        },
+        {
+          colId: ColumnsId.dstwkd,
+          values: [{ v: obj!.metadata!.name as string }]
+        },
+        {
+          colId: ColumnsId.dstnamespace,
           values: [{ v: obj!.metadata!.namespace as string }]
         }
       ];

--- a/web/src/utils/columns.ts
+++ b/web/src/utils/columns.ts
@@ -21,6 +21,8 @@ export enum ColumnsId {
   packets = 'Packets',
   srcwkd = 'SrcWorkload',
   dstwkd = 'DstWorkload',
+  srcwkdkind = 'SrcWorkloadKind',
+  dstwkdkind = 'DstWorkloadKind',
   srchost = 'SrcHostIP',
   dsthost = 'DstHostIP',
   flowdir = 'FlowDirection'
@@ -52,7 +54,7 @@ export const getDefaultColumns = (t: TFunction): Column[] => {
       id: ColumnsId.srcpod,
       name: t('Src pod'),
       isSelected: true,
-      filterType: FilterType.POD,
+      filterType: FilterType.TEXT,
       value: f => f.fields.SrcPod || '',
       sort: (a, b, col) => compareStrings(col.value(a) as string, col.value(b) as string),
       width: 30
@@ -61,16 +63,25 @@ export const getDefaultColumns = (t: TFunction): Column[] => {
       id: ColumnsId.srcwkd,
       name: t('Src workload'),
       isSelected: false,
-      filterType: FilterType.WORKLOAD,
+      filterType: FilterType.TEXT,
       value: f => f.labels.SrcWorkload || '',
       sort: (a, b, col) => compareStrings(col.value(a) as string, col.value(b) as string),
       width: 30
     },
     {
+      id: ColumnsId.srcwkdkind,
+      name: t('Src kind'),
+      isSelected: false,
+      filterType: FilterType.TEXT,
+      value: f => f.fields.SrcWorkloadKind || '',
+      sort: (a, b, col) => compareStrings(col.value(a) as string, col.value(b) as string),
+      width: 10
+    },
+    {
       id: ColumnsId.srcnamespace,
       name: t('Src namespace'),
       isSelected: true,
-      filterType: FilterType.NAMESPACE,
+      filterType: FilterType.TEXT,
       value: f => f.labels.SrcNamespace || '',
       sort: (a, b, col) => compareStrings(col.value(a) as string, col.value(b) as string),
       width: 30
@@ -106,7 +117,7 @@ export const getDefaultColumns = (t: TFunction): Column[] => {
       id: ColumnsId.dstpod,
       name: t('Dst pod'),
       isSelected: true,
-      filterType: FilterType.POD,
+      filterType: FilterType.TEXT,
       value: f => f.fields.DstPod || '',
       sort: (a, b, col) => compareStrings(col.value(a) as string, col.value(b) as string),
       width: 30
@@ -115,8 +126,17 @@ export const getDefaultColumns = (t: TFunction): Column[] => {
       id: ColumnsId.dstwkd,
       name: t('Dst workload'),
       isSelected: false,
-      filterType: FilterType.WORKLOAD,
+      filterType: FilterType.TEXT,
       value: f => f.labels.DstWorkload || '',
+      sort: (a, b, col) => compareStrings(col.value(a) as string, col.value(b) as string),
+      width: 30
+    },
+    {
+      id: ColumnsId.dstwkdkind,
+      name: t('Dst kind'),
+      isSelected: false,
+      filterType: FilterType.TEXT,
+      value: f => f.fields.DstWorkloadKind || '',
       sort: (a, b, col) => compareStrings(col.value(a) as string, col.value(b) as string),
       width: 30
     },
@@ -124,7 +144,7 @@ export const getDefaultColumns = (t: TFunction): Column[] => {
       id: ColumnsId.dstnamespace,
       name: t('Dst namespace'),
       isSelected: true,
-      filterType: FilterType.NAMESPACE,
+      filterType: FilterType.TEXT,
       value: f => f.labels.DstNamespace || '',
       sort: (a, b, col) => compareStrings(col.value(a) as string, col.value(b) as string),
       width: 30

--- a/web/src/utils/filters.ts
+++ b/web/src/utils/filters.ts
@@ -5,13 +5,11 @@ import { ColumnsId } from './columns';
 
 export enum FilterType {
   NONE,
-  POD,
-  WORKLOAD,
   ADDRESS,
-  NAMESPACE,
   PORT,
   PROTOCOL,
-  NUMBER
+  NUMBER,
+  TEXT
 }
 
 export interface FilterValue {


### PR DESCRIPTION
- Fix Deployment tab filters using workload instead of pod
- New tabs in StatefulSet, DaemonSet, ~Job, Cronjob~
- Adding workload kind column, essentially to allows filtering on it
- Changing filter types like POD or NAMESPACE to simply TEXT, as
  they don't involve any special processing