### PR TITLE
NETOBSERV-259 Topology: Filter from side panel

### DIFF
--- a/web/src/components/netflow-topology/__tests__/element-panel.spec.tsx
+++ b/web/src/components/netflow-topology/__tests__/element-panel.spec.tsx
@@ -1,8 +1,9 @@
-import { DrawerCloseButton } from '@patternfly/react-core';
+import { Button, DrawerCloseButton } from '@patternfly/react-core';
 import { BaseEdge, BaseNode } from '@patternfly/react-topology';
 import { mount, shallow } from 'enzyme';
 import * as React from 'react';
 import { DefaultOptions, TopologyScopes } from '../../../model/topology';
+import { Filter } from '../../../model/filters';
 import { TopologyMetrics } from '../../../api/loki';
 import { MetricFunction, MetricType } from '../../../model/flow-query';
 import { ElementPanel, ElementPanelContent } from '../element-panel';
@@ -34,6 +35,8 @@ describe('<ElementPanel />', () => {
       ...DefaultOptions,
       scope: TopologyScopes.RESOURCE
     },
+    filters: [] as Filter[],
+    setFilters: jest.fn(),
     onClose: jest.fn(),
     id: 'element-panel-test'
   };
@@ -69,5 +72,17 @@ describe('<ElementPanel />', () => {
     expect(wrapper.find('#fromCount').last().text()).toBe('78 kB');
     expect(wrapper.find('#toCount').last().text()).toBe('317 kB');
     expect(wrapper.find('#total').last().text()).toBe('396 kB');
+  });
+
+  it('should filter content', async () => {
+    const wrapper = mount(<ElementPanelContent {...mocks} />);
+    const filterButton = wrapper.find(Button);
+    filterButton.simulate('click');
+    expect(mocks.setFilters).toHaveBeenCalledWith([
+      {
+        def: expect.any(Object),
+        values: [{ v: '10.129.0.15' }]
+      }
+    ]);
   });
 });

--- a/web/src/components/netflow-traffic.tsx
+++ b/web/src/components/netflow-traffic.tsx
@@ -537,6 +537,8 @@ export const NetflowTraffic: React.FC<{
           metricFunction={metricFunction}
           metricType={metricType}
           options={topologyOptions}
+          filters={filters}
+          setFilters={setFilters}
           onClose={() => onElementSelect(undefined)}
         />
       );


### PR DESCRIPTION
This PR implements filtering from side panel on both topology nodes & edges.

![image](https://user-images.githubusercontent.com/91894519/165944897-cf1aecf8-9f5b-461d-beab-afae92611991.png)
![image](https://user-images.githubusercontent.com/91894519/165944996-c082fb2f-4188-4546-b260-b1bc697655ec.png)


Filtering from `netflow-topology` has been merged into a single place so we will need to wait for https://github.com/netobserv/network-observability-console-plugin/pull/131 & https://github.com/netobserv/network-observability-console-plugin/pull/146