### PR TITLE
NETOBSERV-254 Topology highlight on hover

### DIFF
--- a/web/src/components/netflow-topology/components/edge.tsx
+++ b/web/src/components/netflow-topology/components/edge.tsx
@@ -1,0 +1,163 @@
+import * as React from 'react';
+import { css } from '@patternfly/react-styles';
+import styles from '@patternfly/react-styles/css/components/Topology/topology-components';
+import {
+  Edge,
+  EdgeTerminalType,
+  NodeStatus,
+  WithRemoveConnectorProps,
+  WithSourceDragProps,
+  WithTargetDragProps,
+  WithSelectionProps,
+  WithContextMenuProps,
+  useHover,
+  getEdgeAnimationDuration,
+  getEdgeStyleClassModifier,
+  Point,
+  Layer,
+  TOP_LAYER,
+  DefaultConnectorTerminal,
+  observer
+} from '@patternfly/react-topology';
+import DefaultConnectorTag from '@patternfly/react-topology/dist/esm/components/edges/DefaultConnectorTag';
+import { HOVER_EVENT } from '../netflow-topology';
+
+type BaseEdgeProps = {
+  element: Edge;
+  dragging?: boolean;
+  className?: string;
+  animationDuration?: number;
+  startTerminalType?: EdgeTerminalType;
+  startTerminalClass?: string;
+  startTerminalStatus?: NodeStatus;
+  endTerminalType?: EdgeTerminalType;
+  endTerminalClass?: string;
+  endTerminalStatus?: NodeStatus;
+  shadowed?: boolean;
+  highlighted?: boolean;
+  tag?: string;
+  tagClass?: string;
+  tagStatus?: NodeStatus;
+} & WithRemoveConnectorProps &
+  WithSourceDragProps &
+  WithTargetDragProps &
+  WithSelectionProps &
+  Partial<WithContextMenuProps>;
+
+// BaseEdge: slightly modified from @patternfly/react-topology/src/components/edges/DefaultEdge.tsx
+// to support shadow / hover behaviors
+
+const BaseEdge: React.FC<BaseEdgeProps> = ({
+  element,
+  dragging,
+  sourceDragRef,
+  targetDragRef,
+  animationDuration,
+  onShowRemoveConnector,
+  onHideRemoveConnector,
+  startTerminalType = EdgeTerminalType.none,
+  startTerminalClass,
+  startTerminalStatus,
+  endTerminalType = EdgeTerminalType.directional,
+  endTerminalClass,
+  endTerminalStatus,
+  shadowed,
+  highlighted,
+  tag,
+  tagClass,
+  tagStatus,
+  children,
+  className,
+  selected,
+  onSelect,
+  onContextMenu
+}) => {
+  const [hover, hoverRef] = useHover();
+  const startPoint = element.getStartPoint();
+  const endPoint = element.getEndPoint();
+
+  React.useLayoutEffect(() => {
+    if (hover && !dragging) {
+      onShowRemoveConnector && onShowRemoveConnector();
+    } else {
+      onHideRemoveConnector && onHideRemoveConnector();
+    }
+    element.getController().fireEvent(HOVER_EVENT, {
+      ...element.getData(),
+      id: element.getId(),
+      isHovered: hover
+    });
+  }, [hover, dragging, onShowRemoveConnector, onHideRemoveConnector, element]);
+
+  const groupClassName = css(
+    styles.topologyEdge,
+    className,
+    hover && 'pf-m-hover',
+    dragging && 'pf-m-dragging',
+    selected && 'pf-m-selected',
+    'topology',
+    shadowed && 'shadowed',
+    highlighted && 'edge-highlighted'
+  );
+
+  const edgeAnimationDuration = animationDuration ?? getEdgeAnimationDuration(element.getEdgeAnimationSpeed());
+  const linkClassName = css(styles.topologyEdgeLink, getEdgeStyleClassModifier(element.getEdgeStyle()));
+
+  const bendpoints = element.getBendpoints();
+
+  const d = `M${startPoint.x} ${startPoint.y} ${bendpoints.map((b: Point) => `L${b.x} ${b.y} `).join('')}L${
+    endPoint.x
+  } ${endPoint.y}`;
+
+  return (
+    <Layer id={dragging || hover || highlighted ? TOP_LAYER : undefined}>
+      <g
+        ref={hoverRef as React.LegacyRef<SVGGElement> | undefined}
+        data-test-id="edge-handler"
+        className={groupClassName}
+        onClick={onSelect}
+        onContextMenu={onContextMenu}
+      >
+        <path
+          strokeWidth={10}
+          stroke="transparent"
+          d={d}
+          fill="none"
+          onMouseEnter={onShowRemoveConnector}
+          onMouseLeave={onHideRemoveConnector}
+        />
+        <path className={linkClassName} d={d} style={{ animationDuration: `${edgeAnimationDuration}s` }} />
+        {tag && (
+          <DefaultConnectorTag
+            className={tagClass}
+            startPoint={element.getStartPoint()}
+            endPoint={element.getEndPoint()}
+            tag={tag}
+            status={tagStatus}
+          />
+        )}
+        <DefaultConnectorTerminal
+          className={startTerminalClass}
+          isTarget={false}
+          edge={element}
+          dragRef={sourceDragRef}
+          terminalType={startTerminalType}
+          status={startTerminalStatus}
+          highlight={dragging || hover || highlighted}
+        />
+        <DefaultConnectorTerminal
+          className={endTerminalClass}
+          isTarget
+          dragRef={targetDragRef}
+          edge={element}
+          terminalType={endTerminalType}
+          status={endTerminalStatus}
+          highlight={dragging || hover || highlighted}
+        />
+        {children}
+      </g>
+    </Layer>
+  );
+};
+
+export default observer(BaseEdge);

