### PR TITLE
NETOBSERV-279 fix issues with filters on nodes

### DIFF
--- a/pkg/handler/flows.go
+++ b/pkg/handler/flows.go
@@ -83,7 +83,7 @@ func GetFlows(cfg loki.Config) func(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func getFlows(cfg loki.Config, client httpclient.HTTPClient, params url.Values) ([]byte, int, error) {
+func getFlows(cfg loki.Config, client httpclient.Interface, params url.Values) ([]byte, int, error) {
 	start, err := getStartTime(params)
 	if err != nil {
 		return nil, http.StatusBadRequest, err

--- a/pkg/handler/flows.go
+++ b/pkg/handler/flows.go
@@ -83,7 +83,7 @@ func GetFlows(cfg loki.Config) func(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func getFlows(cfg loki.Config, client httpclient.Interface, params url.Values) ([]byte, int, error) {
+func getFlows(cfg loki.Config, client httpclient.Caller, params url.Values) ([]byte, int, error) {
 	start, err := getStartTime(params)
 	if err != nil {
 		return nil, http.StatusBadRequest, err

--- a/pkg/handler/loki.go
+++ b/pkg/handler/loki.go
@@ -21,7 +21,7 @@ const (
 	lokiOrgIDHeader = "X-Scope-OrgID"
 )
 
-func newLokiClient(cfg *loki.Config) httpclient.HTTPClient {
+func newLokiClient(cfg *loki.Config) httpclient.Interface {
 	var headers map[string][]string
 	if cfg.TenantID != "" {
 		headers = map[string][]string{
@@ -54,7 +54,7 @@ func getLokiError(resp []byte, code int) string {
 	return fmt.Sprintf("Error from Loki (code: %d): %s", code, message)
 }
 
-func executeLokiQuery(flowsURL string, lokiClient httpclient.HTTPClient) ([]byte, int, error) {
+func executeLokiQuery(flowsURL string, lokiClient httpclient.Interface) ([]byte, int, error) {
 	hlog.Debugf("executeLokiQuery URL: %s", flowsURL)
 
 	resp, code, err := lokiClient.Get(flowsURL)
@@ -68,7 +68,7 @@ func executeLokiQuery(flowsURL string, lokiClient httpclient.HTTPClient) ([]byte
 	return resp, http.StatusOK, nil
 }
 
-func fetchParallel(lokiClient httpclient.HTTPClient, queries []string) ([]byte, int, error) {
+func fetchParallel(lokiClient httpclient.Interface, queries []string) ([]byte, int, error) {
 	// Run queries in parallel, then aggregate them
 	resChan := make(chan model.QueryResponse, len(queries))
 	errChan := make(chan errorWithCode, len(queries))

--- a/pkg/handler/loki.go
+++ b/pkg/handler/loki.go
@@ -21,7 +21,7 @@ const (
 	lokiOrgIDHeader = "X-Scope-OrgID"
 )
 
-func newLokiClient(cfg *loki.Config) httpclient.Interface {
+func newLokiClient(cfg *loki.Config) httpclient.Caller {
 	var headers map[string][]string
 	if cfg.TenantID != "" {
 		headers = map[string][]string{
@@ -54,7 +54,7 @@ func getLokiError(resp []byte, code int) string {
 	return fmt.Sprintf("Error from Loki (code: %d): %s", code, message)
 }
 
-func executeLokiQuery(flowsURL string, lokiClient httpclient.Interface) ([]byte, int, error) {
+func executeLokiQuery(flowsURL string, lokiClient httpclient.Caller) ([]byte, int, error) {
 	hlog.Debugf("executeLokiQuery URL: %s", flowsURL)
 
 	resp, code, err := lokiClient.Get(flowsURL)
@@ -68,7 +68,7 @@ func executeLokiQuery(flowsURL string, lokiClient httpclient.Interface) ([]byte,
 	return resp, http.StatusOK, nil
 }
 
-func fetchParallel(lokiClient httpclient.Interface, queries []string) ([]byte, int, error) {
+func fetchParallel(lokiClient httpclient.Caller, queries []string) ([]byte, int, error) {
 	// Run queries in parallel, then aggregate them
 	resChan := make(chan model.QueryResponse, len(queries))
 	errChan := make(chan errorWithCode, len(queries))

--- a/pkg/handler/resources.go
+++ b/pkg/handler/resources.go
@@ -41,7 +41,7 @@ func GetNamespaces(cfg loki.Config) func(w http.ResponseWriter, r *http.Request)
 	}
 }
 
-func getLabelValues(cfg *loki.Config, lokiClient httpclient.Interface, label string) ([]string, int, error) {
+func getLabelValues(cfg *loki.Config, lokiClient httpclient.Caller, label string) ([]string, int, error) {
 	baseURL := strings.TrimRight(cfg.URL.String(), "/")
 	url := fmt.Sprintf("%s/loki/api/v1/label/%s/values", baseURL, label)
 	hlog.Debugf("getLabelValues URL: %s", url)
@@ -92,7 +92,7 @@ func GetNames(cfg loki.Config) func(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func getNamesForPrefix(cfg loki.Config, lokiClient httpclient.Interface, prefix, kind, namespace string) ([]string, int, error) {
+func getNamesForPrefix(cfg loki.Config, lokiClient httpclient.Caller, prefix, kind, namespace string) ([]string, int, error) {
 	lokiParams := [][]string{}
 	if namespace != "" {
 		lokiParams = append(lokiParams, []string{prefix + fields.Namespace, exact(namespace)})

--- a/pkg/handler/resources.go
+++ b/pkg/handler/resources.go
@@ -41,7 +41,7 @@ func GetNamespaces(cfg loki.Config) func(w http.ResponseWriter, r *http.Request)
 	}
 }
 
-func getLabelValues(cfg *loki.Config, lokiClient httpclient.HTTPClient, label string) ([]string, int, error) {
+func getLabelValues(cfg *loki.Config, lokiClient httpclient.Interface, label string) ([]string, int, error) {
 	baseURL := strings.TrimRight(cfg.URL.String(), "/")
 	url := fmt.Sprintf("%s/loki/api/v1/label/%s/values", baseURL, label)
 	hlog.Debugf("getLabelValues URL: %s", url)
@@ -92,10 +92,11 @@ func GetNames(cfg loki.Config) func(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func getNamesForPrefix(cfg loki.Config, lokiClient httpclient.HTTPClient, prefix, kind, namespace string) ([]string, int, error) {
-	lokiParams := [][]string{{
-		prefix + fields.Namespace, exact(namespace),
-	}}
+func getNamesForPrefix(cfg loki.Config, lokiClient httpclient.Interface, prefix, kind, namespace string) ([]string, int, error) {
+	lokiParams := [][]string{}
+	if namespace != "" {
+		lokiParams = append(lokiParams, []string{prefix + fields.Namespace, exact(namespace)})
+	}
 	var fieldToExtract string
 	if utils.IsOwnerKind(kind) {
 		lokiParams = append(lokiParams, []string{prefix + fields.OwnerType, exact(kind)})

--- a/pkg/handler/resources_test.go
+++ b/pkg/handler/resources_test.go
@@ -1,0 +1,79 @@
+package handler
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/netobserv/network-observability-console-plugin/pkg/httpclient/httpclienttest"
+	"github.com/netobserv/network-observability-console-plugin/pkg/loki"
+)
+
+var testLokiConfig = loki.Config{
+	URL: &url.URL{Scheme: "http", Host: "loki"},
+	Labels: map[string]struct{}{
+		"SrcK8S_Namespace": {},
+		"DstK8S_Namespace": {},
+		"SrcK8S_OwnerName": {},
+		"DstK8S_OwnerName": {},
+	},
+}
+
+const testLokiBaseURL = "http://loki/loki/api/v1/"
+
+func TestGetSourceOwnerNames(t *testing.T) {
+	lokiClientMock := new(httpclienttest.HTTPClientMock)
+	lokiClientMock.SpyURL(func(url string) {
+		assert.Equal(
+			t,
+			testLokiBaseURL+"query_range?query={app=\"netobserv-flowcollector\",SrcK8S_Namespace=\"default\"}|~`SrcK8S_OwnerType\":\"Deployment\"`",
+			url,
+		)
+	})
+	_, _, _ = getNamesForPrefix(testLokiConfig, lokiClientMock, "Src", "Deployment", "default")
+
+	lokiClientMock.AssertNumberOfCalls(t, "Get", 1)
+}
+
+func TestGetDestPodNames(t *testing.T) {
+	lokiClientMock := new(httpclienttest.HTTPClientMock)
+	lokiClientMock.SpyURL(func(url string) {
+		assert.Equal(
+			t,
+			testLokiBaseURL+"query_range?query={app=\"netobserv-flowcollector\",DstK8S_Namespace=\"default\"}|~`DstK8S_Type\":\"Pod\"`",
+			url,
+		)
+	})
+	_, _, _ = getNamesForPrefix(testLokiConfig, lokiClientMock, "Dst", "Pod", "default")
+
+	lokiClientMock.AssertNumberOfCalls(t, "Get", 1)
+}
+
+func TestGetSourceNodeNames(t *testing.T) {
+	lokiClientMock := new(httpclienttest.HTTPClientMock)
+	lokiClientMock.SpyURL(func(url string) {
+		assert.Equal(
+			t,
+			testLokiBaseURL+"query_range?query={app=\"netobserv-flowcollector\"}|~`SrcK8S_Type\":\"Node\"`",
+			url,
+		)
+	})
+	_, _, _ = getNamesForPrefix(testLokiConfig, lokiClientMock, "Src", "Node", "")
+
+	lokiClientMock.AssertNumberOfCalls(t, "Get", 1)
+}
+
+func TestGetLabelValues(t *testing.T) {
+	lokiClientMock := new(httpclienttest.HTTPClientMock)
+	lokiClientMock.SpyURL(func(url string) {
+		assert.Equal(
+			t,
+			testLokiBaseURL+"label/DstK8S_Namespace/values",
+			url,
+		)
+	})
+	_, _, _ = getLabelValues(&testLokiConfig, lokiClientMock, "DstK8S_Namespace")
+
+	lokiClientMock.AssertNumberOfCalls(t, "Get", 1)
+}

--- a/pkg/handler/topology.go
+++ b/pkg/handler/topology.go
@@ -28,7 +28,7 @@ func GetTopology(cfg loki.Config) func(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func getTopologyFlows(cfg loki.Config, client httpclient.HTTPClient, params url.Values) ([]byte, int, error) {
+func getTopologyFlows(cfg loki.Config, client httpclient.Interface, params url.Values) ([]byte, int, error) {
 	hlog.Debugf("GetTopology query params: %s", params)
 
 	start, err := getStartTime(params)

--- a/pkg/handler/topology.go
+++ b/pkg/handler/topology.go
@@ -28,7 +28,7 @@ func GetTopology(cfg loki.Config) func(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func getTopologyFlows(cfg loki.Config, client httpclient.Interface, params url.Values) ([]byte, int, error) {
+func getTopologyFlows(cfg loki.Config, client httpclient.Caller, params url.Values) ([]byte, int, error) {
 	hlog.Debugf("GetTopology query params: %s", params)
 
 	start, err := getStartTime(params)

--- a/pkg/httpclient/http_client.go
+++ b/pkg/httpclient/http_client.go
@@ -7,17 +7,17 @@ import (
 	"time"
 )
 
-type Interface interface {
+type Caller interface {
 	Get(url string) ([]byte, int, error)
 }
 
 type httpClient struct {
-	Interface
+	Caller
 	client  http.Client
 	headers map[string][]string
 }
 
-func NewHTTPClient(timeout time.Duration, overrideHeaders map[string][]string) Interface {
+func NewHTTPClient(timeout time.Duration, overrideHeaders map[string][]string) Caller {
 	transport := &http.Transport{
 		DialContext:     (&net.Dialer{Timeout: timeout}).DialContext,
 		IdleConnTimeout: timeout,

--- a/pkg/httpclient/http_client.go
+++ b/pkg/httpclient/http_client.go
@@ -7,24 +7,29 @@ import (
 	"time"
 )
 
-type HTTPClient struct {
+type Interface interface {
+	Get(url string) ([]byte, int, error)
+}
+
+type httpClient struct {
+	Interface
 	client  http.Client
 	headers map[string][]string
 }
 
-func NewHTTPClient(timeout time.Duration, overrideHeaders map[string][]string) HTTPClient {
+func NewHTTPClient(timeout time.Duration, overrideHeaders map[string][]string) Interface {
 	transport := &http.Transport{
 		DialContext:     (&net.Dialer{Timeout: timeout}).DialContext,
 		IdleConnTimeout: timeout,
 	}
 
-	return HTTPClient{
+	return &httpClient{
 		client:  http.Client{Transport: transport, Timeout: timeout},
 		headers: overrideHeaders,
 	}
 }
 
-func (hc *HTTPClient) Get(url string) ([]byte, int, error) {
+func (hc *httpClient) Get(url string) ([]byte, int, error) {
 	// TODO: manage authentication / TLS
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)

--- a/pkg/httpclient/httpclienttest/http_client_mock.go
+++ b/pkg/httpclient/httpclienttest/http_client_mock.go
@@ -1,0 +1,23 @@
+package httpclienttest
+
+import (
+	"github.com/stretchr/testify/mock"
+)
+
+type HTTPClientMock struct {
+	mock.Mock
+}
+
+func (o *HTTPClientMock) Get(url string) ([]byte, int, error) {
+	args := o.Called(url)
+	return args.Get(0).([]byte), args.Int(1), args.Error(2)
+}
+
+func (o *HTTPClientMock) SpyURL(fn func(url string)) {
+	o.On(
+		"Get",
+		mock.AnythingOfType("string"),
+	).Run(func(args mock.Arguments) {
+		fn(args[0].(string))
+	}).Return([]byte{}, 0, nil)
+}

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -16,6 +16,7 @@ func setupRoutes(cfg *Config) *mux.Router {
 	r.HandleFunc("/api/loki/topology", handler.GetTopology(cfg.Loki))
 	r.HandleFunc("/api/resources/namespaces", handler.GetNamespaces(cfg.Loki))
 	r.HandleFunc("/api/resources/namespace/{namespace}/kind/{kind}/names", handler.GetNames(cfg.Loki))
+	r.HandleFunc("/api/resources/kind/{kind}/names", handler.GetNames(cfg.Loki))
 	r.HandleFunc("/api/frontend-config", handler.GetConfig(cfg.FrontendConfig))
 	r.PathPrefix("/").Handler(http.FileServer(http.Dir("./web/dist/")))
 	return r

--- a/web/src/api/routes.ts
+++ b/web/src/api/routes.ts
@@ -32,7 +32,10 @@ export const getNamespaces = (): Promise<string[]> => {
 };
 
 export const getResources = (namespace: string, kind: string): Promise<string[]> => {
-  return axios.get(`${host}/api/resources/namespace/${namespace}/kind/${kind}/names`).then(r => {
+  const url = namespace
+    ? `${host}/api/resources/namespace/${namespace}/kind/${kind}/names`
+    : `${host}/api/resources/kind/${kind}/names`;
+  return axios.get(url).then(r => {
     if (r.status >= 400) {
       throw new Error(`${r.statusText} [code=${r.status}]`);
     }

--- a/web/src/model/__tests__/resource.spec.ts
+++ b/web/src/model/__tests__/resource.spec.ts
@@ -1,0 +1,59 @@
+import { splitResource, SplitStage } from '../resource';
+
+describe('splitResource', () => {
+  it('should split partial kind', () => {
+    const split = splitResource('Po');
+    expect(split.stage).toEqual(SplitStage.PartialKind);
+    expect(split.kind).toEqual('Po');
+    expect(split.namespace).toEqual('');
+    expect(split.name).toEqual('');
+  });
+
+  it('should split partial empty namespace', () => {
+    const split = splitResource('Pod.');
+    expect(split.stage).toEqual(SplitStage.PartialNamespace);
+    expect(split.kind).toEqual('Pod');
+    expect(split.namespace).toEqual('');
+    expect(split.name).toEqual('');
+  });
+
+  it('should split partial namespace', () => {
+    const split = splitResource('Pod.d');
+    expect(split.stage).toEqual(SplitStage.PartialNamespace);
+    expect(split.kind).toEqual('Pod');
+    expect(split.namespace).toEqual('d');
+    expect(split.name).toEqual('');
+  });
+
+  it('should split empty name', () => {
+    const split = splitResource('Pod.default.');
+    expect(split.stage).toEqual(SplitStage.Completed);
+    expect(split.kind).toEqual('Pod');
+    expect(split.namespace).toEqual('default');
+    expect(split.name).toEqual('');
+  });
+
+  it('should split completed', () => {
+    const split = splitResource('Pod.default.test');
+    expect(split.stage).toEqual(SplitStage.Completed);
+    expect(split.kind).toEqual('Pod');
+    expect(split.namespace).toEqual('default');
+    expect(split.name).toEqual('test');
+  });
+
+  it('should split partial empty node', () => {
+    const split = splitResource('Node.');
+    expect(split.stage).toEqual(SplitStage.Completed);
+    expect(split.kind).toEqual('Node');
+    expect(split.namespace).toEqual('');
+    expect(split.name).toEqual('');
+  });
+
+  it('should split completed node', () => {
+    const split = splitResource('Node.my-node.ec2.internal');
+    expect(split.stage).toEqual(SplitStage.Completed);
+    expect(split.kind).toEqual('Node');
+    expect(split.namespace).toEqual('');
+    expect(split.name).toEqual('my-node.ec2.internal');
+  });
+});

--- a/web/src/model/resource.ts
+++ b/web/src/model/resource.ts
@@ -8,17 +8,18 @@ type SplitResource = { kind: string; namespace: string; name: string; stage: Spl
 const isNode = (kind: string) => kind.toLowerCase() === 'node';
 
 export const splitResource = (resource: string): SplitResource => {
-  const parts = resource.split('.');
-  if (parts.length === 1) {
-    return { kind: parts[0], namespace: '', name: '', stage: SplitStage.PartialKind };
-  } else if (parts.length === 2) {
-    if (isNode(parts[0])) {
-      // Node is not namespace-scoped
-      return { kind: parts[0], namespace: '', name: parts[1], stage: SplitStage.Completed };
-    }
-    return { kind: parts[0], namespace: parts[1], name: '', stage: SplitStage.PartialNamespace };
+  const [kind, ...rest] = resource.split('.');
+  if (rest.length === 0) {
+    return { kind: kind, namespace: '', name: '', stage: SplitStage.PartialKind };
   }
-  return { kind: parts[0], namespace: parts[1], name: parts[2], stage: SplitStage.Completed };
+  if (isNode(kind)) {
+    // Node is not namespace-scoped; beware that it may contain dots, unlike usual names
+    return { kind: kind, namespace: '', name: rest.join('.'), stage: SplitStage.Completed };
+  }
+  if (rest.length === 1) {
+    return { kind: kind, namespace: rest[0], name: '', stage: SplitStage.PartialNamespace };
+  }
+  return { kind: kind, namespace: rest[0], name: rest[1], stage: SplitStage.Completed };
 };
 
 export const joinResource = (resource: SplitResource): string => {

--- a/web/src/utils/__tests__/label.spec.ts
+++ b/web/src/utils/__tests__/label.spec.ts
@@ -13,8 +13,11 @@ describe('K8S name validation', () => {
     expect(validateK8SName('ab*c')).toBe(true);
   });
 
+  it('should validate partial match node name with dots', () => {
+    expect(validateK8SName('ip-10-0-131-71.ec2.internal')).toBe(true);
+  });
+
   it('should invalidate partial match with disallowed special chars', () => {
-    expect(validateK8SName('ab.c')).toBe(false);
     expect(validateK8SName('ab_c')).toBe(false);
     expect(validateK8SName('ab"c')).toBe(false);
     expect(validateK8SName('ab/c')).toBe(false);
@@ -31,10 +34,13 @@ describe('K8S name validation', () => {
     expect(validateK8SName('"a-1"')).toBe(true);
   });
 
+  it('should validate exact match node name with dots', () => {
+    expect(validateK8SName('"ip-10-0-131-71.ec2.internal"')).toBe(true);
+  });
+
   it('should invalidate exact match with special chars', () => {
     expect(validateK8SName('"ab@c"')).toBe(false);
     expect(validateK8SName('"ab/c"')).toBe(false);
-    expect(validateK8SName('"ab.c"')).toBe(false);
     expect(validateK8SName('"ab|c"')).toBe(false);
     expect(validateK8SName('"ab&c"')).toBe(false);
     expect(validateK8SName('"ab?c"')).toBe(false);

--- a/web/src/utils/label.ts
+++ b/web/src/utils/label.ts
@@ -1,12 +1,12 @@
 /* validate any k8s name
  *  if enclosed in quotes, switch to exact match
  *  else:
- *    allow upper / lower case alphanumeric (case ignored)
+ *    allow upper / lower case alphanumeric (case ignored) and '.' (for nodes)
  *    allow '*'
  *    don't force to start / end with alphanumeric since we can filter on partial names
  */
-export const k8sName = RegExp('^[-a-zA-Z0-9*]*$');
-export const strictK8sName = RegExp('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$');
+export const k8sName = RegExp('^[-a-zA-Z0-9.*]*$');
+export const strictK8sName = RegExp('^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$');
 
 // validate regex and ensure we don't have quotes or only two
 export const validateK8SName = (name: string) => {


### PR DESCRIPTION
- Fix Resource filters when kind is Node (missing API endpoint, bugged
  split function)
- Fix allowing '.' in kubernetes names (for nodes)
- Add tests on both sides back/front; on the backend, create an
  httpClientMock that can easily be reused for mocking loki