### PR TITLE
Use default TAG=dev to prevent accidental push on main by quay admins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 IMG_USER ?= netobserv
-TAG ?= main
+TAG ?= dev
 BUILD_VERSION := $(shell git describe --long HEAD)
 BUILD_DATE := $(shell date +%Y-%m-%d\ %H:%M)
 BUILD_SHA := $(shell git rev-parse --short HEAD)


### PR DESCRIPTION
Yesterday I accidentally pushed the "main" image on quay (I rollbacked minutes later).
This change should avoid such a situation