### PR TITLE
NETOBSERV-287 Aggregate stats, fix limit reach

### DIFF
--- a/pkg/handler/csv/loki_csv.go
+++ b/pkg/handler/csv/loki_csv.go
@@ -12,8 +12,8 @@ const (
 	timestampCol = "Timestamp"
 )
 
-func GetCSVData(qr *model.QueryResponse, columns []string) ([][]string, error) {
-	if streams, ok := qr.Data.Result.(model.Streams); ok { //make csv datas containing header as first line + rows
+func GetCSVData(qr *model.AggregatedQueryResponse, columns []string) ([][]string, error) {
+	if streams, ok := qr.Result.(model.Streams); ok { //make csv datas containing header as first line + rows
 		data := make([][]string, 1)
 		//prepare columns for faster lookup
 		columnsMap := utils.GetMapInterface(columns)
@@ -64,7 +64,7 @@ func GetCSVData(qr *model.QueryResponse, columns []string) ([][]string, error) {
 		}
 		return data, nil
 	}
-	return nil, fmt.Errorf("loki returned an unexpected type: %T", qr.Data.Result)
+	return nil, fmt.Errorf("loki returned an unexpected type: %T", qr.Result)
 }
 
 func getRowDatas(stream model.Stream, entry model.Entry, labels, fields []string,

--- a/pkg/handler/response.go
+++ b/pkg/handler/response.go
@@ -11,15 +11,6 @@ import (
 	"github.com/netobserv/network-observability-console-plugin/pkg/model"
 )
 
-func writeRawJSON(w http.ResponseWriter, code int, payload []byte) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(code)
-	_, err := w.Write(payload)
-	if err != nil {
-		hlog.Errorf("Error while responding raw JSON: %v", err)
-	}
-}
-
 func writeJSON(w http.ResponseWriter, code int, payload interface{}) {
 	response, err := json.Marshal(payload)
 	if err != nil {
@@ -36,15 +27,8 @@ func writeJSON(w http.ResponseWriter, code int, payload interface{}) {
 	}
 }
 
-func writeCSV(w http.ResponseWriter, code int, payload []byte, columns []string) {
-	var qr model.QueryResponse
-	err := json.Unmarshal(payload, &qr)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, fmt.Sprintf("Unknown error from Loki - cannot unmarshal (code: %d resp: %s)", code, payload))
-		return
-	}
-
-	data, err := csvdata.GetCSVData(&qr, columns)
+func writeCSV(w http.ResponseWriter, code int, qr *model.AggregatedQueryResponse, columns []string) {
+	data, err := csvdata.GetCSVData(qr, columns)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return

--- a/pkg/loki/matrix_merger.go
+++ b/pkg/loki/matrix_merger.go
@@ -1,20 +1,30 @@
 package loki
 
 import (
-	"github.com/netobserv/network-observability-console-plugin/pkg/model"
+	"fmt"
+
 	pmodel "github.com/prometheus/common/model"
+
+	"github.com/netobserv/network-observability-console-plugin/pkg/model"
 )
 
 //MatrixMerger stores a state to build unique Matrix from multiple ones
 type MatrixMerger struct {
-	index  map[string]indexedSampleStream
-	merged model.Matrix
+	Merger
+	index        map[string]indexedSampleStream
+	merged       model.Matrix
+	stats        []interface{}
+	numQueries   int
+	reqLimit     int
+	limitReached bool
 }
 
-func NewMatrixMerger() *MatrixMerger {
+func NewMatrixMerger(reqLimit int) *MatrixMerger {
 	return &MatrixMerger{
-		index:  map[string]indexedSampleStream{},
-		merged: model.Matrix{},
+		reqLimit: reqLimit,
+		index:    map[string]indexedSampleStream{},
+		merged:   model.Matrix{},
+		stats:    []interface{}{},
 	}
 }
 
@@ -25,8 +35,20 @@ type indexedSampleStream struct {
 	index        int
 }
 
-func (m *MatrixMerger) AddMatrix(from model.Matrix) model.Matrix {
-	for _, sampleStream := range from {
+func (m *MatrixMerger) Add(from model.QueryResponseData) (model.ResultValue, error) {
+	matrix, ok := from.Result.(model.Matrix)
+	if !ok {
+		return nil, fmt.Errorf("loki returned an unexpected type for MatrixMerger: %T", from)
+	}
+
+	m.numQueries++
+	m.stats = append(m.stats, from.Stats)
+	// In Matrix results, the limit stands for the "topk" value, which relates to the number of streams
+	//	(ie LabelSet cardinality)
+	if len(matrix) >= m.reqLimit {
+		m.limitReached = true
+	}
+	for _, sampleStream := range matrix {
 		skey := sampleStream.Metric.String()
 		idxSampleStream, sampleStreamExists := m.index[skey]
 		if !sampleStreamExists {
@@ -57,9 +79,17 @@ func (m *MatrixMerger) AddMatrix(from model.Matrix) model.Matrix {
 			m.merged[idxSampleStream.index] = idxSampleStream.sampleStream
 		}
 	}
-	return m.merged
+	return m.merged, nil
 }
 
-func (m *MatrixMerger) GetMatrix() model.Matrix {
-	return m.merged
+func (m *MatrixMerger) Get() *model.AggregatedQueryResponse {
+	return &model.AggregatedQueryResponse{
+		ResultType: model.ResultTypeMatrix,
+		Result:     m.merged,
+		Stats: model.AggregatedStats{
+			NumQueries:   m.numQueries,
+			LimitReached: m.limitReached,
+			QueriesStats: m.stats,
+		},
+	}
 }

--- a/pkg/loki/merger.go
+++ b/pkg/loki/merger.go
@@ -1,0 +1,10 @@
+package loki
+
+import (
+	"github.com/netobserv/network-observability-console-plugin/pkg/model"
+)
+
+type Merger interface {
+	Add(from model.QueryResponseData) (model.ResultValue, error)
+	Get() *model.AggregatedQueryResponse
+}

--- a/pkg/loki/streams_merger_test.go
+++ b/pkg/loki/streams_merger_test.go
@@ -5,13 +5,18 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/netobserv/network-observability-console-plugin/pkg/model"
 )
 
+func qrData(result model.ResultValue) model.QueryResponseData {
+	return model.QueryResponseData{Result: result}
+}
+
 func TestStreamsMerge(t *testing.T) {
 	now := time.Now()
-	merger := NewStreamMerger()
+	merger := NewStreamMerger(100)
 	baseline := model.Stream{
 		Labels: map[string]string{
 			"foo": "bar",
@@ -21,10 +26,11 @@ func TestStreamsMerge(t *testing.T) {
 			Line:      "{key: value}",
 		}},
 	}
-	merger.AddStreams(model.Streams{baseline})
+	_, err := merger.Add(qrData(model.Streams{baseline}))
+	require.NoError(t, err)
 
 	// Different label, different line => no dedup
-	merged := merger.AddStreams(model.Streams{{
+	merged, err := merger.Add(qrData(model.Streams{{
 		Labels: map[string]string{
 			"foo":  "bar",
 			"foo2": "bar2",
@@ -36,13 +42,14 @@ func TestStreamsMerge(t *testing.T) {
 			Timestamp: now,
 			Line:      "{key2: value2}",
 		}},
-	}})
+	}}))
+	require.NoError(t, err)
 	assert.Len(t, merged, 2)
-	assert.Len(t, merged[0].Entries, 2)
-	assert.Len(t, merged[1].Entries, 1)
+	assert.Len(t, merged.(model.Streams)[0].Entries, 2)
+	assert.Len(t, merged.(model.Streams)[1].Entries, 1)
 
 	// Same labels in different order => no dedup
-	merged = merger.AddStreams(model.Streams{{
+	merged, err = merger.Add(qrData(model.Streams{{
 		Labels: map[string]string{
 			"foo2": "bar2",
 			"foo":  "bar",
@@ -60,25 +67,27 @@ func TestStreamsMerge(t *testing.T) {
 			"foo2": "bar2",
 		},
 		Entries: baseline.Entries,
-	}})
+	}}))
+	require.NoError(t, err)
 	assert.Len(t, merged, 2)
-	assert.Len(t, merged[0].Entries, 2)
-	assert.Len(t, merged[1].Entries, 1)
+	assert.Len(t, merged.(model.Streams)[0].Entries, 2)
+	assert.Len(t, merged.(model.Streams)[1].Entries, 1)
 
 	// Different timestamp => no dedup
-	merged = merger.AddStreams(model.Streams{{
+	merged, err = merger.Add(qrData(model.Streams{{
 		Labels: baseline.Labels,
 		Entries: []model.Entry{{
 			Timestamp: now.Add(time.Hour),
 			Line:      "{key: value}",
 		}},
-	}})
+	}}))
+	require.NoError(t, err)
 	assert.Len(t, merged, 2)
-	assert.Len(t, merged[0].Entries, 3)
-	assert.Len(t, merged[1].Entries, 1)
+	assert.Len(t, merged.(model.Streams)[0].Entries, 3)
+	assert.Len(t, merged.(model.Streams)[1].Entries, 1)
 
 	// some dedup
-	merged = merger.AddStreams(model.Streams{{
+	merged, err = merger.Add(qrData(model.Streams{{
 		// changed line => no dedup
 		Labels: baseline.Labels,
 		Entries: []model.Entry{{
@@ -102,10 +111,76 @@ func TestStreamsMerge(t *testing.T) {
 	},
 		// baseline itself => must be ignored
 		baseline,
-	})
+	}))
 
 	// Different timestamp => no dedup
+	require.NoError(t, err)
 	assert.Len(t, merged, 2)
-	assert.Len(t, merged[0].Entries, 5)
-	assert.Len(t, merged[1].Entries, 1)
+	assert.Len(t, merged.(model.Streams)[0].Entries, 5)
+	assert.Len(t, merged.(model.Streams)[1].Entries, 1)
+}
+
+func TestStreamsLimitReached(t *testing.T) {
+	now := time.Now()
+	merger := NewStreamMerger(2)
+
+	// Single entry => should not reach limit
+	first := model.Stream{
+		Labels: map[string]string{
+			"foo": "bar",
+		},
+		Entries: []model.Entry{{
+			Timestamp: now,
+			Line:      "{key: value}",
+		}},
+	}
+	_, err := merger.Add(qrData(model.Streams{first}))
+	require.NoError(t, err)
+	assert.False(t, merger.limitReached)
+
+	// Another single entry => limit still not reached (even if total is 2)
+	_, err = merger.Add(qrData(model.Streams{{
+		Labels: map[string]string{
+			"foo": "bar",
+		},
+		Entries: []model.Entry{{
+			Timestamp: now,
+			Line:      "{key: value}",
+		}},
+	}}))
+	require.NoError(t, err)
+	assert.False(t, merger.limitReached)
+
+	// 2 entries => limit reached
+	_, err = merger.Add(qrData(model.Streams{{
+		// changed line => no dedup
+		Labels: first.Labels,
+		Entries: []model.Entry{{
+			Timestamp: now,
+			Line:      "{key: value3}",
+		}},
+	}, {
+		// same as first => dedup, but still counts for limit reached
+		Labels: first.Labels,
+		Entries: []model.Entry{{
+			Timestamp: now,
+			Line:      "{key: value}",
+		}},
+	},
+	}))
+	require.NoError(t, err)
+	assert.True(t, merger.limitReached)
+
+	// Another single entry => limit still reached
+	_, err = merger.Add(qrData(model.Streams{{
+		Labels: map[string]string{
+			"foo": "bar",
+		},
+		Entries: []model.Entry{{
+			Timestamp: now,
+			Line:      "{key: value}",
+		}},
+	}}))
+	require.NoError(t, err)
+	assert.True(t, merger.limitReached)
 }

--- a/pkg/model/loki_test.go
+++ b/pkg/model/loki_test.go
@@ -1,0 +1,130 @@
+package model
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueryResponseMarshal(t *testing.T) {
+	qr := QueryResponse{
+		Data: QueryResponseData{
+			ResultType: ResultTypeStream,
+			Result:     Streams{},
+		},
+	}
+
+	js, err := json.Marshal(qr)
+	require.NoError(t, err)
+	assert.Equal(t, `{"status":"","data":{"resultType":"streams","result":[]}}`, string(js))
+}
+
+func TestQueryResponseUnmarshal(t *testing.T) {
+	js := `{"status":"","data":{"resultType":"streams","result":[]}}`
+	var qr QueryResponse
+	err := json.Unmarshal([]byte(js), &qr)
+	require.NoError(t, err)
+	assert.Equal(t, ResultTypeStream, string(qr.Data.ResultType))
+	assert.NotNil(t, qr.Data.Result)
+	assert.Empty(t, qr.Data.Result)
+	var expType Streams
+	assert.IsType(t, expType, qr.Data.Result)
+}
+
+func TestAggregatedQueryResponseMarshal(t *testing.T) {
+	qr := AggregatedQueryResponse{
+		ResultType: ResultTypeStream,
+		Result:     Streams{},
+		Stats: AggregatedStats{
+			NumQueries: 1,
+		},
+	}
+
+	js, err := json.Marshal(qr)
+	require.NoError(t, err)
+	assert.Equal(t, `{"resultType":"streams","result":[],"stats":{"numQueries":1,"limitReached":false,"queriesStats":null}}`, string(js))
+}
+
+func TestAggregatedQueryResponseUnmarshal(t *testing.T) {
+	js := `{"resultType":"streams","result":[],"stats":{"numQueries":1,"limitReached":false,"queriesStats":null}}`
+	var qr AggregatedQueryResponse
+	err := json.Unmarshal([]byte(js), &qr)
+	require.NoError(t, err)
+	assert.Equal(t, ResultTypeStream, string(qr.ResultType))
+	assert.NotNil(t, qr.Result)
+	assert.Empty(t, qr.Result)
+	var expType Streams
+	assert.IsType(t, expType, qr.Result)
+}
+
+func TestQueryResponseMatrixMarshal(t *testing.T) {
+	qr := QueryResponse{
+		Data: QueryResponseData{
+			ResultType: ResultTypeMatrix,
+			Result:     Matrix{},
+		},
+	}
+
+	js, err := json.Marshal(qr)
+	require.NoError(t, err)
+	assert.Equal(t, `{"status":"","data":{"resultType":"matrix","result":[]}}`, string(js))
+}
+
+func TestQueryResponseMatrixUnmarshal(t *testing.T) {
+	js := `{"status":"","data":{"resultType":"matrix","result":[]}}`
+	var qr QueryResponse
+	err := json.Unmarshal([]byte(js), &qr)
+	require.NoError(t, err)
+	assert.Equal(t, ResultTypeMatrix, string(qr.Data.ResultType))
+	assert.NotNil(t, qr.Data.Result)
+	assert.Empty(t, qr.Data.Result)
+	var expType Matrix
+	assert.IsType(t, expType, qr.Data.Result)
+}
+
+func TestAggregatedQueryResponseMatrixMarshal(t *testing.T) {
+	qr := AggregatedQueryResponse{
+		ResultType: ResultTypeMatrix,
+		Result:     Matrix{},
+		Stats: AggregatedStats{
+			NumQueries: 1,
+		},
+	}
+
+	js, err := json.Marshal(qr)
+	require.NoError(t, err)
+	assert.Equal(t, `{"resultType":"matrix","result":[],"stats":{"numQueries":1,"limitReached":false,"queriesStats":null}}`, string(js))
+}
+
+func TestAggregatedQueryResponseMatrixUnmarshal(t *testing.T) {
+	js := `{"resultType":"matrix","result":[],"stats":{"numQueries":1,"limitReached":false,"queriesStats":null}}`
+	var qr AggregatedQueryResponse
+	err := json.Unmarshal([]byte(js), &qr)
+	require.NoError(t, err)
+	assert.Equal(t, ResultTypeMatrix, string(qr.ResultType))
+	assert.NotNil(t, qr.Result)
+	assert.Empty(t, qr.Result)
+	var expType Matrix
+	assert.IsType(t, expType, qr.Result)
+}
+
+func TestReencodeStats(t *testing.T) {
+	js := `{"status":"","data":{"resultType":"streams","result":[],"stats":{"ingester":{"foo":"bar"}}}}`
+	var qr QueryResponse
+	err := json.Unmarshal([]byte(js), &qr)
+	require.NoError(t, err)
+	agg := AggregatedQueryResponse{
+		ResultType: qr.Data.ResultType,
+		Result:     qr.Data.Result,
+		Stats: AggregatedStats{
+			NumQueries:   1,
+			LimitReached: false,
+			QueriesStats: []interface{}{qr.Data.Stats},
+		},
+	}
+	reencoded, err := json.Marshal(agg)
+	require.NoError(t, err)
+	assert.Equal(t, `{"resultType":"streams","result":[],"stats":{"numQueries":1,"limitReached":false,"queriesStats":[{"ingester":{"foo":"bar"}}]}}`, string(reencoded))
+}

--- a/web/locales/en/plugin__network-observability-plugin.json
+++ b/web/locales/en/plugin__network-observability-plugin.json
@@ -31,7 +31,7 @@
   "Reporter node": "Reporter node",
   "Whether each query result has to match all the filters or just any of them": "Whether each query result has to match all the filters or just any of them",
   "Match filters": "Match filters",
-  "Query limit for Loki. Depending on the matching and filter settings, several Loki queries can be performed under the cover, resulting in having more results than the limit set.": "Query limit for Loki. Depending on the matching and filter settings, several Loki queries can be performed under the cover, resulting in having more results than the limit set.",
+  "Limit for internal backend queries. Depending on the matching and filter settings, several queries can be performed under the cover, each with this limit set, resulting in more results after aggregation.": "Limit for internal backend queries. Depending on the matching and filter settings, several queries can be performed under the cover, each with this limit set, resulting in more results after aggregation.",
   "Limit": "Limit",
   "Query Options": "Query Options",
   "Refresh off": "Refresh off",

--- a/web/locales/en/plugin__network-observability-plugin.json
+++ b/web/locales/en/plugin__network-observability-plugin.json
@@ -31,6 +31,7 @@
   "Reporter node": "Reporter node",
   "Whether each query result has to match all the filters or just any of them": "Whether each query result has to match all the filters or just any of them",
   "Match filters": "Match filters",
+  "Query limit for Loki. Depending on the matching and filter settings, several Loki queries can be performed under the cover, resulting in having more results than the limit set.": "Query limit for Loki. Depending on the matching and filter settings, several Loki queries can be performed under the cover, resulting in having more results than the limit set.",
   "Limit": "Limit",
   "Query Options": "Query Options",
   "Refresh off": "Refresh off",

--- a/web/src/api/loki.ts
+++ b/web/src/api/loki.ts
@@ -3,18 +3,32 @@ import { MetricFunction } from '../model/flow-query';
 import { cyrb53 } from '../utils/hash';
 import { Fields, Labels, Record } from './ipfix';
 
-export interface LokiResponse {
+export interface AggregatedQueryResponse {
   resultType: string;
   result: StreamResult[] | TopologyMetrics[];
-  stats: LokiStats;
+  stats: Stats;
 }
 
-export interface LokiStats {}
+export interface Stats {
+  numQueries: number;
+  limitReached: boolean;
+  // Here, more (raw) stats available in queriesStats array
+}
 
-export type StreamResult = {
+export interface StreamResult {
   stream: { [key: string]: string };
   values: string[][];
-};
+}
+
+export interface RecordsResult {
+  records: Record[];
+  stats: Stats;
+}
+
+export interface TopologyResult {
+  metrics: TopologyMetrics[];
+  stats: Stats;
+}
 
 export const parseStream = (raw: StreamResult): Record[] => {
   return raw.values.map(v => {

--- a/web/src/components/__tests-data__/flows.ts
+++ b/web/src/components/__tests-data__/flows.ts
@@ -1,3 +1,4 @@
+import { RecordsResult } from '../../api/loki';
 import { FlowDirection, Record } from '../../api/ipfix';
 
 export const FlowsSample: Record[] = [
@@ -68,3 +69,11 @@ export const FlowsSample: Record[] = [
     }
   }
 ];
+
+export const FlowsResultSample: RecordsResult = {
+  records: FlowsSample,
+  stats: {
+    limitReached: false,
+    numQueries: 1
+  }
+};

--- a/web/src/components/__tests__/netflow-traffic.spec.tsx
+++ b/web/src/components/__tests__/netflow-traffic.spec.tsx
@@ -6,13 +6,13 @@ import { act } from 'react-dom/test-utils';
 import { getFlows } from '../../api/routes';
 import NetflowTraffic from '../netflow-traffic';
 import { extensionsMock } from '../__tests-data__/extensions';
-import { FlowsSample } from '../__tests-data__/flows';
+import { FlowsResultSample } from '../__tests-data__/flows';
 import NetflowTrafficParent from '../netflow-traffic-parent';
 
 const useResolvedExtensionsMock = useResolvedExtensions as jest.Mock;
 
 jest.mock('../../api/routes', () => ({
-  getFlows: jest.fn(() => Promise.resolve(FlowsSample))
+  getFlows: jest.fn(() => Promise.resolve(FlowsResultSample))
 }));
 const getFlowsMock = getFlows as jest.Mock;
 

--- a/web/src/components/dropdowns/__tests__/query-options-dropdown.spec.tsx
+++ b/web/src/components/dropdowns/__tests__/query-options-dropdown.spec.tsx
@@ -36,7 +36,7 @@ describe('<QueryOptionsPanel />', () => {
   });
   it('should render component', async () => {
     const wrapper = shallow(<QueryOptionsPanel {...props} />);
-    expect(wrapper.find('.pf-c-select__menu-group').length).toBe(2);
+    expect(wrapper.find('.pf-c-select__menu-group').length).toBe(3);
     expect(wrapper.find('.pf-c-select__menu-group-title').length).toBe(3);
     expect(wrapper.find(Radio)).toHaveLength(8);
 

--- a/web/src/components/dropdowns/query-options-dropdown.tsx
+++ b/web/src/components/dropdowns/query-options-dropdown.tsx
@@ -116,7 +116,7 @@ export const QueryOptionsPanel: React.FC<QueryOptionsDropdownProps> = ({
         <Tooltip
           content={t(
             // eslint-disable-next-line max-len
-            'Query limit for Loki. Depending on the matching and filter settings, several Loki queries can be performed under the cover, resulting in having more results than the limit set.'
+            'Limit for internal backend queries. Depending on the matching and filter settings, several queries can be performed under the cover, each with this limit set, resulting in more results after aggregation.'
           )}
         >
           <div className="pf-c-select__menu-group-title">

--- a/web/src/components/dropdowns/query-options-dropdown.tsx
+++ b/web/src/components/dropdowns/query-options-dropdown.tsx
@@ -112,21 +112,34 @@ export const QueryOptionsPanel: React.FC<QueryOptionsDropdownProps> = ({
           </div>
         ))}
       </div>
-      <div className="pf-c-select__menu-group-title">{t('Limit')}</div>
-      {[100, 500, 1000].map(l => (
-        <div key={'limit-' + l}>
-          <label className="pf-c-select__menu-item">
-            <Radio
-              id={'limit-' + l}
-              name={'limit-' + l}
-              isChecked={l === limit}
-              label={String(l)}
-              onChange={() => setLimit(l)}
-              value={String(l)}
-            />
-          </label>
-        </div>
-      ))}
+      <div className="pf-c-select__menu-group">
+        <Tooltip
+          content={t(
+            // eslint-disable-next-line max-len
+            'Query limit for Loki. Depending on the matching and filter settings, several Loki queries can be performed under the cover, resulting in having more results than the limit set.'
+          )}
+        >
+          <div className="pf-c-select__menu-group-title">
+            <>
+              {t('Limit')} <InfoAltIcon />
+            </>
+          </div>
+        </Tooltip>
+        {[100, 500, 1000].map(l => (
+          <div key={'limit-' + l}>
+            <label className="pf-c-select__menu-item">
+              <Radio
+                id={'limit-' + l}
+                name={'limit-' + l}
+                isChecked={l === limit}
+                label={String(l)}
+                onChange={() => setLimit(l)}
+                value={String(l)}
+              />
+            </label>
+          </div>
+        ))}
+      </div>
     </>
   );
 };

--- a/web/src/components/netflow-traffic.tsx
+++ b/web/src/components/netflow-traffic.tsx
@@ -29,7 +29,7 @@ import {
   MetricFunction,
   MetricType
 } from '../model/flow-query';
-import { TopologyMetrics } from '../api/loki';
+import { Stats, TopologyMetrics } from '../api/loki';
 import { DefaultOptions, LayoutName, TopologyOptions } from '../model/topology';
 import { Column, getDefaultColumns } from '../utils/columns';
 import { TimeRange } from '../utils/datetime';
@@ -96,6 +96,7 @@ export const NetflowTraffic: React.FC<{
 
   const [loading, setLoading] = React.useState(true);
   const [flows, setFlows] = React.useState<Record[]>([]);
+  const [stats, setStats] = React.useState<Stats | undefined>(undefined);
   const [layout, setLayout] = React.useState<LayoutName>(LayoutName.ColaNoForce);
   const [topologyOptions, setTopologyOptions] = React.useState<TopologyOptions>(DefaultOptions);
   const [metrics, setMetrics] = React.useState<TopologyMetrics[]>([]);
@@ -198,7 +199,10 @@ export const NetflowTraffic: React.FC<{
     switch (selectedViewId) {
       case 'table':
         getFlows(fq)
-          .then(setFlows)
+          .then(result => {
+            setFlows(result.records);
+            setStats(result.stats);
+          })
           .catch(err => {
             setFlows([]);
             setError(getHTTPErrorDetails(err));
@@ -209,7 +213,10 @@ export const NetflowTraffic: React.FC<{
         break;
       case 'topology':
         getTopology(fq, range)
-          .then(setMetrics)
+          .then(result => {
+            setMetrics(result.metrics);
+            setStats(result.stats);
+          })
           .catch(err => {
             setMetrics([]);
             setError(getHTTPErrorDetails(err));
@@ -408,8 +415,8 @@ export const NetflowTraffic: React.FC<{
         <SummaryPanel
           id="summaryPanel"
           flows={flows}
+          stats={stats}
           range={range}
-          limit={limit}
           onClose={() => setShowQuerySummary(false)}
         />
       );
@@ -515,7 +522,7 @@ export const NetflowTraffic: React.FC<{
       <QuerySummary
         flows={flows}
         range={range}
-        limit={limit}
+        stats={stats}
         toggleQuerySummary={() => onToggleQuerySummary(!isShowQuerySummary)}
       />
       <TimeRangeModal

--- a/web/src/components/query-summary/__tests__/query-summary.spec.tsx
+++ b/web/src/components/query-summary/__tests__/query-summary.spec.tsx
@@ -8,7 +8,10 @@ describe('<QuerySummary />', () => {
     toggleQuerySummary: jest.fn(),
     flows: FlowsSample,
     range: 300,
-    limit: 100
+    stats: {
+      limitReached: false,
+      numQueries: 1
+    }
   };
 
   it('should shallow component', async () => {

--- a/web/src/components/query-summary/__tests__/summary-panel.spec.tsx
+++ b/web/src/components/query-summary/__tests__/summary-panel.spec.tsx
@@ -9,7 +9,10 @@ describe('<SummaryPanel />', () => {
     onClose: jest.fn(),
     flows: FlowsSample,
     range: 300,
-    limit: 100,
+    stats: {
+      limitReached: false,
+      numQueries: 1
+    },
     id: 'summary-panel'
   };
 

--- a/web/src/components/query-summary/query-summary.tsx
+++ b/web/src/components/query-summary/query-summary.tsx
@@ -6,14 +6,15 @@ import { Record } from '../../api/ipfix';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import './query-summary.css';
 import { bytesPerSeconds, humanFileSize } from '../../utils/bytes';
+import { Stats } from '../../api/loki';
 
 export const QuerySummaryContent: React.FC<{
   flows: Record[];
+  limitReached: boolean;
   range: number | TimeRange;
-  limit: number;
   direction: 'row' | 'column';
   className?: string;
-}> = ({ flows, range, limit, direction, className }) => {
+}> = ({ flows, limitReached, range, direction, className }) => {
   const { t } = useTranslation('plugin__network-observability-plugin');
 
   let rangeInSeconds: number;
@@ -23,7 +24,6 @@ export const QuerySummaryContent: React.FC<{
     rangeInSeconds = (range.to - range.from) / 1000;
   }
 
-  const limitReached = limit === flows.length;
   const totalBytes = flows.map(f => f.fields.Bytes).reduce((a, b) => a + b, 0);
 
   return (
@@ -75,14 +75,14 @@ export const QuerySummaryContent: React.FC<{
 
 export const QuerySummary: React.FC<{
   flows: Record[] | undefined;
+  stats: Stats | undefined;
   range: number | TimeRange;
-  limit: number;
   toggleQuerySummary: () => void;
-}> = ({ flows, range, limit, toggleQuerySummary }) => {
-  if (flows && flows.length) {
+}> = ({ flows, stats, range, toggleQuerySummary }) => {
+  if (flows && flows.length && stats) {
     return (
       <Card id="query-summary" isSelectable onClick={toggleQuerySummary}>
-        <QuerySummaryContent direction="row" flows={flows} range={range} limit={limit} />
+        <QuerySummaryContent direction="row" flows={flows} limitReached={stats.limitReached} range={range} />
       </Card>
     );
   }

--- a/web/src/components/query-summary/summary-panel.tsx
+++ b/web/src/components/query-summary/summary-panel.tsx
@@ -25,6 +25,7 @@ import { QuerySummaryContent } from './query-summary';
 import { comparePorts, formatPort } from '../../utils/port';
 import { formatProtocol } from '../../utils/protocol';
 import { compareIPs } from '../../utils/ip';
+import { Stats } from '../../api/loki';
 import './summary-panel.css';
 
 type TypeCardinality = {
@@ -39,9 +40,9 @@ type K8SObjectCardinality = {
 
 export const SummaryPanelContent: React.FC<{
   flows: Record[] | undefined;
+  stats: Stats | undefined;
   range: number | TimeRange;
-  limit: number;
-}> = ({ flows, range, limit }) => {
+}> = ({ flows, stats, range }) => {
   const { t } = useTranslation('plugin__network-observability-plugin');
   const [expanded, setExpanded] = React.useState<string>('');
 
@@ -224,8 +225,8 @@ export const SummaryPanelContent: React.FC<{
           className="summary-container-grouped"
           direction={'column'}
           flows={flows || []}
+          limitReached={stats?.limitReached || false}
           range={range}
-          limit={limit}
         />
       </TextContent>
       <TextContent className="summary-text-container">
@@ -240,10 +241,10 @@ export const SummaryPanelContent: React.FC<{
 export const SummaryPanel: React.FC<{
   onClose: () => void;
   flows: Record[] | undefined;
+  stats: Stats | undefined;
   range: number | TimeRange;
-  limit: number;
   id?: string;
-}> = ({ flows, range, limit, id, onClose }) => {
+}> = ({ flows, stats, range, id, onClose }) => {
   const { t } = useTranslation('plugin__network-observability-plugin');
 
   return (
@@ -255,7 +256,7 @@ export const SummaryPanel: React.FC<{
         </DrawerActions>
       </DrawerHead>
       <DrawerPanelBody>
-        <SummaryPanelContent flows={flows} range={range} limit={limit} />
+        <SummaryPanelContent flows={flows} stats={stats} range={range} />
       </DrawerPanelBody>
     </DrawerPanelContent>
   );


### PR DESCRIPTION
- Stats are now aggregated in backend (needed when multiple queries are performed)
- Add a few tests
- On the frontend, limit reached now comes as a stats provided from
  backend
- Add info tooltip on limit setting, to clarify it's the limit per loki
  query, so we may end up with more flows than this limit