--- a/web/src/components/netflow-topology/components/node.tsx
+++ b/web/src/components/netflow-topology/components/node.tsx
@@ -1,0 +1,266 @@
+import * as React from 'react';
+import { css } from '@patternfly/react-styles';
+import { Tooltip, TooltipPosition } from '@patternfly/react-core';
+import CheckCircleIcon from '@patternfly/react-icons/dist/esm/icons/check-circle-icon';
+import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
+import ExclamationTriangleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
+import styles from '@patternfly/react-styles/css/components/Topology/topology-components';
+import {
+  TopologyQuadrant,
+  NodeStatus,
+  LabelPosition,
+  BadgeLocation,
+  GraphElement,
+  ShapeProps,
+  WithSelectionProps,
+  WithDragNodeProps,
+  WithDndDragProps,
+  WithDndDropProps,
+  WithCreateConnectorProps,
+  WithContextMenuProps,
+  useHover,
+  DEFAULT_DECORATOR_RADIUS,
+  getDefaultShapeDecoratorCenter,
+  Decorator,
+  getShapeComponent,
+  StatusModifier,
+  createSvgIdUrl,
+  Node,
+  NodeShadows,
+  NodeLabel,
+  observer,
+  Layer,
+  TOP_LAYER
+} from '@patternfly/react-topology';
+import {
+  NODE_SHADOW_FILTER_ID_DANGER,
+  NODE_SHADOW_FILTER_ID_HOVER
+} from '@patternfly/react-topology/dist/esm/components/nodes/NodeShadows';
+import { HOVER_EVENT } from '../netflow-topology';
+
+const StatusQuadrant = TopologyQuadrant.upperLeft;
+
+const getStatusIcon = (status: NodeStatus) => {
+  switch (status) {
+    case NodeStatus.danger:
+      return <ExclamationCircleIcon className="pf-m-danger" />;
+    case NodeStatus.warning:
+      return <ExclamationTriangleIcon className="pf-m-warning" />;
+    case NodeStatus.success:
+      return <CheckCircleIcon className="pf-m-success" />;
+    default:
+      return null;
+  }
+};
+
+type BaseNodeProps = {
+  element: Node;
+  droppable?: boolean;
+  hover?: boolean;
+  canDrop?: boolean;
+  dragging?: boolean;
+  edgeDragging?: boolean;
+  dropTarget?: boolean;
+  shadowed?: boolean;
+  highlighted?: boolean;
+  label?: string; // Defaults to element.getLabel()
+  secondaryLabel?: string;
+  showLabel?: boolean; // Defaults to true
+  labelPosition?: LabelPosition; // Defaults to bottom
+  truncateLength?: number; // Defaults to 13
+  labelIconClass?: string; // Icon to show in label
+  labelIconPadding?: number;
+  badge?: string;
+  badgeColor?: string;
+  badgeTextColor?: string;
+  badgeBorderColor?: string;
+  badgeClassName?: string;
+  badgeLocation?: BadgeLocation;
+  attachments?: React.ReactNode; // ie. decorators
+  showStatusBackground?: boolean;
+  showStatusDecorator?: boolean;
+  statusDecoratorTooltip?: React.ReactNode;
+  onStatusDecoratorClick?: (event: React.MouseEvent<SVGGElement, MouseEvent>, element: GraphElement) => void;
+  getCustomShape?: (node: Node) => React.FC<ShapeProps>;
+  getShapeDecoratorCenter?: (quadrant: TopologyQuadrant, node: Node, radius?: number) => { x: number; y: number };
+} & Partial<
+  WithSelectionProps &
+    WithDragNodeProps &
+    WithDndDragProps &
+    WithDndDropProps &
+    WithCreateConnectorProps &
+    WithContextMenuProps
+>;
+
+// BaseNode: slightly modified from @patternfly/react-topology/src/components/nodes/DefaultNode.tsx
+// to support shadow / hover behaviors
+
+const BaseNode: React.FC<BaseNodeProps> = ({
+  element,
+  selected,
+  hover,
+  showLabel = true,
+  label,
+  shadowed,
+  highlighted,
+  secondaryLabel,
+  labelPosition = LabelPosition.bottom,
+  truncateLength,
+  labelIconClass,
+  showStatusBackground,
+  showStatusDecorator = false,
+  statusDecoratorTooltip,
+  getCustomShape,
+  getShapeDecoratorCenter,
+  onStatusDecoratorClick,
+  badge,
+  badgeColor,
+  badgeTextColor,
+  badgeBorderColor,
+  badgeClassName,
+  badgeLocation,
+  onSelect,
+  children,
+  attachments,
+  dragNodeRef,
+  dragging,
+  edgeDragging,
+  canDrop,
+  dropTarget,
+  dndDropRef,
+  onHideCreateConnector,
+  onShowCreateConnector,
+  onContextMenu,
+  contextMenuOpen
+}) => {
+  const [hovered, hoverRef] = useHover();
+  const status = element.getNodeStatus();
+  const { width, height } = element.getDimensions();
+  const isHover = hover !== undefined ? hover : hovered;
+
+  const statusDecorator = React.useMemo(() => {
+    if (!status || !showStatusDecorator) {
+      return null;
+    }
+
+    const icon = getStatusIcon(status);
+    if (!icon) {
+      return null;
+    }
+
+    const { x, y } = getShapeDecoratorCenter
+      ? getShapeDecoratorCenter(StatusQuadrant, element, DEFAULT_DECORATOR_RADIUS)
+      : getDefaultShapeDecoratorCenter(StatusQuadrant, element, DEFAULT_DECORATOR_RADIUS);
+
+    const decorator = (
+      <Decorator
+        x={x}
+        y={y}
+        radius={DEFAULT_DECORATOR_RADIUS}
+        showBackground={false}
+        onClick={e => onStatusDecoratorClick && onStatusDecoratorClick(e, element)}
+        icon={<g className={css(styles.topologyNodeDecoratorStatus)}>{icon}</g>}
+      />
+    );
+
+    if (statusDecoratorTooltip) {
+      return (
+        <Tooltip content={statusDecoratorTooltip} position={TooltipPosition.left}>
+          {decorator}
+        </Tooltip>
+      );
+    }
+
+    return decorator;
+  }, [showStatusDecorator, status, getShapeDecoratorCenter, element, statusDecoratorTooltip, onStatusDecoratorClick]);
+
+  React.useEffect(() => {
+    if (isHover) {
+      onShowCreateConnector && onShowCreateConnector();
+    } else {
+      onHideCreateConnector && onHideCreateConnector();
+    }
+    element.getController().fireEvent(HOVER_EVENT, {
+      ...element.getData(),
+      id: element.getId(),
+      isHovered: isHover
+    });
+  }, [isHover, onShowCreateConnector, onHideCreateConnector, element]);
+
+  const ShapeComponent = (getCustomShape && getCustomShape(element)) || getShapeComponent(element);
+
+  const groupClassName = css(
+    styles.topologyNode,
+    isHover && 'pf-m-hover',
+    (dragging || edgeDragging) && 'pf-m-dragging',
+    canDrop && dropTarget && 'pf-m-drop-target',
+    selected && 'pf-m-selected',
+    StatusModifier[status],
+    'topology',
+    shadowed && 'shadowed',
+    highlighted && 'node-highlighted'
+  );
+
+  const backgroundClassName = css(
+    styles.topologyNodeBackground,
+    showStatusBackground && StatusModifier[status],
+    showStatusBackground && selected && 'pf-m-selected'
+  );
+
+  let filter;
+  if (status === 'danger') {
+    filter = createSvgIdUrl(NODE_SHADOW_FILTER_ID_DANGER);
+  } else if (isHover || dragging || edgeDragging || dropTarget) {
+    filter = createSvgIdUrl(NODE_SHADOW_FILTER_ID_HOVER);
+  }
+
+  return (
+    <Layer id={dragging || hover || highlighted ? TOP_LAYER : undefined}>
+      <g ref={hoverRef as React.LegacyRef<SVGGElement> | undefined} className={groupClassName}>
+        <NodeShadows />
+        <g ref={dragNodeRef} onClick={onSelect} onContextMenu={onContextMenu}>
+          {ShapeComponent && (
+            <ShapeComponent
+              className={backgroundClassName}
+              element={element}
+              width={width}
+              height={height}
+              dndDropRef={dndDropRef}
+              filter={filter}
+            />
+          )}
+          {showLabel && (label || element.getLabel()) && (
+            <NodeLabel
+              className={css(styles.topologyNodeLabel)}
+              x={labelPosition === LabelPosition.right ? width + 8 : width / 2}
+              y={labelPosition === LabelPosition.right ? height / 2 : height + 6}
+              position={labelPosition}
+              paddingX={8}
+              paddingY={4}
+              secondaryLabel={secondaryLabel}
+              truncateLength={truncateLength}
+              status={status}
+              badge={badge}
+              badgeColor={badgeColor}
+              badgeTextColor={badgeTextColor}
+              badgeBorderColor={badgeBorderColor}
+              badgeClassName={badgeClassName}
+              badgeLocation={badgeLocation}
+              onContextMenu={onContextMenu as never}
+              contextMenuOpen={contextMenuOpen ? true : false}
+              hover={isHover}
+              labelIconClass={labelIconClass}
+            >
+              {label || element.getLabel()}
+            </NodeLabel>
+          )}
+          {children}
+        </g>
+        {statusDecorator}
+        {hovered && attachments}
+      </g>
+    </Layer>
+  );
+};
+
+export default observer(BaseNode);

