### PR TITLE
NETOBSERV-269 Port exact match

### DIFF
--- a/pkg/loki/flow_query.go
+++ b/pkg/loki/flow_query.go
@@ -128,17 +128,22 @@ func (q *FlowQueryBuilder) addLineFilters(key string, values []string) {
 		if i > 0 {
 			regexStr.WriteByte('|')
 		}
-		//match end of KEY + regex VALUE:
-		//if numeric, KEY":VALUE
-		//if string KEY":"VALUE"
-		//ie 'Port' key will match both 'SrcPort":"XXX"' and 'DstPort":"XXX"
-		//VALUE can be quoted for exact match or contains * to inject regex any
+		// match end of KEY + regex VALUE:
+		// if numeric, KEY":VALUE,
+		// if string KEY":"VALUE"
+		// ie 'Port' key will match both 'SrcPort":"XXX"' and 'DstPort":"XXX"
+		// VALUE can be quoted for exact match or contains * to inject regex any
+		// For numeric values, exact match is implicit
+		// 	(the trick is to match for the ending coma; it works as long as the filtered field
+		// 	is not the last one (they're in alphabetic order); a less performant alternative
+		// 	but more future-proof/less hacky could be to move that to a json filter, if needed)
 		regexStr.WriteString(key)
 		regexStr.WriteString(`":`)
 		if fields.IsNumeric(key) {
 			regexStr.WriteString(value)
+			regexStr.WriteByte(',')
 		} else {
-			regexStr.WriteString(`"`)
+			regexStr.WriteByte('"')
 			// match start any if not quoted
 			// and case insensitive
 			if !strings.HasPrefix(value, `"`) {
@@ -150,7 +155,7 @@ func (q *FlowQueryBuilder) addLineFilters(key string, values []string) {
 			if !strings.HasSuffix(value, `"`) {
 				regexStr.WriteString(".*")
 			}
-			regexStr.WriteString(`"`)
+			regexStr.WriteByte('"')
 		}
 	}
 

--- a/pkg/server/server_flows_test.go
+++ b/pkg/server/server_flows_test.go
@@ -38,19 +38,19 @@ func TestLokiFiltering(t *testing.T) {
 		inputPath: "?filters=" + url.QueryEscape("Proto=6&SrcK8S_Name=test"),
 		outputQueryParts: []string{
 			"?query={app=\"netobserv-flowcollector\"}",
-			"|~`Proto\":6`",
+			"|~`Proto\":6,`",
 			"|~`SrcK8S_Name\":\"(?i).*test.*\"`",
 		},
 	}, {
 		inputPath: "?filters=" + url.QueryEscape("Proto=6|SrcK8S_Name=test"),
 		outputQueries: []string{
-			"?query={app=\"netobserv-flowcollector\"}|~`Proto\":6`",
+			"?query={app=\"netobserv-flowcollector\"}|~`Proto\":6,`",
 			"?query={app=\"netobserv-flowcollector\"}|~`SrcK8S_Name\":\"(?i).*test.*\"`",
 		},
 	}, {
 		inputPath: "?filters=" + url.QueryEscape("Proto=6|SrcK8S_Name=test") + "&reporter=source",
 		outputQueries: []string{
-			"?query={app=\"netobserv-flowcollector\",FlowDirection=\"1\"}|~`Proto\":6`",
+			"?query={app=\"netobserv-flowcollector\",FlowDirection=\"1\"}|~`Proto\":6,`",
 			"?query={app=\"netobserv-flowcollector\",FlowDirection=\"1\"}|~`SrcK8S_Name\":\"(?i).*test.*\"`",
 		},
 	}, {
@@ -71,7 +71,7 @@ func TestLokiFiltering(t *testing.T) {
 	}, {
 		inputPath: "?filters=" + url.QueryEscape("SrcPort=8080&SrcAddr=10.128.0.1&SrcK8S_Namespace=default"),
 		outputQueries: []string{
-			"?query={app=\"netobserv-flowcollector\",SrcK8S_Namespace=~\"(?i).*default.*\"}|~`SrcPort\":8080`|json|SrcAddr=ip(\"10.128.0.1\")",
+			"?query={app=\"netobserv-flowcollector\",SrcK8S_Namespace=~\"(?i).*default.*\"}|~`SrcPort\":8080,`|json|SrcAddr=ip(\"10.128.0.1\")",
 		},
 	}, {
 		inputPath: "?filters=" + url.QueryEscape("SrcAddr=10.128.0.1&DstAddr=10.128.0.2"),
@@ -90,14 +90,14 @@ func TestLokiFiltering(t *testing.T) {
 		outputQueries: []string{
 			"?query={app=\"netobserv-flowcollector\",SrcK8S_Namespace=~\"(?i).*default.*\"}",
 			"?query={app=\"netobserv-flowcollector\"}|json|SrcAddr=ip(\"10.128.0.1\")",
-			"?query={app=\"netobserv-flowcollector\"}|~`SrcPort\":8080`",
+			"?query={app=\"netobserv-flowcollector\"}|~`SrcPort\":8080,`",
 		},
 	}, {
 		inputPath: "?filters=" + url.QueryEscape("SrcPort=8080|SrcAddr=10.128.0.1|SrcK8S_Namespace=default") + "&reporter=destination",
 		outputQueries: []string{
 			"?query={app=\"netobserv-flowcollector\",FlowDirection=\"0\",SrcK8S_Namespace=~\"(?i).*default.*\"}",
 			"?query={app=\"netobserv-flowcollector\",FlowDirection=\"0\"}|json|SrcAddr=ip(\"10.128.0.1\")",
-			"?query={app=\"netobserv-flowcollector\",FlowDirection=\"0\"}|~`SrcPort\":8080`",
+			"?query={app=\"netobserv-flowcollector\",FlowDirection=\"0\"}|~`SrcPort\":8080,`",
 		},
 	}, {
 		inputPath:     "?startTime=1640991600",
@@ -125,27 +125,27 @@ func TestLokiFiltering(t *testing.T) {
 		inputPath: "?filters=" + url.QueryEscape("Port=8080&K8S_Name=test"),
 		outputQueryParts: []string{
 			"?query={app=\"netobserv-flowcollector\"}",
-			"|~`Port\":8080`",
+			"|~`Port\":8080,`",
 			"|~`K8S_Name\":\"(?i).*test.*\"`",
 		},
 	}, {
 		inputPath: "?filters=" + url.QueryEscape("Port=8080|K8S_Name=test"),
 		outputQueries: []string{
 			"?query={app=\"netobserv-flowcollector\"}|~`K8S_Name\":\"(?i).*test.*\"`",
-			"?query={app=\"netobserv-flowcollector\"}|~`Port\":8080`",
+			"?query={app=\"netobserv-flowcollector\"}|~`Port\":8080,`",
 		},
 	}, {
 		inputPath: "?filters=" + url.QueryEscape("Port=8080&SrcK8S_Namespace=test|Port=8080&DstK8S_Namespace=test"),
 		outputQueries: []string{
-			"?query={app=\"netobserv-flowcollector\",SrcK8S_Namespace=~\"(?i).*test.*\"}|~`Port\":8080`",
-			"?query={app=\"netobserv-flowcollector\",DstK8S_Namespace=~\"(?i).*test.*\"}|~`Port\":8080`",
+			"?query={app=\"netobserv-flowcollector\",SrcK8S_Namespace=~\"(?i).*test.*\"}|~`Port\":8080,`",
+			"?query={app=\"netobserv-flowcollector\",DstK8S_Namespace=~\"(?i).*test.*\"}|~`Port\":8080,`",
 		},
 	}, {
 		inputPath: "?filters=" + url.QueryEscape("Port=8080|SrcK8S_Namespace=test|DstK8S_Namespace=test"),
 		outputQueries: []string{
 			"?query={app=\"netobserv-flowcollector\",SrcK8S_Namespace=~\"(?i).*test.*\"}",
 			"?query={app=\"netobserv-flowcollector\",DstK8S_Namespace=~\"(?i).*test.*\"}",
-			"?query={app=\"netobserv-flowcollector\"}|~`Port\":8080`",
+			"?query={app=\"netobserv-flowcollector\"}|~`Port\":8080,`",
 		},
 	}}
 


### PR DESCRIPTION
doing a "trick" by matching for a coma after the port value, to ensure exact match. It works as long as port isn't the last field (which is never the case afaik). The other option could be to do an explicit exact match after a json extraction, which is probably cleaner but less performant. So, it's debatable...
