### PR TITLE
NETOBSERV-229 CI: create pre-merge images

### DIFF
--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -1,4 +1,4 @@
-name: push to quay.io
+name: Build and push to quay.io
 on:
   push:
     branches: [ main ]
@@ -27,7 +27,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: build images
-        run: IMAGE="quay.io/netobserv/${{ env.IMAGE }}:${{ env.TAG }}" make sha-image
+        run: IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.TAG }}" make sha-image
       - name: podman login to quay.io
         uses: redhat-actions/podman-login@v1
         with:

--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -7,8 +7,8 @@ env:
   REGISTRY_USER: netobserv+github_ci
   REGISTRY_PASSWORD: ${{ secrets.QUAY_SECRET }}
   REGISTRY: quay.io/netobserv
-  IMAGE: network-observability-console-plugin
-  TAG: main
+  REG_IMAGE: network-observability-console-plugin
+  REG_TAG: main
 
 jobs:
   push-image:
@@ -27,7 +27,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: build images
-        run: IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.TAG }}" make sha-image
+        run: BASE_IMAGE="${{ env.REGISTRY }}/${{ env.REG_IMAGE }}" TAG="${{ env.REG_TAG }}" make build-ci-images
       - name: podman login to quay.io
         uses: redhat-actions/podman-login@v1
         with:
@@ -41,8 +41,8 @@ jobs:
         id: push-to-quay
         uses: redhat-actions/push-to-registry@v2
         with:
-          image: ${{ env.IMAGE }}
-          tags: ${{ env.TAG }} ${{ steps.shortsha.outputs.short_sha }}
+          image: ${{ env.REG_IMAGE }}
+          tags: ${{ env.REG_TAG }} ${{ steps.shortsha.outputs.short_sha }}
           registry: ${{ env.REGISTRY }}
       - name: print image url
         run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"

--- a/.github/workflows/push_image_pr.yml
+++ b/.github/workflows/push_image_pr.yml
@@ -6,7 +6,7 @@ on:
 env:
   REGISTRY_USER: netobserv+github_ci
   REGISTRY: quay.io/netobserv
-  IMAGE: network-observability-console-plugin
+  REG_IMAGE: network-observability-console-plugin
 
 jobs:
   push-pr-image:
@@ -28,7 +28,7 @@ jobs:
         with:
           ref: "refs/pull/${{ github.event.number }}/merge"
       - name: build images
-        run: IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE }}:temp" make sha-image
+        run: BASE_IMAGE="${{ env.REGISTRY }}/${{ env.REG_IMAGE }}" TAG=temp make build-ci-images
       - name: podman login to quay.io
         uses: redhat-actions/podman-login@v1
         with:
@@ -42,7 +42,7 @@ jobs:
         id: push-to-quay
         uses: redhat-actions/push-to-registry@v2
         with:
-          image: ${{ env.IMAGE }}
+          image: ${{ env.REG_IMAGE }}
           tags: ${{ steps.shortsha.outputs.short_sha }}
           registry: ${{ env.REGISTRY }}
       - uses: actions/github-script@v5

--- a/.github/workflows/push_image_pr.yml
+++ b/.github/workflows/push_image_pr.yml
@@ -1,0 +1,69 @@
+name: Build and push PR image to quay.io
+on:
+  pull_request_target
+
+env:
+  REGISTRY_USER: netobserv+github_ci
+  REGISTRY_PASSWORD: ${{ secrets.QUAY_SECRET }}
+  REGISTRY: quay.io/netobserv
+  IMAGE: network-observability-console-plugin
+  ALLOWED_USERS: mariomac jotak jpinsonneau OlivierCazade eranra KalmanMeth ronensc
+
+jobs:
+  push-pr-image:
+    name: push PR image
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        go: ['1.17']
+    steps:
+      - name: install make
+        run: sudo apt-get install make
+      - name: set up go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+      - name: validate user
+        id: validate_user
+        run: |
+          allowed=(${{ env.ALLOWED_USERS }})
+          for user in ${allowed[@]}; do
+            if [[ "${{ github.event.pull_request.user.login }}" == "$user" ]]; then
+                echo "$user is a known user, proceeding to build."
+                exit 0
+            fi
+          done
+          echo "User ${{ github.event.pull_request.user.login }} is unknown, PR image build canceled."
+          exit 1
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          ref: "refs/pull/${{ github.event.number }}/merge"
+      - name: build images
+        run: IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE }}:temp" make sha-image
+      - name: podman login to quay.io
+        uses: redhat-actions/podman-login@v1
+        with:
+          username: ${{ env.REGISTRY_USER }}
+          password: ${{ env.REGISTRY_PASSWORD }}
+          registry: quay.io
+      - name: get short sha
+        id: shortsha
+        run: echo "::set-output name=short_sha::$(git rev-parse --short HEAD)"
+      - name: push to quay.io
+        id: push-to-quay
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ env.IMAGE }}
+          tags: ${{ steps.shortsha.outputs.short_sha }}
+          registry: ${{ env.REGISTRY }}
+      - uses: actions/github-script@v5
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'New image: ${{ steps.push-to-quay.outputs.registry-paths }}'
+            })

