### PR TITLE
NETOBSERV-169 labels from flag

### DIFF
--- a/cmd/plugin-backend.go
+++ b/cmd/plugin-backend.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -25,6 +26,7 @@ var (
 	corsMaxAge  = flag.String("cors-max-age", "", "CORS allowed max age (default: unset)")
 	// todo: default value temporarily kept to make it work with older versions of the NOO. Remove default and force setup of loki url
 	lokiURL      = flag.String("loki", "http://localhost:3100", "URL of the loki querier host")
+	lokiLabels   = flag.String("loki-labels", "SrcNamespace,SrcWorkload,DstNamespace,DstWorkload,FlowDirection", "Loki labels, comma separated")
 	lokiTimeout  = flag.Duration("loki-timeout", 10*time.Second, "Timeout of the Loki query to retrieve logs")
 	lokiTenantID = flag.String("loki-tenant-id", "", "Tenant organization ID for multi-tenant-loki (submitted as the X-Scope-OrgID HTTP header)")
 	logLevel     = flag.String("loglevel", "info", "log level (default: info)")
@@ -55,6 +57,11 @@ func main() {
 		log.WithError(err).Fatal("wrong Loki URL")
 	}
 
+	lLabels := *lokiLabels
+	if len(lLabels) == 0 {
+		log.Fatal("labels cannot be empty")
+	}
+
 	server.Start(&server.Config{
 		Port:             *port,
 		CertFile:         *cert,
@@ -67,6 +74,7 @@ func main() {
 			URL:      lURL,
 			Timeout:  *lokiTimeout,
 			TenantID: *lokiTenantID,
+			Labels:   strings.Split(lLabels, ","),
 		},
 	})
 }

--- a/pkg/loki/query_test.go
+++ b/pkg/loki/query_test.go
@@ -86,6 +86,6 @@ func TestQuery_AddURLParam(t *testing.T) {
 }
 
 func TestQuery_BackQuote_Error(t *testing.T) {
-	query := NewQuery(false)
+	query := NewQuery([]string{"lab1", "lab2"}, false)
 	assert.Error(t, query.AddParam("key", "backquoted`val"))
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -295,8 +295,8 @@ func TestLokiFiltering(t *testing.T) {
 	}, {
 		inputPath: "?Proto=6&SrcPod=test&FlowDirection=1&match=any",
 		outputQuery: []string{
-			"?query={app=\"netobserv-flowcollector\"}|~`(\"Proto\":6)|(\"SrcPod\":\"[^\"]*test)`|~`\"FlowDirection\":1`",
-			"?query={app=\"netobserv-flowcollector\"}|~`(\"SrcPod\":\"[^\"]*test)|(\"Proto\":6)`|~`\"FlowDirection\":1`",
+			"?query={app=\"netobserv-flowcollector\",FlowDirection=\"1\"}|~`(\"Proto\":6)|(\"SrcPod\":\"[^\"]*test)`",
+			"?query={app=\"netobserv-flowcollector\",FlowDirection=\"1\"}|~`(\"SrcPod\":\"[^\"]*test)|(\"Proto\":6)`",
 		},
 	}, {
 		inputPath: "?SrcNamespace=test-namespace&match=all",
@@ -321,7 +321,7 @@ func TestLokiFiltering(t *testing.T) {
 	}, {
 		inputPath: "?SrcPort=8080&SrcAddr=10.128.0.1&SrcNamespace=default&match=any&FlowDirection=0",
 		outputQuery: []string{
-			"?query={app=\"netobserv-flowcollector\"}|~`\"FlowDirection\":0`|json|SrcNamespace=~\".*default.*\"+or+SrcAddr=ip(\"10.128.0.1\")+or+SrcPort=8080",
+			"?query={app=\"netobserv-flowcollector\",FlowDirection=\"0\"}|json|SrcNamespace=~\".*default.*\"+or+SrcAddr=ip(\"10.128.0.1\")+or+SrcPort=8080",
 		},
 	}, {
 		inputPath:   "?startTime=1640991600&match=all",
@@ -376,6 +376,7 @@ func TestLokiFiltering(t *testing.T) {
 		Loki: handler.LokiConfig{
 			URL:     lokiURL,
 			Timeout: time.Second,
+			Labels:  []string{"SrcNamespace", "SrcWorkload", "DstNamespace", "DstWorkload", "FlowDirection"},
 		},
 	})
 	backendSvc := httptest.NewServer(backendRoutes)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -9,11 +9,10 @@ func Contains(s []string, e string) bool {
 	return false
 }
 
-func GetMatchingString(s []string, e string) string {
+func GetMapInterface(s []string) map[string]struct{} {
+	res := map[string]struct{}{}
 	for _, a := range s {
-		if a == e {
-			return e
-		}
+		res[a] = struct{}{}
 	}
-	return ""
+	return res
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,19 @@
+package utils
+
+func Contains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}
+
+func GetMatchingString(s []string, e string) string {
+	for _, a := range s {
+		if a == e {
+			return e
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
This PR is part of [NETOBSERV-169](https://issues.redhat.com/browse/NETOBSERV-169) - Create index on FlowDirection
Changes:
- Get Loki labels from flag to allow operator to set them on both `goflow kube` and `console plugin backend`

Check https://github.com/netobserv/network-observability-operator/pull/54