### PR TITLE
Fix linefilter regex, disallowing '"' in before-match

### DIFF
--- a/pkg/loki/flow_query.go
+++ b/pkg/loki/flow_query.go
@@ -147,7 +147,7 @@ func (q *FlowQueryBuilder) addLineFilters(key string, values []string) {
 			// match start any if not quoted
 			// and case insensitive
 			if !strings.HasPrefix(value, `"`) {
-				regexStr.WriteString("(?i).*")
+				regexStr.WriteString("(?i)[^\"]*")
 			}
 			//inject value with regex
 			regexStr.WriteString(valueReplacer.Replace(value))

--- a/pkg/server/server_flows_test.go
+++ b/pkg/server/server_flows_test.go
@@ -32,26 +32,26 @@ func TestLokiFiltering(t *testing.T) {
 	}{{
 		inputPath: "?filters=SrcK8S_Name=test-pod",
 		outputQueries: []string{
-			"?query={app=\"netobserv-flowcollector\"}|~`SrcK8S_Name\":\"(?i).*test-pod.*\"`",
+			"?query={app=\"netobserv-flowcollector\"}|~`SrcK8S_Name\":\"(?i)[^\"]*test-pod.*\"`",
 		},
 	}, {
 		inputPath: "?filters=" + url.QueryEscape("Proto=6&SrcK8S_Name=test"),
 		outputQueryParts: []string{
 			"?query={app=\"netobserv-flowcollector\"}",
 			"|~`Proto\":6,`",
-			"|~`SrcK8S_Name\":\"(?i).*test.*\"`",
+			"|~`SrcK8S_Name\":\"(?i)[^\"]*test.*\"`",
 		},
 	}, {
 		inputPath: "?filters=" + url.QueryEscape("Proto=6|SrcK8S_Name=test"),
 		outputQueries: []string{
 			"?query={app=\"netobserv-flowcollector\"}|~`Proto\":6,`",
-			"?query={app=\"netobserv-flowcollector\"}|~`SrcK8S_Name\":\"(?i).*test.*\"`",
+			"?query={app=\"netobserv-flowcollector\"}|~`SrcK8S_Name\":\"(?i)[^\"]*test.*\"`",
 		},
 	}, {
 		inputPath: "?filters=" + url.QueryEscape("Proto=6|SrcK8S_Name=test") + "&reporter=source",
 		outputQueries: []string{
 			"?query={app=\"netobserv-flowcollector\",FlowDirection=\"1\"}|~`Proto\":6,`",
-			"?query={app=\"netobserv-flowcollector\",FlowDirection=\"1\"}|~`SrcK8S_Name\":\"(?i).*test.*\"`",
+			"?query={app=\"netobserv-flowcollector\",FlowDirection=\"1\"}|~`SrcK8S_Name\":\"(?i)[^\"]*test.*\"`",
 		},
 	}, {
 		inputPath: "?filters=" + url.QueryEscape("SrcK8S_Namespace=test-namespace"),
@@ -61,7 +61,7 @@ func TestLokiFiltering(t *testing.T) {
 	}, {
 		inputPath: "?filters=" + url.QueryEscape("SrcK8S_Name=name1,name2"),
 		outputQueries: []string{
-			"?query={app=\"netobserv-flowcollector\"}|~`SrcK8S_Name\":\"(?i).*name1.*\"|SrcK8S_Name\":\"(?i).*name2.*\"`",
+			"?query={app=\"netobserv-flowcollector\"}|~`SrcK8S_Name\":\"(?i)[^\"]*name1.*\"|SrcK8S_Name\":\"(?i)[^\"]*name2.*\"`",
 		},
 	}, {
 		inputPath: "?filters=" + url.QueryEscape("SrcK8S_Namespace=ns1,ns2"),
@@ -126,12 +126,12 @@ func TestLokiFiltering(t *testing.T) {
 		outputQueryParts: []string{
 			"?query={app=\"netobserv-flowcollector\"}",
 			"|~`Port\":8080,`",
-			"|~`K8S_Name\":\"(?i).*test.*\"`",
+			"|~`K8S_Name\":\"(?i)[^\"]*test.*\"`",
 		},
 	}, {
 		inputPath: "?filters=" + url.QueryEscape("Port=8080|K8S_Name=test"),
 		outputQueries: []string{
-			"?query={app=\"netobserv-flowcollector\"}|~`K8S_Name\":\"(?i).*test.*\"`",
+			"?query={app=\"netobserv-flowcollector\"}|~`K8S_Name\":\"(?i)[^\"]*test.*\"`",
 			"?query={app=\"netobserv-flowcollector\"}|~`Port\":8080,`",
 		},
 	}, {


### PR DESCRIPTION
Fixes https://github.com/netobserv/network-observability-console-plugin/pull/105#issuecomment-1092730150
wrong "dns-default" appearing when searching for dest name loki