### PR TITLE
NETOBSERV-156 tabs initialQueryOptions

### DIFF
--- a/web/src/components/netflow-traffic.tsx
+++ b/web/src/components/netflow-traffic.tsx
@@ -52,7 +52,8 @@ import TimeRangeDropdown from './time-range-dropdown';
 
 export const NetflowTraffic: React.FC<{
   forcedFilters?: Filter[];
-}> = ({ forcedFilters }) => {
+  initialQueryOptions?: QueryOptions;
+}> = ({ forcedFilters, initialQueryOptions }) => {
   const { push } = useHistory();
   const [extensions] = useResolvedExtensions<ModelFeatureFlag>(isModelFeatureFlag);
   const [loading, setLoading] = React.useState(true);
@@ -71,7 +72,9 @@ export const NetflowTraffic: React.FC<{
   });
   const [filters, setFilters] = React.useState<Filter[]>(getFiltersFromURL(columns));
   const [range, setRange] = React.useState<number | TimeRange>(getRangeFromURL());
-  const [queryOptions, setQueryOptions] = React.useState<QueryOptions>(getQueryOptionsFromURL());
+  const [queryOptions, setQueryOptions] = React.useState<QueryOptions>(
+    initialQueryOptions ? initialQueryOptions : getQueryOptionsFromURL()
+  );
   const [interval, setInterval] = useLocalStorage<number | undefined>(LOCAL_STORAGE_REFRESH_KEY);
   const isInit = React.useRef(true);
   const [selectedRecord, setSelectedRecord] = React.useState<Record | undefined>(undefined);

--- a/web/src/model/query-options.ts
+++ b/web/src/model/query-options.ts
@@ -1,6 +1,6 @@
 export type Reporter = 'source' | 'destination' | 'both';
 
-export type Match = 'all' | 'any';
+export type Match = 'all' | 'any' | 'srcOrDst';
 
 export interface QueryOptions {
   reporter: Reporter;


### PR DESCRIPTION
This PR sets initial query options for tabs. The user can still update them from the dropdown.

Changes :
- set destination fields
- match all / srcOrDst according to each case

Related PR: https://github.com/netobserv/network-observability-console-plugin/pull/83