### PR TITLE
NETOBSERV-176 regex case insensitive

### DIFF
--- a/pkg/loki/query.go
+++ b/pkg/loki/query.go
@@ -201,8 +201,9 @@ func (q *Query) processStreamSelector(key string, values []string) {
 			regexStr.WriteByte('|')
 		}
 		//match the begining of string if quoted without a star
+		//and case insensitive if no quotes
 		if !strings.HasPrefix(value, `"`) {
-			regexStr.WriteString(".*")
+			regexStr.WriteString("(?i).*")
 		} else if !strings.HasPrefix(value, `"*`) {
 			regexStr.WriteString("^")
 		}
@@ -259,8 +260,9 @@ func (q *Query) processLineFilters(key string, values []string) error {
 		} else {
 			regexStr.WriteString(`"`)
 			// match start any if not quoted
+			// and case insensitive
 			if !strings.HasPrefix(value, `"`) {
-				regexStr.WriteString(".*")
+				regexStr.WriteString("(?i).*")
 			}
 			//inject value with regex
 			regexStr.WriteString(valueReplacer.Replace(value))

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -263,12 +263,12 @@ func TestLokiFiltering(t *testing.T) {
 	}{{
 		inputPath: "?SrcPod=test-pod",
 		outputQuery: []string{
-			"?query={app=\"netobserv-flowcollector\"}|~`\"SrcPod\":\".*test-pod.*\"`",
+			"?query={app=\"netobserv-flowcollector\"}|~`\"SrcPod\":\"(?i).*test-pod.*\"`",
 		},
 	}, {
 		inputPath: "?SrcPod=test-pod&match=any",
 		outputQuery: []string{
-			"?query={app=\"netobserv-flowcollector\"}|~`\"SrcPod\":\".*test-pod.*\"`",
+			"?query={app=\"netobserv-flowcollector\"}|~`\"SrcPod\":\"(?i).*test-pod.*\"`",
 		},
 	}, {
 		inputPath: "?Proto=6&match=all",
@@ -283,45 +283,45 @@ func TestLokiFiltering(t *testing.T) {
 	}, {
 		inputPath: "?Proto=6&SrcPod=test",
 		outputQuery: []string{
-			"?query={app=\"netobserv-flowcollector\"}|~`\"Proto\":6`|~`\"SrcPod\":\".*test.*\"`",
-			"?query={app=\"netobserv-flowcollector\"}|~`\"SrcPod\":\".*test.*\"`|~`\"Proto\":6`",
+			"?query={app=\"netobserv-flowcollector\"}|~`\"Proto\":6`|~`\"SrcPod\":\"(?i).*test.*\"`",
+			"?query={app=\"netobserv-flowcollector\"}|~`\"SrcPod\":\"(?i).*test.*\"`|~`\"Proto\":6`",
 		},
 	}, {
 		inputPath: "?Proto=6&SrcPod=test&match=any",
 		outputQuery: []string{
-			"?query={app=\"netobserv-flowcollector\"}|~`(\"Proto\":6)|(\"SrcPod\":\".*test.*\")`",
-			"?query={app=\"netobserv-flowcollector\"}|~`(\"SrcPod\":\".*test.*\")|(\"Proto\":6)`",
+			"?query={app=\"netobserv-flowcollector\"}|~`(\"Proto\":6)|(\"SrcPod\":\"(?i).*test.*\")`",
+			"?query={app=\"netobserv-flowcollector\"}|~`(\"SrcPod\":\"(?i).*test.*\")|(\"Proto\":6)`",
 		},
 	}, {
 		inputPath: "?Proto=6&SrcPod=test&FlowDirection=1&match=any",
 		outputQuery: []string{
-			"?query={app=\"netobserv-flowcollector\",FlowDirection=\"1\"}|~`(\"Proto\":6)|(\"SrcPod\":\".*test.*\")`",
-			"?query={app=\"netobserv-flowcollector\",FlowDirection=\"1\"}|~`(\"SrcPod\":\".*test.*\")|(\"Proto\":6)`",
+			"?query={app=\"netobserv-flowcollector\",FlowDirection=\"1\"}|~`(\"Proto\":6)|(\"SrcPod\":\"(?i).*test.*\")`",
+			"?query={app=\"netobserv-flowcollector\",FlowDirection=\"1\"}|~`(\"SrcPod\":\"(?i).*test.*\")|(\"Proto\":6)`",
 		},
 	}, {
 		inputPath: "?SrcNamespace=test-namespace&match=all",
 		outputQuery: []string{
-			`?query={SrcNamespace=~".*test-namespace.*",app="netobserv-flowcollector"}`,
+			`?query={SrcNamespace=~"(?i).*test-namespace.*",app="netobserv-flowcollector"}`,
 		},
 	}, {
 		inputPath: "?SrcNamespace=test-namespace&match=any",
 		outputQuery: []string{
-			`?query={SrcNamespace=~".*test-namespace.*",app="netobserv-flowcollector"}`,
+			`?query={SrcNamespace=~"(?i).*test-namespace.*",app="netobserv-flowcollector"}`,
 		},
 	}, {
 		inputPath: "?SrcPort=8080&SrcAddr=10.128.0.1&SrcNamespace=default",
 		outputQuery: []string{
-			"?query={SrcNamespace=~\".*default.*\",app=\"netobserv-flowcollector\"}|~`\"SrcPort\":8080`|json|SrcAddr=ip(\"10.128.0.1\")",
+			"?query={SrcNamespace=~\"(?i).*default.*\",app=\"netobserv-flowcollector\"}|~`\"SrcPort\":8080`|json|SrcAddr=ip(\"10.128.0.1\")",
 		},
 	}, {
 		inputPath: "?SrcPort=8080&SrcAddr=10.128.0.1&SrcNamespace=default&match=any",
 		outputQuery: []string{
-			"?query={app=\"netobserv-flowcollector\"}|json|SrcNamespace=~\".*default.*\"+or+SrcAddr=ip(\"10.128.0.1\")+or+SrcPort=8080",
+			"?query={app=\"netobserv-flowcollector\"}|json|SrcNamespace=~\"(?i).*default.*\"+or+SrcAddr=ip(\"10.128.0.1\")+or+SrcPort=8080",
 		},
 	}, {
 		inputPath: "?SrcPort=8080&SrcAddr=10.128.0.1&SrcNamespace=default&match=any&FlowDirection=0",
 		outputQuery: []string{
-			"?query={app=\"netobserv-flowcollector\",FlowDirection=\"0\"}|json|SrcNamespace=~\".*default.*\"+or+SrcAddr=ip(\"10.128.0.1\")+or+SrcPort=8080",
+			"?query={app=\"netobserv-flowcollector\",FlowDirection=\"0\"}|json|SrcNamespace=~\"(?i).*default.*\"+or+SrcAddr=ip(\"10.128.0.1\")+or+SrcPort=8080",
 		},
 	}, {
 		inputPath:   "?startTime=1640991600&match=all",

--- a/web/locales/en/plugin__network-observability-plugin.json
+++ b/web/locales/en/plugin__network-observability-plugin.json
@@ -27,6 +27,7 @@
   "Containing any alphanumeric, hyphen, underscrore or dot character": "Containing any alphanumeric, hyphen, underscrore or dot character",
   "Partial text like cluster, cluster-image, image-registry": "Partial text like cluster, cluster-image, image-registry",
   "Exact match using quotes like \"cluster-image-registry\"": "Exact match using quotes like \"cluster-image-registry\"",
+  "Case sensitive match using quotes like \"Deployment\"": "Case sensitive match using quotes like \"Deployment\"",
   "Starting text like cluster, \"cluster-*\"": "Starting text like cluster, \"cluster-*\"",
   "Ending text like \"*-registry\"": "Ending text like \"*-registry\"",
   "Pattern like \"cluster-*-registry\", \"c*-*-r*y\", -i*e-": "Pattern like \"cluster-*-registry\", \"c*-*-r*y\", -i*e-",

--- a/web/src/components/filters-toolbar.tsx
+++ b/web/src/components/filters-toolbar.tsx
@@ -357,6 +357,7 @@ export const FiltersToolbar: React.FC<FiltersToolbarProps> = ({
         - ${t('Containing any alphanumeric, hyphen, underscrore or dot character')}
         - ${t('Partial text like cluster, cluster-image, image-registry')}
         - ${t('Exact match using quotes like "cluster-image-registry"')}
+        - ${t('Case sensitive match using quotes like "Deployment"')}
         - ${t('Starting text like cluster, "cluster-*"')}
         - ${t('Ending text like "*-registry"')}
         - ${t('Pattern like "cluster-*-registry", "c*-*-r*y", -i*e-')}`;


### PR DESCRIPTION
Following @memodi comment on [NETOBSERV-176](https://issues.redhat.com/browse/NETOBSERV-176) we can add case insensitive to regex when text is not quoted

I have added an example in the "Learn more" section.
It seems there is no performance changes for this implementation,  at least for our queries