### PR TITLE
Disabling and sign in flows request

### DIFF
--- a/pkg/handler/loki.go
+++ b/pkg/handler/loki.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -231,14 +232,16 @@ func processIPFilters(key string, values []string, ipFilters *strings.Builder) {
 	}
 }
 
+var filterRegexpValidation = regexp.MustCompile(`^[\w-\.\:\/]+$`)
+
 func processLineFilters(key string, values []string, lineFilters *strings.Builder) error {
 	regexStr := strings.Builder{}
 	for i, value := range values {
 		if i > 0 {
 			regexStr.WriteByte('|')
 		}
-		if strings.Contains(value, "`") {
-			return errors.New("backquote not authorized in flows requests")
+		if !filterRegexpValidation.MatchString(value) {
+			return errors.New("unauthorized sign in flows request")
 		}
 		//match KEY + VALUE: "KEY":"[^\"]*VALUE" (ie: contains VALUE) or, if numeric, "KEY":VALUE
 		regexStr.WriteString(`"`)


### PR DESCRIPTION
Looks like and symbol still create some parsing error with loki parsing even if they are escaped using backquote.

Disabling them since they are not used anyway in pod or namespace name.

This is an addition to this PR:
https://github.com/netobserv/network-observability-console-plugin/pull/57