### PR TITLE
NETOBSERV-226 matrix merger implementation

### DIFF
--- a/pkg/loki/matrix_merger.go
+++ b/pkg/loki/matrix_merger.go
@@ -1,0 +1,65 @@
+package loki
+
+import (
+	"github.com/netobserv/network-observability-console-plugin/pkg/model"
+	pmodel "github.com/prometheus/common/model"
+)
+
+//MatrixMerger stores a state to build unique Matrix from multiple ones
+type MatrixMerger struct {
+	index  map[string]indexedSampleStream
+	merged model.Matrix
+}
+
+func NewMatrixMerger() *MatrixMerger {
+	return &MatrixMerger{
+		index:  map[string]indexedSampleStream{},
+		merged: model.Matrix{},
+	}
+}
+
+//indexedSampleStream stores a unique SampleStream at a specific index with merged values
+type indexedSampleStream struct {
+	sampleStream pmodel.SampleStream
+	values       map[string]interface{}
+	index        int
+}
+
+func (m *MatrixMerger) AddMatrix(from model.Matrix) model.Matrix {
+	for _, sampleStream := range from {
+		skey := sampleStream.Metric.String()
+		idxSampleStream, sampleStreamExists := m.index[skey]
+		if !sampleStreamExists {
+			// SampleStream doesn't exist => create new index
+			idxSampleStream = indexedSampleStream{
+				sampleStream: sampleStream,
+				values:       map[string]interface{}{},
+				index:        len(m.index),
+			}
+		}
+		// Merge content (values)
+		for _, v := range sampleStream.Values {
+			vkey := v.String()
+			if _, valueExists := idxSampleStream.values[vkey]; !valueExists {
+				// Add value to the existing sampleStream, and mark it as existing in idxSampleStream.values
+				idxSampleStream.values[vkey] = nil
+				if sampleStreamExists {
+					idxSampleStream.sampleStream.Values = append(m.index[skey].sampleStream.Values, v)
+				}
+			} // Else: entry found => ignore duplicate
+		}
+		// Add or overwrite index
+		m.index[skey] = idxSampleStream
+		if !sampleStreamExists {
+			// SampleStream doesn't exist => append it
+			m.merged = append(m.merged, idxSampleStream.sampleStream)
+		} else {
+			m.merged[idxSampleStream.index] = idxSampleStream.sampleStream
+		}
+	}
+	return m.merged
+}
+
+func (m *MatrixMerger) GetMatrix() model.Matrix {
+	return m.merged
+}

--- a/pkg/loki/matrix_merger_test.go
+++ b/pkg/loki/matrix_merger_test.go
@@ -1,0 +1,112 @@
+package loki
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/netobserv/network-observability-console-plugin/pkg/model"
+	pmodel "github.com/prometheus/common/model"
+)
+
+func TestMatrixMerge(t *testing.T) {
+	now := pmodel.Now()
+	merger := NewMatrixMerger()
+	baseline := pmodel.SampleStream{
+		Metric: pmodel.Metric{
+			"foo": "bar",
+		},
+		Values: []pmodel.SamplePair{{
+			Timestamp: now,
+			Value:     pmodel.SampleValue(42),
+		}},
+	}
+	merger.AddMatrix(model.Matrix{baseline})
+
+	// Different metric, different value pair => no dedup
+	merged := merger.AddMatrix(model.Matrix{{
+		Metric: pmodel.Metric{
+			"foo":  "bar",
+			"foo2": "bar2",
+		},
+		Values: baseline.Values,
+	}, {
+		Metric: baseline.Metric,
+		Values: []pmodel.SamplePair{{
+			Timestamp: now,
+			Value:     pmodel.SampleValue(12),
+		}},
+	}})
+	assert.Len(t, merged, 2)
+	assert.Len(t, merged[0].Values, 2)
+	assert.Len(t, merged[1].Values, 1)
+
+	// Same metrics in different order => no dedup
+	merged = merger.AddMatrix(model.Matrix{{
+		Metric: pmodel.Metric{
+			"foo2": "bar2",
+			"foo":  "bar",
+		},
+		Values: baseline.Values,
+	}, {
+		Metric: pmodel.Metric{
+			"foo2": "bar2",
+			"foo":  "bar",
+		},
+		Values: baseline.Values,
+	}, {
+		Metric: pmodel.Metric{
+			"foo":  "bar",
+			"foo2": "bar2",
+		},
+		Values: baseline.Values,
+	}})
+	assert.Len(t, merged, 2)
+	assert.Len(t, merged[0].Values, 2)
+	assert.Len(t, merged[1].Values, 1)
+
+	// Different timestamp => no dedup
+	merged = merger.AddMatrix(model.Matrix{{
+		Metric: baseline.Metric,
+		Values: []pmodel.SamplePair{{
+			Timestamp: now.Add(time.Hour),
+			Value:     pmodel.SampleValue(12),
+		}},
+	}})
+	assert.Len(t, merged, 2)
+	assert.Len(t, merged[0].Values, 3)
+	assert.Len(t, merged[1].Values, 1)
+
+	// some dedup
+	merged = merger.AddMatrix(model.Matrix{{
+		// changed value => no dedup
+		Metric: baseline.Metric,
+		Values: []pmodel.SamplePair{{
+			Timestamp: now,
+			Value:     pmodel.SampleValue(8),
+		}},
+	}, {
+		// changed value => no dedup
+		Metric: baseline.Metric,
+		Values: []pmodel.SamplePair{{
+			Timestamp: now,
+			Value:     pmodel.SampleValue(0),
+		}},
+	}, {
+		// same as previously modified timestamp => will be added
+		Metric: baseline.Metric,
+		Values: []pmodel.SamplePair{{
+			Timestamp: now.Add(time.Hour),
+			Value:     pmodel.SampleValue(42),
+		}},
+	},
+		// baseline itself => must be ignored
+		baseline,
+	})
+
+	// Different timestamp
+	assert.Len(t, merged, 2)
+	assert.Len(t, merged[0].Values, 6)
+	assert.Len(t, merged[1].Values, 1)
+}

