### PR TITLE
NETOBSERV-219 PoC Operators - skip TLS checks

### DIFF
--- a/cmd/plugin-backend.go
+++ b/cmd/plugin-backend.go
@@ -30,6 +30,7 @@ var (
 	lokiLabels     = flag.String("loki-labels", "SrcK8S_Namespace,SrcK8S_OwnerName,DstK8S_Namespace,DstK8S_OwnerName,FlowDirection", "Loki labels, comma separated")
 	lokiTimeout    = flag.Duration("loki-timeout", 10*time.Second, "Timeout of the Loki query to retrieve logs")
 	lokiTenantID   = flag.String("loki-tenant-id", "", "Tenant organization ID for multi-tenant-loki (submitted as the X-Scope-OrgID HTTP header)")
+	lokiSkipTLS    = flag.Bool("loki-skip-tls", false, "Skip TLS checks for loki HTTPS connection")
 	logLevel       = flag.String("loglevel", "info", "log level (default: info)")
 	frontendConfig = flag.String("frontend-config", "", "path to the console plugin config file")
 	versionFlag    = flag.Bool("v", false, "print version")
@@ -72,7 +73,7 @@ func main() {
 		CORSAllowMethods: *corsMethods,
 		CORSAllowHeaders: *corsHeaders,
 		CORSMaxAge:       *corsMaxAge,
-		Loki:             loki.NewConfig(lURL, *lokiTimeout, *lokiTenantID, strings.Split(lLabels, ",")),
+		Loki:             loki.NewConfig(lURL, *lokiTimeout, *lokiTenantID, *lokiSkipTLS, strings.Split(lLabels, ",")),
 		FrontendConfig:   *frontendConfig,
 	})
 }

--- a/pkg/handler/loki.go
+++ b/pkg/handler/loki.go
@@ -29,7 +29,7 @@ func newLokiClient(cfg *loki.Config) httpclient.Caller {
 		}
 	}
 	// TODO: loki with auth
-	return httpclient.NewHTTPClient(cfg.Timeout, headers)
+	return httpclient.NewHTTPClient(cfg.Timeout, headers, cfg.SkipTLS)
 }
 
 /* loki query will fail if spaces or quotes are not encoded

--- a/pkg/httpclient/http_client.go
+++ b/pkg/httpclient/http_client.go
@@ -6,6 +6,8 @@ import (
 	"net"
 	"net/http"
 	"time"
+
+	"github.com/sirupsen/logrus"
 )
 
 type Caller interface {
@@ -18,6 +20,8 @@ type httpClient struct {
 	headers map[string][]string
 }
 
+var slog = logrus.WithField("module", "server")
+
 func NewHTTPClient(timeout time.Duration, overrideHeaders map[string][]string, skipTLS bool) Caller {
 	transport := &http.Transport{
 		DialContext:     (&net.Dialer{Timeout: timeout}).DialContext,
@@ -27,6 +31,7 @@ func NewHTTPClient(timeout time.Duration, overrideHeaders map[string][]string, s
 	//TODO: add loki tls config https://issues.redhat.com/browse/NETOBSERV-309
 	if skipTLS {
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		slog.Warn("skipping TLS checks. SSL certificate verification is now disabled !")
 	}
 
 	return &httpClient{

--- a/pkg/httpclient/http_client.go
+++ b/pkg/httpclient/http_client.go
@@ -1,6 +1,7 @@
 package httpclient
 
 import (
+	"crypto/tls"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -17,10 +18,15 @@ type httpClient struct {
 	headers map[string][]string
 }
 
-func NewHTTPClient(timeout time.Duration, overrideHeaders map[string][]string) Caller {
+func NewHTTPClient(timeout time.Duration, overrideHeaders map[string][]string, skipTLS bool) Caller {
 	transport := &http.Transport{
 		DialContext:     (&net.Dialer{Timeout: timeout}).DialContext,
 		IdleConnTimeout: timeout,
+	}
+
+	//TODO: add loki tls config https://issues.redhat.com/browse/NETOBSERV-309
+	if skipTLS {
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}
 
 	return &httpClient{

--- a/pkg/loki/config.go
+++ b/pkg/loki/config.go
@@ -11,14 +11,16 @@ type Config struct {
 	URL      *url.URL
 	Timeout  time.Duration
 	TenantID string
+	SkipTLS  bool
 	Labels   map[string]struct{}
 }
 
-func NewConfig(url *url.URL, timeout time.Duration, tenantID string, labels []string) Config {
+func NewConfig(url *url.URL, timeout time.Duration, tenantID string, skipTLS bool, labels []string) Config {
 	return Config{
 		URL:      url,
 		Timeout:  timeout,
 		TenantID: tenantID,
+		SkipTLS:  skipTLS,
 		Labels:   utils.GetMapInterface(labels),
 	}
 }

--- a/pkg/loki/query_test.go
+++ b/pkg/loki/query_test.go
@@ -12,7 +12,7 @@ import (
 func TestFlowQuery_AddLabelFilters(t *testing.T) {
 	lokiURL, err := url.Parse("/")
 	require.NoError(t, err)
-	cfg := NewConfig(lokiURL, time.Second, "", []string{"foo", "flis"})
+	cfg := NewConfig(lokiURL, time.Second, "", false, []string{"foo", "flis"})
 	query := NewFlowQueryBuilderWithDefaults(&cfg)
 	err = query.AddFilter("foo", `"bar"`)
 	require.NoError(t, err)
@@ -25,7 +25,7 @@ func TestFlowQuery_AddLabelFilters(t *testing.T) {
 func TestQuery_BackQuote_Error(t *testing.T) {
 	lokiURL, err := url.Parse("/")
 	require.NoError(t, err)
-	cfg := NewConfig(lokiURL, time.Second, "", []string{"lab1", "lab2"})
+	cfg := NewConfig(lokiURL, time.Second, "", false, []string{"lab1", "lab2"})
 	query := NewFlowQueryBuilderWithDefaults(&cfg)
 	assert.Error(t, query.AddFilter("key", "backquoted`val"))
 }

--- a/pkg/server/server_flows_test.go
+++ b/pkg/server/server_flows_test.go
@@ -181,6 +181,7 @@ func TestLokiFiltering(t *testing.T) {
 			lokiURL,
 			time.Second,
 			"",
+			false,
 			[]string{"SrcK8S_Namespace", "SrcK8S_OwnerName", "DstK8S_Namespace", "DstK8S_OwnerName", "FlowDirection"},
 		),
 	})


### PR DESCRIPTION
Skip TLS checks until https://issues.redhat.com/browse/NETOBSERV-309 implementation

This will be usefull for https://github.com/netobserv/network-observability-operator/pull/59 since Loki Operator uses its own certificates
![image](https://user-images.githubusercontent.com/91894519/166656008-4404a69c-f5fa-4043-8ba7-0ed5599fffe1.png)
