### PR TITLE
NETOBSERV-253 Topology: Enrich Host informations

### DIFF
--- a/pkg/loki/topology_query.go
+++ b/pkg/loki/topology_query.go
@@ -86,19 +86,19 @@ func getFields(scope, groups string) string {
 	var fields []string
 	switch scope {
 	case "host":
-		fields = []string{"SrcK8S_HostIP", "DstK8S_HostIP"}
+		fields = []string{"SrcK8S_HostName", "DstK8S_HostName"}
 	case "namespace":
 		fields = []string{"SrcK8S_Namespace", "DstK8S_Namespace"}
 	case "owner":
 		fields = []string{"SrcK8S_OwnerName", "SrcK8S_OwnerType", "DstK8S_OwnerName", "DstK8S_OwnerType"}
 	default:
-		fields = []string{"SrcK8S_Name", "SrcK8S_Type", "SrcK8S_OwnerName", "SrcK8S_OwnerType", "SrcK8S_Namespace", "SrcAddr", "SrcK8S_HostIP", "DstK8S_Name", "DstK8S_Type", "DstK8S_OwnerName", "DstK8S_OwnerType", "DstK8S_Namespace", "DstAddr", "DstK8S_HostIP"}
+		fields = []string{"SrcK8S_Name", "SrcK8S_Type", "SrcK8S_OwnerName", "SrcK8S_OwnerType", "SrcK8S_Namespace", "SrcAddr", "SrcK8S_HostName", "DstK8S_Name", "DstK8S_Type", "DstK8S_OwnerName", "DstK8S_OwnerType", "DstK8S_Namespace", "DstAddr", "DstK8S_HostName"}
 	}
 
 	if len(groups) > 0 {
 		if strings.Contains(groups, "hosts") {
-			if !utils.Contains(fields, "SrcK8S_HostIP") {
-				fields = append(fields, "SrcK8S_HostIP", "DstK8S_HostIP")
+			if !utils.Contains(fields, "SrcK8S_HostName") {
+				fields = append(fields, "SrcK8S_HostName", "DstK8S_HostName")
 			}
 		}
 

--- a/pkg/model/fields/fields.go
+++ b/pkg/model/fields/fields.go
@@ -27,6 +27,9 @@ const (
 	HostIP        = "K8S_HostIP"
 	SrcHostIP     = Src + HostIP
 	DstHostIP     = Dst + HostIP
+	HostName      = "K8S_HostName"
+	SrcHostName   = Src + HostName
+	DstHostName   = Dst + HostName
 	Packets       = "Packets"
 	Proto         = "Proto"
 	Bytes         = "Bytes"

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -254,7 +254,7 @@ func TestLokiConfigurationForTopology(t *testing.T) {
 
 	// THEN the query has been properly forwarded to Loki
 	req := lokiMock.Calls[0].Arguments[1].(*http.Request)
-	assert.Equal(t, `topk(100,sum by(SrcK8S_Name,SrcK8S_Type,SrcK8S_OwnerName,SrcK8S_OwnerType,SrcK8S_Namespace,SrcAddr,SrcK8S_HostIP,DstK8S_Name,DstK8S_Type,DstK8S_OwnerName,DstK8S_OwnerType,DstK8S_Namespace,DstAddr,DstK8S_HostIP) (sum_over_time({app="netobserv-flowcollector"}|json|unwrap Bytes|__error__=""[300s])))`, req.URL.Query().Get("query"))
+	assert.Equal(t, `topk(100,sum by(SrcK8S_Name,SrcK8S_Type,SrcK8S_OwnerName,SrcK8S_OwnerType,SrcK8S_Namespace,SrcAddr,SrcK8S_HostName,DstK8S_Name,DstK8S_Type,DstK8S_OwnerName,DstK8S_OwnerType,DstK8S_Namespace,DstAddr,DstK8S_HostName) (sum_over_time({app="netobserv-flowcollector"}|json|unwrap Bytes|__error__=""[300s])))`, req.URL.Query().Get("query"))
 	// without any multi-tenancy header
 	assert.Empty(t, req.Header.Get("X-Scope-OrgID"))
 

--- a/web/locales/en/plugin__network-observability-plugin.json
+++ b/web/locales/en/plugin__network-observability-plugin.json
@@ -157,6 +157,7 @@
   "Owner Kinds": "Owner Kinds",
   "Ports": "Ports",
   "Node IP": "Node IP",
+  "Node Name": "Node Name",
   "Kubernetes Objects": "Kubernetes Objects",
   "Owner Kubernetes Objects": "Owner Kubernetes Objects",
   "IPs & Ports": "IPs & Ports",

--- a/web/src/api/ipfix.ts
+++ b/web/src/api/ipfix.ts
@@ -32,6 +32,8 @@ export interface Fields {
   DstK8S_OwnerType?: string;
   SrcK8S_HostIP?: string;
   DstK8S_HostIP?: string;
+  SrcK8S_HostName?: string;
+  DstK8S_HostName?: string;
   Packets: number;
   Proto: number;
   Bytes: number;

--- a/web/src/api/loki.ts
+++ b/web/src/api/loki.ts
@@ -48,14 +48,14 @@ export interface TopologyMetric {
   DstK8S_OwnerName: string;
   DstK8S_OwnerType: string;
   DstK8S_Type: string;
-  DstK8S_HostIP: string;
+  DstK8S_HostName: string;
   SrcAddr: string;
   SrcK8S_Name: string;
   SrcK8S_Namespace: string;
   SrcK8S_OwnerName: string;
   SrcK8S_OwnerType: string;
   SrcK8S_Type: string;
-  SrcK8S_HostIP: string;
+  SrcK8S_HostName: string;
 }
 
 export interface TopologyMetrics {

--- a/web/src/components/filters/__tests__/text-filter.spec.tsx
+++ b/web/src/components/filters/__tests__/text-filter.spec.tsx
@@ -83,7 +83,7 @@ describe('<TextFilter />', () => {
   });
 
   it('should not filter invalid IP', done => {
-    const wrapper = mount(<TextFilter {...props} filterDefinition={findFilter(t, 'dst_host')!} />);
+    const wrapper = mount(<TextFilter {...props} filterDefinition={findFilter(t, 'dst_host_address')!} />);
     const textInput = wrapper.find(TextInput).at(0);
     const searchButton = wrapper.find('#search-button').at(0);
 

--- a/web/src/components/netflow-record/record-field.tsx
+++ b/web/src/components/netflow-record/record-field.tsx
@@ -76,19 +76,19 @@ export const RecordField: React.FC<{
   const explicitKubeObjContent = (ip: string, port: number, kind?: string, namespace?: string, name?: string) => {
     // Note: namespace is not mandatory here (e.g. Node objects)
     if (name && kind) {
-      return doubleContainer(kubeObjContent(name, kind, namespace), namespaceContent(namespace), false);
+      return doubleContainer(kubeObjContent(name, kind, namespace), kindContent('Namespace', namespace), false);
     } else {
       return ipPortContent(ip, port);
     }
   };
 
-  const namespaceContent = (value?: string) => {
+  const kindContent = (kind: 'Namespace' | 'Node', value?: string) => {
     if (value) {
       return (
         <div className="force-truncate">
-          <ResourceLink className={size} inline={true} kind="Namespace" name={value} />
+          <ResourceLink className={size} inline={true} kind={kind} name={value} />
           <div className="record-field-tooltip">
-            <h4>{t('Namespace')}</h4>
+            <h4>{t(kind)}</h4>
             <span>{value}</span>
           </div>
         </div>
@@ -259,12 +259,21 @@ export const RecordField: React.FC<{
         );
       case ColumnsId.namespace:
         return doubleContainer(
-          namespaceContent(flow.labels.SrcK8S_Namespace),
-          namespaceContent(flow.labels.DstK8S_Namespace)
+          kindContent('Namespace', flow.labels.SrcK8S_Namespace),
+          kindContent('Namespace', flow.labels.DstK8S_Namespace)
         );
       case ColumnsId.srcnamespace:
       case ColumnsId.dstnamespace: {
-        return singleContainer(namespaceContent(value as string));
+        return singleContainer(kindContent('Namespace', value as string));
+      }
+      case ColumnsId.hostname:
+        return doubleContainer(
+          kindContent('Node', flow.fields.SrcK8S_HostName),
+          kindContent('Node', flow.fields.DstK8S_HostName)
+        );
+      case ColumnsId.srchostname:
+      case ColumnsId.dsthostname: {
+        return singleContainer(kindContent('Node', value as string));
       }
       case ColumnsId.port:
         return doubleContainer(

--- a/web/src/components/netflow-record/record-panel.tsx
+++ b/web/src/components/netflow-record/record-panel.tsx
@@ -132,7 +132,28 @@ export const RecordPanel: React.FC<RecordDrawerProps> = ({
     [t, filters, setFilters]
   );
 
-  const groups = getColumnGroups(columns);
+  const groups = getColumnGroups(
+    columns.filter(
+      c =>
+        //remove empty / duplicates columns for Node
+        (record?.fields.SrcK8S_Type !== 'Node' ||
+          ![
+            ColumnsId.srcnamespace,
+            ColumnsId.srcowner,
+            ColumnsId.srcownertype,
+            ColumnsId.srchostaddr,
+            ColumnsId.srchostname
+          ].includes(c.id)) &&
+        (record?.fields.DstK8S_Type !== 'Node' ||
+          ![
+            ColumnsId.dstnamespace,
+            ColumnsId.dstowner,
+            ColumnsId.dstownertype,
+            ColumnsId.dsthostaddr,
+            ColumnsId.dsthostname
+          ].includes(c.id))
+    )
+  );
   return (
     <DrawerPanelContent id={id} isResizable defaultSize={defaultSize} minSize={minSize} maxSize={maxSize}>
       <DrawerHead>

--- a/web/src/components/netflow-topology/element-panel.tsx
+++ b/web/src/components/netflow-topology/element-panel.tsx
@@ -146,10 +146,10 @@ export const ElementPanelContent: React.FC<{
       function getName(m: TopologyMetrics) {
         switch (options.scope) {
           case TopologyScopes.HOST:
-            const srcNode = m.metric.SrcK8S_HostIP ? m.metric.SrcK8S_HostIP : t('External');
-            const dstNode = m.metric.DstK8S_HostIP ? m.metric.DstK8S_HostIP : t('External');
+            const srcNode = m.metric.SrcK8S_HostName ? m.metric.SrcK8S_HostName : t('External');
+            const dstNode = m.metric.DstK8S_HostName ? m.metric.DstK8S_HostName : t('External');
             return nodeData?.host
-              ? m.metric.SrcK8S_HostIP === nodeData.host
+              ? m.metric.SrcK8S_HostName === nodeData.host
                 ? `${t('To')} ${dstNode}`
                 : `${t('From')} ${srcNode}`
               : `${srcNode} -> ${dstNode}`;
@@ -325,7 +325,7 @@ export const ElementPanelContent: React.FC<{
             dstCount += m.total;
           }
         } else if (data.type === 'Node') {
-          if (m.metric.SrcK8S_HostIP === data.name) {
+          if (m.metric.SrcK8S_HostName === data.name) {
             srcCount += m.total;
           } else {
             dstCount += m.total;
@@ -369,8 +369,8 @@ export const ElementPanelContent: React.FC<{
       switch (options.scope) {
         case TopologyScopes.HOST:
           return (
-            (m.metric.SrcK8S_HostIP === srcData.host && m.metric.DstK8S_HostIP === tgtData.host) ||
-            (m.metric.SrcK8S_HostIP === tgtData.host && m.metric.DstK8S_HostIP === srcData.host)
+            (m.metric.SrcK8S_HostName === srcData.host && m.metric.DstK8S_HostName === tgtData.host) ||
+            (m.metric.SrcK8S_HostName === tgtData.host && m.metric.DstK8S_HostName === srcData.host)
           );
         case TopologyScopes.NAMESPACE:
           return (
@@ -392,7 +392,7 @@ export const ElementPanelContent: React.FC<{
     });
     edgeMetrics.forEach(m => {
       if (
-        (options.scope === TopologyScopes.HOST && m.metric.SrcK8S_HostIP === srcData.host) ||
+        (options.scope === TopologyScopes.HOST && m.metric.SrcK8S_HostName === srcData.host) ||
         m.metric.SrcAddr === srcData.addr
       ) {
         srcCount += m.total;

--- a/web/src/components/netflow-topology/element-panel.tsx
+++ b/web/src/components/netflow-topology/element-panel.tsx
@@ -293,7 +293,7 @@ export const ElementPanelContent: React.FC<{
                 return matchExclusively(m, 'Namespace', data.name);
               case 'Node':
                 //host must match exclusively Source OR Destination
-                return matchExclusively(m, 'HostIP', data.name);
+                return matchExclusively(m, 'HostName', data.name);
               default:
                 //fallback on Owners match exclusively Source OR Destination
                 return matchExclusively(m, 'OwnerName', data.name);
@@ -306,7 +306,7 @@ export const ElementPanelContent: React.FC<{
                 return matchExclusively(m, 'Namespace', data.namespace);
               case TopologyScopes.HOST:
                 //host must match exclusively Source OR Destination
-                return matchExclusively(m, 'HostIP', data.host);
+                return matchExclusively(m, 'HostName', data.host);
               case TopologyScopes.OWNER:
                 //owner must match exclusively Source OR Destination
                 return matchExclusively(m, 'OwnerName', data.name);

--- a/web/src/components/netflow-topology/netflow-topology.tsx
+++ b/web/src/components/netflow-topology/netflow-topology.tsx
@@ -170,7 +170,7 @@ const TopologyContent: React.FC<{
         def = findFilter(t, 'resource')!;
         value = `${data.type}.${data.namespace}.${data.name}`;
       } else if (data.type === 'Node' && data.host) {
-        def = findFilter(t, 'host')!;
+        def = findFilter(t, 'host_name')!;
         value = data.host;
       } else if (data.type === 'Namespace' && data.namespace) {
         def = findFilter(t, 'namespace')!;

--- a/web/src/model/filters.ts
+++ b/web/src/model/filters.ts
@@ -42,9 +42,12 @@ export type FilterId =
   | 'port'
   | 'src_port'
   | 'dst_port'
-  | 'host'
-  | 'src_host'
-  | 'dst_host'
+  | 'host_address'
+  | 'src_host_address'
+  | 'dst_host_address'
+  | 'host_name'
+  | 'src_host_name'
+  | 'dst_host_name'
   | 'protocol';
 
 export interface FilterDefinition {

--- a/web/src/model/topology.ts
+++ b/web/src/model/topology.ts
@@ -379,8 +379,10 @@ export const generateDataModel = (
     const namespace = m[`${prefix}K8S_Namespace`];
     const ownerType = m[`${prefix}K8S_OwnerType`];
     const ownerName = m[`${prefix}K8S_OwnerName`];
-    //TODO: enrich Host Name to use ResourceLink in element-panel
-    const host = m[`${prefix}K8S_HostIP`];
+    const host = m[`${prefix}K8S_HostName`];
+    const type = m[`${prefix}K8S_Type`];
+    const name = m[`${prefix}K8S_Name`];
+    const addr = m[`${prefix}Addr`];
 
     const hostGroup =
       [TopologyGroupTypes.HOSTS_NAMESPACES, TopologyGroupTypes.HOSTS_OWNERS, TopologyGroupTypes.HOSTS].includes(
@@ -444,9 +446,9 @@ export const generateDataModel = (
         return addNode(
           {
             namespace,
-            type: m[`${prefix}K8S_Type`],
-            name: m[`${prefix}K8S_Name`],
-            addr: m[`${prefix}Addr`],
+            type,
+            name,
+            addr,
             host
           },
           parent

--- a/web/src/utils/columns.ts
+++ b/web/src/utils/columns.ts
@@ -44,12 +44,16 @@ export enum ColumnsId {
   srcownerkubeobject = 'SrcK8S_OwnerObject',
   dstownerkubeobject = 'DstK8S_OwnerObject',
   host = 'K8S_HostIP',
-  srchost = 'SrcK8S_HostIP',
-  dsthost = 'DstK8S_HostIP',
-  flowdir = 'FlowDirection',
   duration = 'FlowDuration',
   collectiontime = 'CollectionTime',
-  collectionlatency = 'CollectionLatency'
+  collectionlatency = 'CollectionLatency',
+  hostaddr = 'K8S_HostIP',
+  srchostaddr = 'SrcK8S_HostIP',
+  dsthostaddr = 'DstK8S_HostIP',
+  hostname = 'K8S_HostName',
+  srchostname = 'SrcK8S_HostName',
+  dsthostname = 'DstK8S_HostName',
+  flowdir = 'FlowDirection'
 }
 
 export interface Column {
@@ -209,12 +213,20 @@ export const getCommonColumns = (t: TFunction, withConcatenatedFields = true): C
       width: 10
     },
     {
-      id: ColumnsId.host,
+      id: ColumnsId.hostaddr,
       name: t('Node IP'),
       isSelected: false,
       value: f => getSrcOrDstValue(f.fields.SrcK8S_HostIP, f.fields.DstK8S_HostIP),
       sort: (a, b, col) => compareIPs((col.value(a) as string[]).join(''), (col.value(b) as string[]).join('')),
       width: 10
+    },
+    {
+      id: ColumnsId.hostname,
+      name: t('Node Name'),
+      isSelected: false,
+      value: f => getSrcOrDstValue(f.fields.SrcK8S_HostName, f.fields.DstK8S_HostName),
+      sort: (a, b, col) => compareStrings((col.value(a) as string[]).join(''), (col.value(b) as string[]).join('')),
+      width: 15
     }
   ];
 
@@ -364,15 +376,26 @@ export const getSrcColumns = (t: TFunction): Column[] => {
       width: 10
     },
     {
-      id: ColumnsId.srchost,
+      id: ColumnsId.srchostaddr,
       group: t('Source'),
       name: t('Node IP'),
       fieldName: 'SrcK8S_HostIP',
-      quickFilter: 'src_host',
+      quickFilter: 'src_host_address',
       isSelected: false,
       value: f => f.fields.SrcK8S_HostIP || '',
       sort: (a, b, col) => compareIPs(col.value(a) as string, col.value(b) as string),
       width: 10
+    },
+    {
+      id: ColumnsId.srchostname,
+      group: t('Source'),
+      name: t('Node Name'),
+      fieldName: 'SrcK8S_HostName',
+      quickFilter: 'src_host_name',
+      isSelected: false,
+      value: f => f.fields.SrcK8S_HostName || '',
+      sort: (a, b, col) => compareStrings(col.value(a) as string, col.value(b) as string),
+      width: 15
     }
   ];
 };
@@ -457,15 +480,26 @@ export const getDstColumns = (t: TFunction): Column[] => {
       width: 10
     },
     {
-      id: ColumnsId.dsthost,
+      id: ColumnsId.dsthostaddr,
       group: t('Destination'),
       name: t('Node IP'),
       fieldName: 'DstK8S_HostIP',
-      quickFilter: 'dst_host',
+      quickFilter: 'dst_host_address',
       isSelected: false,
       value: f => f.fields.DstK8S_HostIP || '',
       sort: (a, b, col) => compareIPs(col.value(a) as string, col.value(b) as string),
       width: 10
+    },
+    {
+      id: ColumnsId.dsthostname,
+      group: t('Destination'),
+      name: t('Node Name'),
+      fieldName: 'DstK8S_HostName',
+      quickFilter: 'dst_host_name',
+      isSelected: false,
+      value: f => f.fields.DstK8S_HostName || '',
+      sort: (a, b, col) => compareStrings(col.value(a) as string, col.value(b) as string),
+      width: 15
     }
   ];
 };

--- a/web/src/utils/filter-definitions.ts
+++ b/web/src/utils/filter-definitions.ts
@@ -300,7 +300,7 @@ export const getFilterDefinitions = (t: TFunction): FilterDefinition[] => {
       ),
       ...peers(
         {
-          id: 'host',
+          id: 'host_address',
           name: t('Node IP'),
           component: FilterComponent.Text,
           category: FilterCategory.Common,
@@ -317,6 +317,21 @@ export const getFilterDefinitions = (t: TFunction): FilterDefinition[] => {
         },
         singleFieldMapping('SrcK8S_HostIP'),
         singleFieldMapping('DstK8S_HostIP')
+      ),
+      ...peers(
+        {
+          id: 'host_name',
+          name: t('Node Name'),
+          component: FilterComponent.Text,
+          category: FilterCategory.Common,
+          getOptions: noOption,
+          validate: k8sNameValidation,
+          hint: k8sNameHint,
+          examples: k8sNameExamples,
+          fieldMatching: {}
+        },
+        singleFieldMapping('SrcK8S_HostName'),
+        singleFieldMapping('DstK8S_HostName')
       ),
       {
         id: 'protocol',


### PR DESCRIPTION
You will up to date [flowlogs-pipeline](https://github.com/netobserv/flowlogs-pipeline) to get `K8S_HostName` fields.

This PR adds `Node Name`:
- Columns
- Filters
- Replaced Node IP by names in topology

![image](https://user-images.githubusercontent.com/91894519/166221773-818cbccd-a053-4b62-8e03-e0d08aa895b4.png)


Also removed empty / duplicated fields on side panel when a `Node` is selected
![image](https://user-images.githubusercontent.com/91894519/166221406-c0396333-c693-49d6-bfed-fa92fa957c5f.png)