--- a/pkg/loki/streams_merger.go
+++ b/pkg/loki/streams_merger.go
@@ -12,8 +12,8 @@ type StreamMerger struct {
 	merged model.Streams
 }
 
-func NewStreamMerger() StreamMerger {
-	return StreamMerger{
+func NewStreamMerger() *StreamMerger {
+	return &StreamMerger{
 		index:  map[string]indexedStream{},
 		merged: model.Streams{},
 	}
@@ -45,7 +45,7 @@ func uniqueEntry(e *model.Entry) string {
 	return e.Timestamp.String() + e.Line
 }
 
-func (m *StreamMerger) Add(from model.Streams) model.Streams {
+func (m *StreamMerger) AddStreams(from model.Streams) model.Streams {
 	for _, stream := range from {
 		lkey := uniqueStream(&stream)
 		idxStream, streamExists := m.index[lkey]

--- a/pkg/loki/streams_merger_test.go
+++ b/pkg/loki/streams_merger_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/netobserv/network-observability-console-plugin/pkg/model"
 )
 
-func TestMerge(t *testing.T) {
+func TestStreamsMerge(t *testing.T) {
 	now := time.Now()
 	merger := NewStreamMerger()
 	baseline := model.Stream{
@@ -21,10 +21,10 @@ func TestMerge(t *testing.T) {
 			Line:      "{key: value}",
 		}},
 	}
-	merger.Add(model.Streams{baseline})
+	merger.AddStreams(model.Streams{baseline})
 
 	// Different label, different line => no dedup
-	merged := merger.Add(model.Streams{{
+	merged := merger.AddStreams(model.Streams{{
 		Labels: map[string]string{
 			"foo":  "bar",
 			"foo2": "bar2",
@@ -42,7 +42,7 @@ func TestMerge(t *testing.T) {
 	assert.Len(t, merged[1].Entries, 1)
 
 	// Same labels in different order => no dedup
-	merged = merger.Add(model.Streams{{
+	merged = merger.AddStreams(model.Streams{{
 		Labels: map[string]string{
 			"foo2": "bar2",
 			"foo":  "bar",
@@ -66,7 +66,7 @@ func TestMerge(t *testing.T) {
 	assert.Len(t, merged[1].Entries, 1)
 
 	// Different timestamp => no dedup
-	merged = merger.Add(model.Streams{{
+	merged = merger.AddStreams(model.Streams{{
 		Labels: baseline.Labels,
 		Entries: []model.Entry{{
 			Timestamp: now.Add(time.Hour),
@@ -78,7 +78,7 @@ func TestMerge(t *testing.T) {
 	assert.Len(t, merged[1].Entries, 1)
 
 	// some dedup
-	merged = merger.Add(model.Streams{{
+	merged = merger.AddStreams(model.Streams{{
 		// changed line => no dedup
 		Labels: baseline.Labels,
 		Entries: []model.Entry{{


### PR DESCRIPTION
Following https://github.com/netobserv/network-observability-console-plugin/pull/105 Matrix merger was not implemented

This adds the missing backend part to run topology queries keeping the `fetchParallel` approach.

I have some concerns about performances since we are replacing Loki `Query Frontend` role by splitting queries on our side. This can generate thousands internal queries.
https://grafana.com/docs/loki/latest/configuration/query-frontend/#parallelization

We can unlock the situation with this PR and decide what to do next after performance testing.