--- a/web/src/components/netflow-topology/netflow-topology.css
+++ b/web/src/components/netflow-topology/netflow-topology.css
@@ -44,3 +44,13 @@ span.pf-topology-control-bar {
 g.topology.shadowed {
   opacity: 0.5;
 }
+
+g.topology.node-highlighted>g>ellipse {
+  stroke: #0066CC;
+  stroke-width: 3px;
+}
+
+g.topology.edge-highlighted>.pf-topology__edge__link,
+g.topology.edge-highlighted>.pf-topology-connector-arrow {
+  stroke: #0066CC;
+}

--- a/web/src/components/netflow-topology/styles/styleEdge.tsx
+++ b/web/src/components/netflow-topology/styles/styleEdge.tsx
@@ -1,18 +1,11 @@
-import * as React from 'react';
-import {
-  DefaultEdge,
-  Edge,
-  WithContextMenuProps,
-  WithSelectionProps,
-  observer,
-  ScaleDetailsLevel
-} from '@patternfly/react-topology';
+import { Edge, observer, ScaleDetailsLevel, WithSelectionProps } from '@patternfly/react-topology';
+import BaseEdge from '../components/edge';
 import useDetailsLevel from '@patternfly/react-topology/dist/esm/hooks/useDetailsLevel';
+import * as React from 'react';
 
 type StyleEdgeProps = {
   element: Edge;
-} & WithContextMenuProps &
-  WithSelectionProps;
+} & WithSelectionProps;
 
 const StyleEdge: React.FC<StyleEdgeProps> = ({ element, ...rest }) => {
   const data = element.getData();
@@ -31,11 +24,7 @@ const StyleEdge: React.FC<StyleEdgeProps> = ({ element, ...rest }) => {
     return newData;
   }, [data, detailsLevel]);
 
