### PR TITLE
NETOBSERV-187 : Restrict port to service formatting to ports below 1024

### DIFF
--- a/web/src/utils/__tests__/port.spec.ts
+++ b/web/src/utils/__tests__/port.spec.ts
@@ -5,6 +5,9 @@ describe('formatport', () => {
     expect(formatPort(443)).toEqual('https (443)');
     expect(formatPort(32876)).toEqual('32876');
   });
+  it('should not format port above 1024', () => {
+    expect(formatPort(3000)).toEqual('3000');
+  });
 });
 
 describe('comparePort', () => {

--- a/web/src/utils/filters.ts
+++ b/web/src/utils/filters.ts
@@ -1,7 +1,8 @@
 import * as _ from 'lodash';
 import protocols from 'protocol-numbers';
-import { getPort, getService } from 'port-numbers';
+import { getPort } from 'port-numbers';
 import { ColumnsId } from './columns';
+import { getProtectedService } from './port';
 
 export enum FilterType {
   NONE,
@@ -33,7 +34,8 @@ export const getActiveColumnFilters = (columnId: ColumnsId, filters: Filter[]) =
 
 const protocolOptions: FilterOption[] = Object.values(protocols)
   .map(proto => ({ name: proto.name, value: proto.value }))
-  .filter(proto => !_.isEmpty(proto.name));
+  .filter(proto => !_.isEmpty(proto.name))
+  .filter(proto => Number(proto.value) < 1024);
 _.orderBy(protocolOptions, 'name');
 
 const getProtocolOptions = (value: string) => {
@@ -44,7 +46,7 @@ const getProtocolOptions = (value: string) => {
 
 const getPortOptions = (value: string) => {
   const isNumber = !isNaN(Number(value));
-  const foundService = isNumber ? getService(Number(value)) : null;
+  const foundService = isNumber ? getProtectedService(Number(value)) : null;
   const foundPort = !isNumber ? getPort(value) : null;
   if (foundService) {
     return [{ name: foundService.name, value: value }];

--- a/web/src/utils/port.ts
+++ b/web/src/utils/port.ts
@@ -1,7 +1,15 @@
 import { getService } from 'port-numbers';
 
+export const getProtectedService = (p: number) => {
+  if (p < 1024) {
+    return getService(p);
+  } else {
+    return null;
+  }
+};
+
 export const formatPort = (p: number) => {
-  const service = getService(p);
+  const service = getProtectedService(p);
   if (service) {
     return `${service.name} (${p})`;
   } else {
@@ -12,8 +20,8 @@ export const formatPort = (p: number) => {
 // This sort is ordering first the port with a known service
 // then order numerically the other port
 export const comparePorts = (p1: number, p2: number) => {
-  const s1 = getService(p1);
-  const s2 = getService(p2);
+  const s1 = getProtectedService(p1);
+  const s2 = getProtectedService(p2);
   if (s1 && s2) {
     return formatPort(p1).localeCompare(formatPort(p2));
   }


### PR DESCRIPTION
IANA ports reservation is mostly respected for ports below 1024, this PR limit port to `service`translation to this ports.

[Corresponding JIRA ticket](https://issues.redhat.com/browse/NETOBSERV-187)