### PR TITLE
NETOBSERV-204 source or destination match

### DIFF
--- a/pkg/loki/convert.go
+++ b/pkg/loki/convert.go
@@ -7,12 +7,11 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var clog = logrus.WithField("component", "loki.convertToAnyMatch")
+var clog = logrus.WithField("component", "loki.convertTo")
 
-// convertToAnyMatch returns a new query with all the matchers and filters
-// of the receiver query. The returned query would match if only one of the
-// filters/attributes/selectors match.
-func (q *Query) convertToAnyMatch() *Query {
+// convertTo returns a new query with all the matchers and filters
+// of the receiver query.
+func (q *Query) convertTo() *Query {
 	// if the input query only has zero or one criterion, or it only has Label filters,
 	// we return a copy by changing the Label Joiner
 	if len(q.lineFilters)+len(q.labelFilters)+len(q.streamSelector) <= 1 ||
@@ -37,7 +36,7 @@ func (q *Query) convertToAnyMatch() *Query {
 		return &out
 	}
 	// otherwise, we move all the arguments to Label filters to be checked after JSON conversion
-	out.labelFilters = append(q.streamSelector, q.labelFilters...)
+	labelFilters := append(q.streamSelector, q.labelFilters...)
 	for _, lf := range q.lineFilters {
 		label, ok := lineToLabelFilter(lf)
 		if !ok {
@@ -45,7 +44,26 @@ func (q *Query) convertToAnyMatch() *Query {
 				Warningf("line filter can't be parsed as json attribute. Ignoring it")
 			continue
 		}
-		out.labelFilters = append(out.labelFilters, label)
+		labelFilters = append(labelFilters, label)
+	}
+
+	//group labelFilters by Src / Dst
+	if q.specialAttrs[matchParam] == srcOrDstMatchValue {
+		// each value of group must match
+		out.labelJoiner = joinAnd
+		var i int
+		indexes := map[string]int{}
+		for _, lf := range labelFilters {
+			// group labels by Src / Dst / Other
+			out.groupedLabelFilters, i = getIndex(lf.key, indexes, out.groupedLabelFilters)
+			// The returned query would match if all
+			// filters/attributes/selectors match in any group.
+			out.groupedLabelFilters[i] = append(out.groupedLabelFilters[i], lf)
+		}
+	} else {
+		// The returned query would match if only one of the
+		// filters/attributes/selectors match.
+		out.labelFilters = labelFilters
 	}
 	return &out
 }
@@ -71,12 +89,35 @@ func lineToLabelFilter(lf string) (labelFilter, bool) {
 			valueType: typeNumber,
 		}, true
 	}
+
+	// TODO: if at some point we want to filter by exact string values, we should
+	// conditionally replace the matcher and remove the .* suffix
+	value := submatch[2]
+	if !strings.HasSuffix(value, ".*") {
+		value = value + ".*"
+	}
+
 	return labelFilter{
 		key: submatch[1],
-		// TODO: if at some point we want to filter by exact string values, we should
-		// conditionally replace the matcher and remove the .* suffix
+
 		matcher:   labelMatches,
-		value:     submatch[2] + ".*",
+		value:     value,
 		valueType: typeRegex,
 	}, true
+}
+
+func getIndex(label string, indexes map[string]int, groupedArray [][]labelFilter) ([][]labelFilter, int) {
+	var key string
+	if strings.HasPrefix(label, "Src") {
+		key = "Src"
+	} else if strings.HasPrefix(label, "Dst") {
+		key = "Dst"
+	} else {
+		key = ""
+	}
+	if _, hasKey := indexes[key]; !hasKey {
+		indexes[key] = len(groupedArray)
+		groupedArray = append(groupedArray, []labelFilter{})
+	}
+	return groupedArray, indexes[key]
 }

--- a/pkg/loki/query_test.go
+++ b/pkg/loki/query_test.go
@@ -62,7 +62,7 @@ func TestQuery_ToURL_ConvertToAnyMatch(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, tc.expect, urlQuery)
 