-  return (
-    <g className={`topology ${data.shadowed ? 'shadowed' : ''}`}>
-      <DefaultEdge element={element} {...rest} {...passedData} />
-    </g>
-  );
+  return <BaseEdge element={element} {...rest} {...passedData} />;
 };
 
 export default observer(StyleEdge);

--- a/web/src/components/netflow-topology/styles/styleNode.tsx
+++ b/web/src/components/netflow-topology/styles/styleNode.tsx
@@ -12,7 +12,6 @@ import {
 } from '@patternfly/react-icons';
 import {
   Decorator,
-  DefaultNode,
   DEFAULT_DECORATOR_RADIUS,
   getDefaultShapeDecoratorCenter,
   Node,
@@ -25,6 +24,7 @@ import {
   WithDragNodeProps,
   WithSelectionProps
 } from '@patternfly/react-topology';
+import BaseNode from '../components/node';
 import useDetailsLevel from '@patternfly/react-topology/dist/esm/hooks/useDetailsLevel';
 import { TFunction } from 'i18next';
 import * as React from 'react';
@@ -305,24 +305,22 @@ const StyleNode: React.FC<StyleNodeProps> = ({ element, showLabel, dragging, reg
   }
 
   return (
-    <g className={`topology ${data.shadowed ? 'shadowed' : ''}`}>
-      <DefaultNode
-        element={element}
-        {...updatedRest}
-        {...passedData}
-        dragging={isPinned ? false : dragging}
-        regrouping={isPinned ? false : regrouping}
-        showLabel={detailsLevel === ScaleDetailsLevel.high && showLabel}
-        showStatusBackground={detailsLevel === ScaleDetailsLevel.low}
-        showStatusDecorator={detailsLevel === ScaleDetailsLevel.high && passedData.showStatusDecorator}
-        attachments={
-          detailsLevel === ScaleDetailsLevel.high &&
-          renderDecorators(t, element, data, isPinned, setPinned, isFiltered, setFiltered, rest.getShapeDecoratorCenter)
-        }
-      >
-        {renderIcon(passedData, element)}
-      </DefaultNode>
-    </g>
+    <BaseNode
+      element={element}
+      {...updatedRest}
+      {...passedData}
+      dragging={isPinned ? false : dragging}
+      regrouping={isPinned ? false : regrouping}
+      showLabel={detailsLevel === ScaleDetailsLevel.high && showLabel}
+      showStatusBackground={detailsLevel === ScaleDetailsLevel.low}
+      showStatusDecorator={detailsLevel === ScaleDetailsLevel.high && passedData.showStatusDecorator}
+      attachments={
+        detailsLevel === ScaleDetailsLevel.high &&
+        renderDecorators(t, element, data, isPinned, setPinned, isFiltered, setFiltered, rest.getShapeDecoratorCenter)
+      }
+    >
+      {renderIcon(passedData, element)}
+    </BaseNode>
   );
 };
 


### PR DESCRIPTION
View updates on hover / select events:
- highlight related node / edges in blue
- Bring the content to front (node / edge)
- show quick actions on hover

![image](https://user-images.githubusercontent.com/91894519/164014799-8c9a9ebc-c2fc-44f3-9980-b5f373ba4653.png)

`DefaultNode` & `DefaultEdge` components from PF library are now included in our code to be able to manage layers and hover events