### PR TITLE
FlowDirection must be read from labels now

### DIFF
--- a/pkg/loki/query.go
+++ b/pkg/loki/query.go
@@ -261,8 +261,7 @@ func isNumeric(v string) bool {
 		"DstPort",
 		"Packets",
 		"Proto",
-		"Bytes",
-		"FlowDirection":
+		"Bytes":
 		return true
 	default:
 		return false

--- a/web/src/api/ipfix.ts
+++ b/web/src/api/ipfix.ts
@@ -10,11 +10,12 @@ export interface Labels {
   DstNamespace?: string;
   SrcWorkload?: string;
   DstWorkload?: string;
+  FlowDirection: FlowDirection;
 }
 
 export enum FlowDirection {
-  Ingress = 0,
-  Egress = 1
+  Ingress = '0',
+  Egress = '1'
 }
 
 export interface Fields {
@@ -33,5 +34,4 @@ export interface Fields {
   Packets: number;
   Proto: number;
   Bytes: number;
-  FlowDirection: FlowDirection;
 }

--- a/web/src/components/__tests-data__/flows.ts
+++ b/web/src/components/__tests-data__/flows.ts
@@ -3,6 +3,7 @@ import { FlowDirection, Record } from '../../api/ipfix';
 export const FlowsSample: Record[] = [
   {
     labels: {
+      FlowDirection: FlowDirection.Egress,
       SrcNamespace: 'default',
       DstNamespace: 'default'
     },
@@ -18,13 +19,13 @@ export const FlowsSample: Record[] = [
       Packets: 400,
       Proto: 6,
       Bytes: 76800,
-      FlowDirection: FlowDirection.Egress,
       SrcMac: '8a:f6:69:6b:1a:cc',
       DstMac: '0a:58:0a:80:00:17'
     }
   },
   {
     labels: {
+      FlowDirection: FlowDirection.Ingress,
       SrcNamespace: 'openshift-console',
       DstNamespace: 'netowrk-observability'
     },
@@ -40,13 +41,13 @@ export const FlowsSample: Record[] = [
       Packets: 300,
       Proto: 6,
       Bytes: 7800,
-      FlowDirection: FlowDirection.Ingress,
       SrcMac: '8a:f6:69:6b:1a:cc',
       DstMac: '0a:58:0a:80:00:17'
     }
   },
   {
     labels: {
+      FlowDirection: FlowDirection.Ingress,
       SrcNamespace: 'kube-system',
       DstNamespace: 'default'
     },
@@ -62,7 +63,6 @@ export const FlowsSample: Record[] = [
       Packets: 400,
       Proto: 6,
       Bytes: 76800,
-      FlowDirection: FlowDirection.Ingress,
       SrcMac: '8a:f6:69:6b:1a:cc',
       DstMac: '0a:58:0a:80:00:17'
     }

--- a/web/src/utils/columns.ts
+++ b/web/src/utils/columns.ts
@@ -251,7 +251,7 @@ export const getDefaultColumns = (t: TFunction): Column[] => {
       isSelected: false,
       // filters are managed via QuickFilters rather than per-column filter search, so set filterType to NONE
       filterType: FilterType.NONE,
-      value: f => f.fields.FlowDirection,
+      value: f => f.labels.FlowDirection,
       sort: (a, b, col) => compareNumbers(col.value(a) as number, col.value(b) as number),
       width: 10
     },


### PR DESCRIPTION
It fixes data displayed in Direction column or in the details panel: without it, all flows were always displayed as EGRESS