-			anyMatchQuery := tc.in.convertToAnyMatch()
+			anyMatchQuery := tc.in.convertTo()
 			// we need to have at least a stream selector, so we add a label for testing purposes
 			// (in production, we add the app label)
 			anyMatchQuery.streamSelector = append(anyMatchQuery.streamSelector,

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -399,6 +399,23 @@ func TestLokiFiltering(t *testing.T) {
 		outputQuery: []string{
 			"?query={app=\"netobserv-flowcollector\"}|~`\"SrcPod\":\"mid-.*d\"`",
 		},
+	}, {
+		inputPath: "?SrcPod=apiserver-xxx&DstPod=network-check-source-yyy&SrcNamespace=openshift-apiserver&DstNamespace=openshift-monitoring&match=srcOrDst",
+		outputQuery: []string{
+			"?query={app=\"netobserv-flowcollector\"}|json|(SrcNamespace=~\".*openshift-apiserver.*\"+and+SrcPod=~`.*apiserver-xxx.*`)+or+(DstNamespace=~\".*openshift-monitoring.*\"+and+DstPod=~`.*network-check-source-yyy.*`)",
+			"?query={app=\"netobserv-flowcollector\"}|json|(DstNamespace=~\".*openshift-monitoring.*\"+and+DstPod=~`.*network-check-source-yyy.*`)+or+(SrcNamespace=~\".*openshift-apiserver.*\"+and+SrcPod=~`.*apiserver-xxx.*`)",
+		},
+	}, {
+		inputPath: "?SrcPod=apiserver-xxx&DstPod=network-check-source-yyy&SrcNamespace=openshift-apiserver&match=srcOrDst",
+		outputQuery: []string{
+			"?query={app=\"netobserv-flowcollector\"}|json|(SrcNamespace=~\".*openshift-apiserver.*\"+and+SrcPod=~`.*apiserver-xxx.*`)+or+(DstPod=~`.*network-check-source-yyy.*`)",
+			"?query={app=\"netobserv-flowcollector\"}|json|(DstPod=~`.*network-check-source-yyy.*`)+or+(SrcNamespace=~\".*openshift-apiserver.*\"+and+SrcPod=~`.*apiserver-xxx.*`)",
+		},
+	}, {
+		inputPath: "?SrcPod=apiserver-xxx&match=srcOrDst",
+		outputQuery: []string{
+			"?query={app=\"netobserv-flowcollector\"}|~`\"SrcPod\":\".*apiserver-xxx.*\"`",
+		},
 	}}
 
 	// GIVEN a Loki service

--- a/web/locales/en/plugin__network-observability-plugin.json
+++ b/web/locales/en/plugin__network-observability-plugin.json
@@ -77,6 +77,7 @@
   "Both": "Both",
   "Match all columns": "Match all columns",
   "Match any column": "Match any column",
+  "Match all Source or Destination": "Match all Source or Destination",
   "Every flow can be reported from the source node and/or the destination node. For in-cluster traffic, usually both source and destination nodes report flows, resulting in duplicated data. Cluster ingress traffic is only reported by destination nodes, and cluster egress by source nodes.": "Every flow can be reported from the source node and/or the destination node. For in-cluster traffic, usually both source and destination nodes report flows, resulting in duplicated data. Cluster ingress traffic is only reported by destination nodes, and cluster egress by source nodes.",
   "Whether each query result has to match all the filters or just any of them": "Whether each query result has to match all the filters or just any of them",
   "Match filters": "Match filters",

--- a/web/src/components/__tests-data__/filters.ts
+++ b/web/src/components/__tests-data__/filters.ts
@@ -20,6 +20,17 @@ export const FiltersSample: Filter[] = [
   }
 ];
 
