### PR TITLE
NETOBSERV-192 Release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,56 @@
+name: release to quay.io
+on:
+  push:
+    tags: [v*]
+
+env:
+  REGISTRY_USER: netobserv+github_ci
+  REGISTRY_PASSWORD: ${{ secrets.QUAY_SECRET }}
+  REGISTRY: quay.io/netobserv
+  IMAGE: network-observability-console-plugin
+
+jobs:
+  push-image:
+    name: push image
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        go: ['1.17']
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: validate tag
+        id: validate_tag
+        run: |
+          tag=`git describe --exact-match --tags 2> /dev/null`
+          if [[ $tag =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$ ]]; then
+              echo "$tag is a valid release tag"
+              set -e
+              echo "::set-output name=tag::$tag"
+          else
+              echo "$tag is NOT a valid release tag"
+              exit 1
+          fi
+      - name: install make
+        run: sudo apt-get install make
+      - name: set up go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+      - name: build images
+        run: IMAGE="quay.io/netobserv/${{ env.IMAGE }}:${{ steps.validate_tag.outputs.tag }} make image
+      - name: podman login to quay.io
+        uses: redhat-actions/podman-login@v1
+        with:
+          username: ${{ env.REGISTRY_USER }}
+          password: ${{ env.REGISTRY_PASSWORD }}
+          registry: quay.io
+      - name: push to quay.io
+        id: push-to-quay
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ env.IMAGE }}
+          tags: ${{ steps.validate_tag.outputs.tag }}
+          registry: ${{ env.REGISTRY }}
+      - name: print image url
+        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"


### PR DESCRIPTION
Similar to the existing push-to-quay action, except it's triggered from
tags and will push just 1 image built using that tag as version.

https://issues.redhat.com/browse/NETOBSERV-192