### PR TITLE
NETOBSERV-270 resizable panel

### DIFF
--- a/web/src/components/netflow-record/record-panel.tsx
+++ b/web/src/components/netflow-record/record-panel.tsx
@@ -13,6 +13,7 @@ import {
 import _ from 'lodash';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
+import { defaultSize, maxSize, minSize } from '../../utils/panel';
 import { defaultTimeRange, flowdirToReporter } from '../../utils/router';
 import { Record } from '../../api/ipfix';
 import { Column, ColumnsId, getColumnGroups } from '../../utils/columns';
@@ -134,7 +135,7 @@ export const RecordPanel: React.FC<RecordDrawerProps> = ({
 
   const groups = getColumnGroups(columns);
   return (
-    <DrawerPanelContent id={id}>
+    <DrawerPanelContent id={id} isResizable defaultSize={defaultSize} minSize={minSize} maxSize={maxSize}>
       <DrawerHead>
         <Text component={TextVariants.h2}>{t('Flow Details')}</Text>
         <DrawerActions>

--- a/web/src/components/netflow-topology/element-panel.tsx
+++ b/web/src/components/netflow-topology/element-panel.tsx
@@ -23,6 +23,7 @@ import {
 import { BaseEdge, BaseNode, GraphElement } from '@patternfly/react-topology';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
+import { defaultSize, maxSize, minSize } from '../../utils/panel';
 import { MetricFunction, MetricType } from 'src/model/flow-query';
 import { TopologyMetrics } from '../../api/loki';
 import { humanFileSize } from '../../utils/bytes';
@@ -336,7 +337,7 @@ export const ElementPanel: React.FC<{
   }, [data.type, element, t]);
 
   return (
-    <DrawerPanelContent id={id}>
+    <DrawerPanelContent id={id} isResizable defaultSize={defaultSize} minSize={minSize} maxSize={maxSize}>
       <DrawerHead>
         {titleContent()}
         <DrawerActions>

--- a/web/src/components/netflow-topology/options-panel.tsx
+++ b/web/src/components/netflow-topology/options-panel.tsx
@@ -10,6 +10,7 @@ import {
 } from '@patternfly/react-core';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
+import { defaultSize, maxSize, minSize } from '../../utils/panel';
 import { LayoutName, TopologyGroupTypes, TopologyOptions } from '../../model/topology';
 import { GroupDropdown } from '../dropdowns/group-dropdown';
 import { LayoutDropdown } from '../dropdowns/layout-dropdown';
@@ -35,7 +36,7 @@ export const OptionsPanel: React.FC<RecordDrawerProps> = ({ id, layout, setLayou
   };
 
   return (
-    <DrawerPanelContent id={id}>
+    <DrawerPanelContent id={id} isResizable defaultSize={defaultSize} minSize={minSize} maxSize={maxSize}>
       <DrawerHead>
         <Text component={TextVariants.h2}>{t('Options')}</Text>
         <DrawerActions>

--- a/web/src/components/netflow-traffic.css
+++ b/web/src/components/netflow-traffic.css
@@ -49,6 +49,10 @@ span.pf-c-button__icon.pf-m-start {
     overflow: hidden;
 }
 
+.pf-c-drawer__panel.pf-m-resizable{
+    overflow: hidden;
+}
+
 /* flex page header */
 #pageHeader {
     display: flex;

--- a/web/src/components/netflow-traffic.tsx
+++ b/web/src/components/netflow-traffic.tsx
@@ -134,20 +134,38 @@ export const NetflowTraffic: React.FC<{
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [forcedFilters]);
 
-  const onRecordSelect = (record?: Record) => {
-    setTRModalOpen(false);
-    setColModalOpen(false);
-    setSelectedRecord(record);
-    setShowTopologyOptions(false);
-    setSelectedElement(undefined);
-  };
-
-  const onElementSelect = (element?: GraphElement) => {
+  const clearSelections = () => {
     setTRModalOpen(false);
     setColModalOpen(false);
     setSelectedRecord(undefined);
     setShowTopologyOptions(false);
+    setShowQuerySummary(false);
+    setSelectedElement(undefined);
+  };
+
+  const selectView = (view: ViewId) => {
+    clearSelections();
+    setSelectedViewId(view);
+  };
+
+  const onRecordSelect = (record?: Record) => {
+    clearSelections();
+    setSelectedRecord(record);
+  };
+
+  const onElementSelect = (element?: GraphElement) => {
+    clearSelections();
     setSelectedElement(element);
+  };
+
+  const onToggleTopologyOptions = (v: boolean) => {
+    clearSelections();
+    setShowTopologyOptions(v);
+  };
+
+  const onToggleQuerySummary = (v: boolean) => {
+    clearSelections();
+    setShowQuerySummary(v);
   };
 
   const buildFlowQuery = React.useCallback((): FlowQuery => {
@@ -274,14 +292,14 @@ export const NetflowTraffic: React.FC<{
             text={t('Flow Table')}
             buttonId="tableViewButton"
             isSelected={selectedViewId === 'table'}
-            onChange={() => setSelectedViewId('table')}
+            onChange={() => selectView('table')}
           />
           <ToggleGroupItem
             icon={<TopologyIcon />}
             text={t('Topology')}
             buttonId="topologyViewButton"
             isSelected={selectedViewId === 'topology'}
-            onChange={() => setSelectedViewId('topology')}
+            onChange={() => selectView('topology')}
           />
         </ToggleGroup>
       )
@@ -441,7 +459,7 @@ export const NetflowTraffic: React.FC<{
             options={topologyOptions}
             filters={filters}
             setFilters={setFilters}
-            toggleTopologyOptions={() => setShowTopologyOptions(!isShowTopologyOptions)}
+            toggleTopologyOptions={() => onToggleTopologyOptions(!isShowTopologyOptions)}
             selected={selectedElement}
             onSelect={onElementSelect}
           />
@@ -500,7 +518,7 @@ export const NetflowTraffic: React.FC<{
         flows={flows}
         range={range}
         limit={limit}
-        toggleQuerySummary={() => setShowQuerySummary(!isShowQuerySummary)}
+        toggleQuerySummary={() => onToggleQuerySummary(!isShowQuerySummary)}
       />
       <TimeRangeModal
         id="time-range-modal"

--- a/web/src/components/query-summary/summary-panel.tsx
+++ b/web/src/components/query-summary/summary-panel.tsx
@@ -16,6 +16,7 @@ import {
 } from '@patternfly/react-core';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
+import { defaultSize, maxSize, minSize } from '../../utils/panel';
 import { compareStrings } from '../../utils/base-compare';
 import { Record } from '../../api/ipfix';
 import { TimeRange } from '../../utils/datetime';
@@ -244,7 +245,7 @@ export const SummaryPanel: React.FC<{
   const { t } = useTranslation('plugin__network-observability-plugin');
 
   return (
-    <DrawerPanelContent id={id}>
+    <DrawerPanelContent id={id} isResizable defaultSize={defaultSize} minSize={minSize} maxSize={maxSize}>
       <DrawerHead>
         <Text component={TextVariants.h2}>{t('Query summary')}</Text>
         <DrawerActions>

--- a/web/src/utils/panel.tsx
+++ b/web/src/utils/panel.tsx
@@ -1,0 +1,3 @@
+export const defaultSize = '500px';
+export const minSize = '250px';
+export const maxSize = '750px';


### PR DESCRIPTION
This PR is part of UI feedback / followup. It implements resizable panel and improve UX on selections / view switch. The selections will now close on view change.

![image](https://user-images.githubusercontent.com/91894519/165323959-862459f3-4b0d-4cb5-96c3-e709f81100b9.png)
![image](https://user-images.githubusercontent.com/91894519/165324016-ee6da7ae-19ef-428b-97ab-7c582f4ba867.png)
![image](https://user-images.githubusercontent.com/91894519/165324105-4a7d2b29-47b5-4e2c-b36d-62aefa432a64.png)