+export const FiltersSample2: Filter[] = [
+  {
+    colId: ColumnsId.srcport,
+    values: [{ v: '1234' }]
+  },
+  {
+    colId: ColumnsId.srcpod,
+    values: [{ v: 'pod or service' }]
+  }
+];
+
 export const FTPSrcPortSample: Filter = {
   colId: ColumnsId.srcport,
   values: [{ v: '21', display: 'ftp' }]

--- a/web/src/components/__tests__/filters-toolbar.spec.tsx
+++ b/web/src/components/__tests__/filters-toolbar.spec.tsx
@@ -1,12 +1,4 @@
-import {
-  Button,
-  Dropdown,
-  TextInput,
-  Toolbar,
-  ToolbarFilter,
-  ToolbarItem,
-  ValidatedOptions
-} from '@patternfly/react-core';
+import { Button, Dropdown, TextInput, Toolbar, ToolbarItem, ValidatedOptions } from '@patternfly/react-core';
 import { mount, shallow } from 'enzyme';
 import * as React from 'react';
 import { act } from 'react-dom/test-utils';
@@ -14,7 +6,7 @@ import { ColumnsId } from '../../utils/columns';
 import { Filter } from '../../utils/filters';
 import FiltersToolbar, { FiltersToolbarProps } from '../filters-toolbar';
 import { ShuffledDefaultColumns } from '../__tests-data__/columns';
-import { FiltersSample, FTPSrcPortSample } from '../__tests-data__/filters';
+import { FiltersSample, FiltersSample2, FTPSrcPortSample } from '../__tests-data__/filters';
 
 describe('<FiltersToolbar />', () => {
   const props: FiltersToolbarProps = {
@@ -42,17 +34,33 @@ describe('<FiltersToolbar />', () => {
   });
   it('should render filters', async () => {
     const wrapper = shallow(<FiltersToolbar {...props} />);
-    expect(wrapper.find(ToolbarFilter)).toHaveLength(props.filters!.length);
+    expect(wrapper.find('.chip-container')).toHaveLength(props.filters!.length);
 
     //add a bunch of filters
     props.filters = FiltersSample;
     wrapper.setProps({ filters: props.filters });
-    expect(wrapper.find(ToolbarFilter)).toHaveLength(props.filters.length);
+    expect(wrapper.find('.chip-container')).toHaveLength(props.filters.length);
 
     //update props to set a single filter
     props.filters = [FiltersSample[0]];
     wrapper.setProps({ filters: props.filters });
-    expect(wrapper.find(ToolbarFilter)).toHaveLength(props.filters.length);
+    expect(wrapper.find('.chip-container')).toHaveLength(props.filters.length);
+  });
+  it('should render grouped filters', async () => {
+    const wrapper = shallow(<FiltersToolbar {...props} />);
+    //group by Source or Destination
+    wrapper.setProps({ queryOptions: { reporter: 'both', limit: 100, match: 'srcOrDst' } });
+
+    //set sample with 2 groups
+    props.filters = FiltersSample;
+    wrapper.setProps({ filters: props.filters });
+    const groupContainers = wrapper.find('.group-container');
+    expect(groupContainers).toHaveLength(2);
+
+    //set sample with one group
+    props.filters = FiltersSample2;
+    wrapper.setProps({ filters: props.filters });
+    expect(wrapper.find('.group-container')).toHaveLength(1);
   });
   it('should open and close', async () => {
     const wrapper = mount(<FiltersToolbar {...props} />);

--- a/web/src/components/__tests__/query-options-dropdown.spec.tsx
+++ b/web/src/components/__tests__/query-options-dropdown.spec.tsx
@@ -29,7 +29,7 @@ describe('<QueryOptionsPanel />', () => {
     const wrapper = shallow(<QueryOptionsPanel {...props} />);
     expect(wrapper.find('.pf-c-select__menu-group').length).toBe(2);
     expect(wrapper.find('.pf-c-select__menu-group-title').length).toBe(3);
-    expect(wrapper.find(Radio)).toHaveLength(8);
+    expect(wrapper.find(Radio)).toHaveLength(9);
 
     //setOptions should not be called at startup, because it is supposed to be already initialized from URL
     expect(props.setOptions).toHaveBeenCalledTimes(0);

--- a/web/src/components/filters-toolbar.css
+++ b/web/src/components/filters-toolbar.css
@@ -60,6 +60,7 @@ button.pf-c-button.pf-m-link.pf-m-inline:empty {
 
 .group-container {
   display: flex;
+  margin-bottom: 10px;
 }
 
 .group-criteria {

--- a/web/src/components/filters-toolbar.css
+++ b/web/src/components/filters-toolbar.css
@@ -49,3 +49,68 @@ button.pf-c-button.pf-m-link.pf-m-inline:empty {
 #more {
   padding: 5px 0px 0px 5px;
 }
+
+/* custom chip groups*/
+
+.pf-c-toolbar__content.group-filters {
+  padding: 0;
+  flex-basis: 100%;
+  margin-top: 5px;
+}
+
+.group-container {
+  display: flex;
+}
+
+.group-criteria {
+  align-self: center;
+  margin: 10px;
+}
+
+.group {
+  text-align: center;
+  background-color: #f0f0f0;
+  border-radius: 3px;
+}
+
+.group-header {
+  display: flex;
+}
+
+.group-title {
+  padding: 5px;
+  flex: 1;
+  align-self: center;
+}
+
+.pf-c-button.group-button {
+  padding: 5px;
+}
+
+.chip-group-content {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.chip-margin {
+  margin: 10px !important;
+}
+
+.chip-container {
+  background: white;
+  border-radius: 5px;
+  border: var(--pf-c-chip--before--BorderWidth) solid var(--pf-c-chip--before--BorderColor);
+  margin-right: 5px;
+}
+
+.chip-custom::before {
+  border: none !important;
+}
+
+.pf-c-button.chip-button {
+  position: relative;
+  right: 0;
+  top: 2px;
+  padding: 0 5px 0 0;
+}

--- a/web/src/components/filters-toolbar.tsx
+++ b/web/src/components/filters-toolbar.tsx
@@ -549,7 +549,7 @@ export const FiltersToolbar: React.FC<FiltersToolbarProps> = ({
               </div>
             </Tooltip>
           ) : (
-            getGroupFilters(forcedFilters, false)
+            <OverflowMenu breakpoint="md">{getGroupFilters(forcedFilters, false)}</OverflowMenu>
           )}
         </ToolbarItem>
         {!_.isEmpty(forcedFilters) && (

--- a/web/src/components/query-options-dropdown.tsx
+++ b/web/src/components/query-options-dropdown.tsx
@@ -40,6 +40,10 @@ export const QueryOptionsPanel: React.FC<QueryOptionsDropdownProps> = ({ options
     {
       label: t('Match any column'),
       value: 'any'
+    },
+    {
+      label: t('Match all Source or Destination'),
+      value: 'srcOrDst'
     }
   ];
 

--- a/web/src/model/query-options.ts
+++ b/web/src/model/query-options.ts
@@ -1,6 +1,6 @@
 export type Reporter = 'source' | 'destination' | 'both';
 
-export type Match = 'all' | 'any';
+export type Match = 'all' | 'any' | 'srcOrDst';
 
 export interface QueryOptions {
   reporter: Reporter;

--- a/web/src/utils/filters.ts
+++ b/web/src/utils/filters.ts
@@ -1,7 +1,8 @@
+import { TFunction } from 'i18next';
 import * as _ from 'lodash';
 import protocols from 'protocol-numbers';
 import { getPort } from 'port-numbers';
-import { ColumnsId } from './columns';
+import { ColumnsId, getDefaultColumns } from './columns';
 import { getProtectedService } from './port';
 
 export enum FilterType {
@@ -22,6 +23,26 @@ export interface Filter {
   colId: ColumnsId;
   values: FilterValue[];
 }
+
+export type FilterGroup = {
+  title?: string;
+  filters: Filter[];
+};
+
+export const getFilterGroups = (filters: Filter[], t: TFunction) => {
+  const groups: FilterGroup[] = [];
+  _.each(filters, filter => {
+    const group = getDefaultColumns(t).find(c => c.id === filter.colId)?.group;
+    const found = groups.find(g => g.title === group);
+    if (found) {
+      found!.filters.push(filter);
+    } else {
+      groups.push({ title: group, filters: [filter] });
+    }
+  });
+
+  return groups;
+};
 
 export interface FilterOption {
   name: string;

--- a/web/src/utils/router.ts
+++ b/web/src/utils/router.ts
@@ -47,7 +47,8 @@ export const reporterToFlowdir = _.invert(flowdirToReporter);
 
 const stringToMatch: { [match: string]: Match } = {
   all: 'all',
-  any: 'any'
+  any: 'any',
+  srcOrDst: 'srcOrDst'
 };
 
 export const buildQueryArguments = (


### PR DESCRIPTION
This PR add a query option to `match all Source OR Destination` fields

```
http://localhost:3100/loki/api/v1/query_range?query={app="netobserv-flowcollector"}|json|(DstNamespace=~".*open.*"+and+DstPod=~`.*api.*`)+or+(SrcNamespace=~".*open.*"+and+SrcPod=~`prom.*`)&start=1645797646&limit=100
```

![image](https://user-images.githubusercontent.com/91894519/155727750-a2b5d99d-cb53-4837-9dd8-e70963985824.png)
![image](https://user-images.githubusercontent.com/91894519/155728912-c82f03bc-88bb-42dc-9e00-03a5372874fb.png)

I suggest to release that as is to unlock https://github.com/netobserv/network-observability-console-plugin/pull/81 and add an extra `custom match` filter in the future to unlock custom grouping.

We can imagine custom grouping using drag and drop on UI side and `match` argument sent to the backend containing group infos (fields, criteria between each value of group / between each group)

Or wait for PF query builder https://github.com/patternfly/patternfly-design/issues/972