### PR TITLE
NETOBSERV-288 - conditionnal rendering to improve perfs on table

### DIFF
--- a/web/src/components/netflow-record/record-field.css
+++ b/web/src/components/netflow-record/record-field.css
@@ -61,7 +61,7 @@ span.co-resource-item.co-resource-item--inline.l,
 }
 
 .record-field-flex-container.l {
-  min-height: 126px;
+  height: 126px;
 }
 
 /* table tooltips - check pf-c-tooltip__content for values */

--- a/web/src/components/netflow-table/__tests__/netflow-table-row.spec.tsx
+++ b/web/src/components/netflow-table/__tests__/netflow-table-row.spec.tsx
@@ -12,7 +12,8 @@ describe('<NetflowTableRow />', () => {
   let flows: Record[] = [];
   const mocks = {
     size: 'm' as Size,
-    onSelect: jest.fn()
+    onSelect: jest.fn(),
+    tableWidth: 100
   };
   it('should render component', async () => {
     flows = FlowsSample;

--- a/web/src/components/netflow-table/netflow-table-header.tsx
+++ b/web/src/components/netflow-table/netflow-table-header.tsx
@@ -39,15 +39,11 @@ export const NetflowTableHeader: React.FC<{
 
   const getTableHeader = React.useCallback(
     (c: Column) => {
-      // no-explicit-any disabled: short list of number expected in Th width, but actually any number works fine
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const width = Math.floor((100 * c.width) / tableWidth) as any;
       const showBorder =
         headersState.useNested && headersState.nestedHeaders.find(nh => _.last(nh.columns) === c) !== undefined;
       return (
         <Th
           hasRightBorder={showBorder}
-          width={width}
           key={c.id}
           sort={{
             sortBy: {
@@ -58,6 +54,7 @@ export const NetflowTableHeader: React.FC<{
             columnIndex: columns.indexOf(c)
           }}
           modifier="wrap"
+          style={{ width: `${Math.floor((100 * c.width) / tableWidth)}%` }}
         >
           {headersState.useNested ? c.name : getFullColumnName(c)}
         </Th>

--- a/web/src/components/netflow-table/netflow-table-row.tsx
+++ b/web/src/components/netflow-table/netflow-table-row.tsx
@@ -14,7 +14,9 @@ const NetflowTableRow: React.FC<{
   size: Size;
   onSelect: (record?: Record) => void;
   highlight: boolean;
-}> = ({ flow, selectedRecord, columns, size, onSelect, highlight }) => {
+  height?: number;
+  tableWidth: number;
+}> = ({ flow, selectedRecord, columns, size, onSelect, highlight, height, tableWidth }) => {
   const onRowClick = () => {
     onSelect(flow);
   };
@@ -31,7 +33,9 @@ const NetflowTableRow: React.FC<{
           timeout={100}
           classNames="newflow"
         >
-          <Td key={c.id}>{<RecordField flow={flow} column={c} size={size}></RecordField>}</Td>
+          <Td key={c.id} style={{ height, width: `${Math.floor((100 * c.width) / tableWidth)}%` }}>
+            {<RecordField flow={flow} column={c} size={size}></RecordField>}
+          </Td>
         </CSSTransition>
       ))}
     </Tr>

--- a/web/src/components/netflow-table/netflow-table.css
+++ b/web/src/components/netflow-table/netflow-table.css
@@ -1,0 +1,16 @@
+div#table-container {
+  overflow: auto;
+  height: 100%;
+}
+
+tr.empty-row.s {
+  height: 59px;
+}
+
+tr.empty-row.m {
+  height: 101px;
+}
+
+tr.empty-row.l {
+  height: 143px;
+}

--- a/web/src/components/netflow-table/netflow-table.tsx
+++ b/web/src/components/netflow-table/netflow-table.tsx
@@ -34,7 +34,8 @@ const NetflowTable: React.FC<{
 }> = ({ flows, selectedRecord, columns, error, loading, size, onSelect, clearFilters }) => {
   const { t } = useTranslation('plugin__network-observability-plugin');
 
-  const [containerHeight, setContainerHeight] = React.useState(0);
+  //default to 300 to allow content to be rendered in tests
+  const [containerHeight, setContainerHeight] = React.useState(300);
   const previousContainerHeight = usePrevious(containerHeight);
   const [scrollPosition, setScrollPosition] = React.useState(0);
   const previousScrollPosition = usePrevious(scrollPosition);

--- a/web/src/components/netflow-table/netflow-table.tsx
+++ b/web/src/components/netflow-table/netflow-table.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { TableComposable, Tbody, InnerScrollContainer, OuterScrollContainer } from '@patternfly/react-table';
+import { TableComposable, Tbody } from '@patternfly/react-table';
 import {
   Bullseye,
   Button,
@@ -19,6 +19,8 @@ import { NetflowTableHeader } from './netflow-table-header';
 import NetflowTableRow from './netflow-table-row';
 import { Column } from '../../utils/columns';
 import { Size } from '../dropdowns/display-dropdown';
+import { usePrevious } from '../../utils/previous-hook';
+import './netflow-table.css';
 
 const NetflowTable: React.FC<{
   flows: Record[];
@@ -32,13 +34,19 @@ const NetflowTable: React.FC<{
 }> = ({ flows, selectedRecord, columns, error, loading, size, onSelect, clearFilters }) => {
   const { t } = useTranslation('plugin__network-observability-plugin');
 
+  const [containerHeight, setContainerHeight] = React.useState(0);
+  const previousContainerHeight = usePrevious(containerHeight);
+  const [scrollPosition, setScrollPosition] = React.useState(0);
+  const previousScrollPosition = usePrevious(scrollPosition);
   // index of the currently active column
   const [activeSortIndex, setActiveSortIndex] = React.useState<number>(-1);
-
+  const previousActiveSortIndex = usePrevious(activeSortIndex);
   // sort direction of the currently active column
   const [activeSortDirection, setActiveSortDirection] = React.useState<string>('asc');
-
+  const previousActiveSortDirection = usePrevious(activeSortDirection);
   const firstRender = React.useRef(true);
+
+  const width = columns.reduce((prev, cur) => prev + cur.width, 0);
 
   React.useEffect(() => {
     if (firstRender.current) {
@@ -47,8 +55,54 @@ const NetflowTable: React.FC<{
     }
   }, [flows]);
 
+  //get row height from display size
+  //these values match netflow-table.css and record-field.css
+  const getRowHeight = React.useCallback(() => {
+    switch (size) {
+      case 'l':
+        return 143;
+      case 'm':
+        return 101;
+      case 's':
+      default:
+        return 59;
+    }
+  }, [size]);
+
+  //update table container height on window resize
+  const handleResize = React.useCallback(() => {
+    const container = document.getElementById('table-container');
+    if (container) {
+      setContainerHeight(container.clientHeight);
+    }
+  }, []);
+
+  const handleScroll = React.useCallback(() => {
+    const rowHeight = getRowHeight();
+    const container = document.getElementById('table-container');
+    const header = container?.children[0].children[0];
+    if (container && header) {
+      const position = container.scrollTop - header.clientHeight;
+      //updates only when position moved more than one row height
+      if (scrollPosition < position - rowHeight || scrollPosition > position + rowHeight) {
+        setScrollPosition(position);
+      }
+    }
+  }, [getRowHeight, scrollPosition]);
+
+  React.useEffect(() => {
+    const container = document.getElementById('table-container');
+    if (container && container.getAttribute('listener') !== 'true') {
+      container.addEventListener('scroll', handleScroll);
+      window.addEventListener('resize', handleResize);
+    }
+
+    handleScroll();
+    handleResize();
+  }, [handleResize, handleScroll, loading]);
+
   // sort function
-  const getSortedFlows = () => {
+  const getSortedFlows = React.useCallback(() => {
     if (activeSortIndex < 0 || activeSortIndex >= columns.length) {
       return flows;
     } else {
@@ -57,7 +111,7 @@ const NetflowTable: React.FC<{
         return activeSortDirection === 'desc' ? col.sort(a, b, col) : col.sort(b, a, col);
       });
     }
-  };
+  }, [activeSortDirection, activeSortIndex, columns, flows]);
 
   // sort handler
   const onSort = (event: React.MouseEvent, index: number, direction: string) => {
@@ -65,7 +119,52 @@ const NetflowTable: React.FC<{
     setActiveSortDirection(direction);
   };
 
-  if (error) {
+  const getBody = React.useCallback(() => {
+    const rowHeight = getRowHeight();
+    return getSortedFlows().map((f, i) =>
+      scrollPosition <= i * rowHeight && scrollPosition + containerHeight > i * rowHeight ? (
+        <NetflowTableRow
+          key={f.key}
+          flow={f}
+          columns={columns}
+          size={size}
+          selectedRecord={selectedRecord}
+          onSelect={onSelect}
+          highlight={
+            previousContainerHeight === containerHeight &&
+            previousScrollPosition === scrollPosition &&
+            previousActiveSortDirection === activeSortDirection &&
+            previousActiveSortIndex === activeSortIndex &&
+            !firstRender.current
+          }
+          height={rowHeight}
+          tableWidth={width}
+        />
+      ) : (
+        <tr className={`empty-row ${size}`} key={f.key} />
+      )
+    );
+  }, [
+    activeSortDirection,
+    activeSortIndex,
+    columns,
+    containerHeight,
+    getRowHeight,
+    getSortedFlows,
+    onSelect,
+    previousActiveSortDirection,
+    previousActiveSortIndex,
+    previousContainerHeight,
+    previousScrollPosition,
+    scrollPosition,
+    selectedRecord,
+    size,
+    width
+  ]);
+
+  if (width === 0) {
+    return null;
+  } else if (error) {
     return (
       <EmptyState data-test="error-state" variant={EmptyStateVariant.small}>
         <Title headingLevel="h2" size="lg">
@@ -99,38 +198,19 @@ const NetflowTable: React.FC<{
     }
   }
 
-  const width = columns.reduce((prev, cur) => prev + cur.width, 0);
-  if (width === 0) {
-    return null;
-  }
-
   return (
-    <OuterScrollContainer>
-      <InnerScrollContainer>
-        <TableComposable aria-label="Netflow table" variant="compact" style={{ minWidth: `${width}em` }} isStickyHeader>
-          <NetflowTableHeader
-            onSort={onSort}
-            sortDirection={activeSortDirection}
-            sortIndex={activeSortIndex}
-            columns={columns}
-            tableWidth={width}
-          />
-          <Tbody>
-            {getSortedFlows().map(f => (
-              <NetflowTableRow
-                key={f.key}
-                flow={f}
-                columns={columns}
-                size={size}
-                selectedRecord={selectedRecord}
-                onSelect={onSelect}
-                highlight={!firstRender.current}
-              />
-            ))}
-          </Tbody>
-        </TableComposable>
-      </InnerScrollContainer>
-    </OuterScrollContainer>
+    <div id="table-container">
+      <TableComposable aria-label="Netflow table" variant="compact" style={{ minWidth: `${width}em` }} isStickyHeader>
+        <NetflowTableHeader
+          onSort={onSort}
+          sortDirection={activeSortDirection}
+          sortIndex={activeSortIndex}
+          columns={columns}
+          tableWidth={width}
+        />
+        <Tbody>{getBody()}</Tbody>
+      </TableComposable>
+    </div>
   );
 };
 

--- a/web/src/components/netflow-traffic.css
+++ b/web/src/components/netflow-traffic.css
@@ -34,15 +34,19 @@ span.pf-c-button__icon.pf-m-start {
     white-space: pre-line;
 }
 
-/*FIXME: remove this override if a better solution for scrolling content is found with the console team*/
 #pageSection {
     display: flex;
     flex-direction: column;
-    max-height: 90vh;
+    height: 100%;
+    padding-bottom: 3em;
 }
 
 #drawer {
     z-index: 1;
+}
+
+#drawerContent {
+    overflow: hidden;
 }
 
 /* flex page header */


### PR DESCRIPTION
This PR is related to https://github.com/netobserv/network-observability-console-plugin/pull/121 about performances with a high limit. 

It removes row items outside of visible area of table scroll. 
These items are replaced by empty divs so the scroll behavior stay normal. 
This approach decrease 19x the total rendering time on 1k rows.

![image](https://user-images.githubusercontent.com/91894519/162966988-573e0ce3-b046-4709-ba99-239630eeb056.png)

The rendering may differ between browsers:
- chrome seems to render after items added / removed
- firefox first render empty rows and directly add them

![image](https://user-images.githubusercontent.com/91894519/162967306-ab7fddf1-0d1a-4e4d-bdb7-ebf086b29761.png)

As discussed, we can merge both https://github.com/netobserv/network-observability-console-plugin/pull/121 & this PR to be able to show a lot of items per page.