--- a/.github/workflows/push_image_pr.yml
+++ b/.github/workflows/push_image_pr.yml
@@ -1,16 +1,16 @@
 name: Build and push PR image to quay.io
 on:
-  pull_request_target
+  pull_request_target:
+    types: [labeled]
 
 env:
   REGISTRY_USER: netobserv+github_ci
-  REGISTRY_PASSWORD: ${{ secrets.QUAY_SECRET }}
   REGISTRY: quay.io/netobserv
   IMAGE: network-observability-console-plugin
-  ALLOWED_USERS: mariomac jotak jpinsonneau OlivierCazade eranra KalmanMeth ronensc
 
 jobs:
   push-pr-image:
+    if: ${{ github.event.label.name == 'ok-to-test' }}
     name: push PR image
     runs-on: ubuntu-20.04
     strategy:
@@ -23,18 +23,6 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go }}
-      - name: validate user
-        id: validate_user
-        run: |
-          allowed=(${{ env.ALLOWED_USERS }})
-          for user in ${allowed[@]}; do
-            if [[ "${{ github.event.pull_request.user.login }}" == "$user" ]]; then
-                echo "$user is a known user, proceeding to build."
-                exit 0
-            fi
-          done
-          echo "User ${{ github.event.pull_request.user.login }} is unknown, PR image build canceled."
-          exit 1
       - name: checkout
         uses: actions/checkout@v2
         with:
@@ -45,7 +33,7 @@ jobs:
         uses: redhat-actions/podman-login@v1
         with:
           username: ${{ env.REGISTRY_USER }}
-          password: ${{ env.REGISTRY_PASSWORD }}
+          password: ${{ secrets.QUAY_SECRET }}
           registry: quay.io
       - name: get short sha
         id: shortsha
@@ -65,5 +53,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'New image: ${{ steps.push-to-quay.outputs.registry-paths }}'
+              body: 'New image: ${{ steps.push-to-quay.outputs.registry-paths }}. It will expire after two weeks.'
             })

--- a/.github/workflows/rm-ok-to-test.yaml
+++ b/.github/workflows/rm-ok-to-test.yaml
@@ -1,0 +1,14 @@
+name: Remove ok-to-test
+on:
+  pull_request:
+    types: [synchronize,reopened]
+
+jobs:
+  rm-ok-to-test:
+    if: contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+    runs-on: ubuntu-20.04
+    name: Remove ok-to-test
+    steps:
+      - uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: ok-to-test

--- a/shortlived.Dockerfile
+++ b/shortlived.Dockerfile
@@ -1,0 +1,3 @@
+ARG BASE_IMAGE=quay.io/netobserv/network-observability-console-plugin:main
+FROM $BASE_IMAGE
+LABEL quay.expires-after=2w


### PR DESCRIPTION
https://issues.redhat.com/browse/NETOBSERV-229

New github action workflow to build and push images per pull request.

Some security consideration: pushing images requires QUAY_SECRET to be used, which isn't
available in the 'pull_request' trigger, so we have to use
'pull_request_target' instead. This trigger uses the base branch HEAD,
rather than the PR's HEAD to execute the workflow, to prevent attacks
stealing secrets. Still, it could be vulnerable to attacks stealing secret from the build itself. So as an additional measure, we inculde a user validation check, so that only allowed users (maintainers) have their PR image built.