### PR TITLE
NETOBSERV-291 - NetFlow table needs pagination

### DIFF
--- a/web/src/components/netflow-traffic.css
+++ b/web/src/components/netflow-traffic.css
@@ -57,6 +57,16 @@ span.pf-c-button__icon.pf-m-start {
     padding-right: var(--pf-global--spacer--md);
 }
 
+#pagination {
+    height: 20px;
+    padding: 0;
+}
+
+.pf-c-pagination__nav-page-select>span {
+    user-select: none;
+    cursor: default;
+}
+
 .flex {
     flex: 1;
 }

--- a/web/src/components/query-summary/__tests__/query-summary.spec.tsx
+++ b/web/src/components/query-summary/__tests__/query-summary.spec.tsx
@@ -27,7 +27,7 @@ describe('<QuerySummary />', () => {
 
   it('should toggle panel', async () => {
     const wrapper = mount(<QuerySummary {...mocks} />);
-    wrapper.find('#query-summary').last().simulate('click');
+    wrapper.find('.query-summary-clickable').last().simulate('click');
     expect(mocks.toggleQuerySummary).toHaveBeenCalledTimes(1);
   });
 });

--- a/web/src/components/query-summary/query-summary.css
+++ b/web/src/components/query-summary/query-summary.css
@@ -3,12 +3,15 @@
   bottom: 0;
   align-self: center;
   padding: 10px;
-  z-index: 0;
+  z-index: 1;
 }
 
 #query-summary-content {
-  user-select: none;
   width: fit-content;
+}
+
+.query-summary-clickable {
+  user-select: none;
 }
 
 .query-summary-warning {

--- a/web/src/components/query-summary/query-summary.tsx
+++ b/web/src/components/query-summary/query-summary.tsx
@@ -1,4 +1,4 @@
-import { Card, Flex, FlexItem, Text, TextVariants, Tooltip } from '@patternfly/react-core';
+import { Card, Flex, FlexItem, Text, TextVariants, ToolbarItem, Tooltip } from '@patternfly/react-core';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { TimeRange } from '../../utils/datetime';
@@ -7,12 +7,14 @@ import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import './query-summary.css';
 
 export const QuerySummaryContent: React.FC<{
+  pagination?: React.ReactNode;
   flows: Record[];
   range: number | TimeRange;
   limit: number;
   direction: 'row' | 'column';
   className?: string;
-}> = ({ flows, range, limit, direction, className }) => {
+  toggleQuerySummary?: () => void;
+}> = ({ pagination, flows, range, limit, direction, className, toggleQuerySummary }) => {
   const { t } = useTranslation('plugin__network-observability-plugin');
 
   let rangeInSeconds: number;
@@ -30,29 +32,39 @@ export const QuerySummaryContent: React.FC<{
       <FlexItem>
         <Flex direction={{ default: 'row' }}>
           {limitReached && (
-            <FlexItem>
+            <FlexItem className={toggleQuerySummary ? 'query-summary-clickable' : ''} onClick={toggleQuerySummary}>
               <Tooltip content={<Text component={TextVariants.p}>{t('Query limit reached')}</Text>}>
                 <ExclamationTriangleIcon className="query-summary-warning" />
               </Tooltip>
             </FlexItem>
           )}
           <FlexItem>
-            <Tooltip content={<Text component={TextVariants.p}>{t('Filtered flows count')}</Text>}>
-              <Text id="flowsCount" component={TextVariants.p} className={limitReached ? 'query-summary-warning' : ''}>
-                {t('{{count}} flows', { count: flows.length })}
-              </Text>
-            </Tooltip>
+            {pagination ? (
+              <ToolbarItem id="pagination-container" variant="pagination">
+                {pagination}
+              </ToolbarItem>
+            ) : (
+              <Tooltip content={<Text component={TextVariants.p}>{t('Filtered flows count')}</Text>}>
+                <Text
+                  id="flowsCount"
+                  component={TextVariants.p}
+                  className={limitReached ? 'query-summary-warning' : ''}
+                >
+                  {t('{{count}} flows', { count: flows.length })}
+                </Text>
+              </Tooltip>
+            )}
           </FlexItem>
         </Flex>
       </FlexItem>
-      <FlexItem>
+      <FlexItem className={toggleQuerySummary ? 'query-summary-clickable' : ''} onClick={toggleQuerySummary}>
         <Tooltip content={<Text component={TextVariants.p}>{t('Filtered sum of bytes')}</Text>}>
           <Text id="bytesCount" component={TextVariants.p}>
             {t('{{count}} bytes', { count: totalBytes })}
           </Text>
         </Tooltip>
       </FlexItem>
-      <FlexItem>
+      <FlexItem className={toggleQuerySummary ? 'query-summary-clickable' : ''} onClick={toggleQuerySummary}>
         <Tooltip content={<Text component={TextVariants.p}>{t('Filtered sum of packets')}</Text>}>
           <Text id="packetsCount" component={TextVariants.p}>
             {t('{{count}} packets', {
@@ -61,7 +73,7 @@ export const QuerySummaryContent: React.FC<{
           </Text>
         </Tooltip>
       </FlexItem>
-      <FlexItem>
+      <FlexItem className={toggleQuerySummary ? 'query-summary-clickable' : ''} onClick={toggleQuerySummary}>
         <Tooltip content={<Text component={TextVariants.p}>{t('Filtered average speed')}</Text>}>
           <Text id="bpsCount" component={TextVariants.p}>
             {t('{{count}} Bps', {
@@ -75,15 +87,23 @@ export const QuerySummaryContent: React.FC<{
 };
 
 export const QuerySummary: React.FC<{
+  pagination?: React.ReactNode;
   flows: Record[] | undefined;
   range: number | TimeRange;
   limit: number;
   toggleQuerySummary: () => void;
-}> = ({ flows, range, limit, toggleQuerySummary }) => {
+}> = ({ pagination, flows, range, limit, toggleQuerySummary }) => {
   if (flows && flows.length) {
     return (
-      <Card id="query-summary" isSelectable onClick={toggleQuerySummary}>
-        <QuerySummaryContent direction="row" flows={flows} range={range} limit={limit} />
+      <Card id="query-summary" isSelectable>
+        <QuerySummaryContent
+          pagination={pagination}
+          direction="row"
+          flows={flows}
+          range={range}
+          limit={limit}
+          toggleQuerySummary={toggleQuerySummary}
+        />
       </Card>
     );
   }


### PR DESCRIPTION
This PR is a base of discussion [following comments about table performances](https://issues.redhat.com/browse/NETOBSERV-288) when we render a lot of columns + rows (ie all columns + 1k rows currently makes your browser really slow)

A quick solution would be to implement pagination and only show a subset of flows.

Sort function still needs to be refactored:
- it sould sort on all flows (here it only sort current page content)
- should apply on flow refresh
- column + direction should be kept in URL
Also vertical scrollbar should not show in some cases.

Here is an example with 1k flows in query limit and 10 flows per page:
![image](https://user-images.githubusercontent.com/91894519/162925054-93ff109d-eb18-42da-bd91-9e8b9b48b804.png)

I put the pager in the top toolbar but it could be also with summary at bottom of the page:
![image](https://user-images.githubusercontent.com/91894519/162933849-512fb95b-badd-45fb-928d-7a0959df2870.png)

Both https://github.com/netobserv/network-observability-console-plugin/pull/122 about conditional rendering and this PR can be merged to improve performances