### PR TITLE
NETOBSERV-289 Sort by Date & time by default

### DIFF
--- a/web/src/components/netflow-table/__tests__/netflow-table.spec.tsx
+++ b/web/src/components/netflow-table/__tests__/netflow-table.spec.tsx
@@ -66,19 +66,27 @@ describe('<NetflowTable />', () => {
     const flows = FlowsSample.slice(0, FlowsSample.length);
     const wrapper = mount(<NetflowTable flows={flows} columns={ShuffledDefaultColumns} {...mocks} />);
     expect(wrapper.find(NetflowTable)).toBeTruthy();
+
+    const timestampIdx = ShuffledDefaultColumns.findIndex(c => c.id === ColumnsId.endtime);
+    let expectedDate = new Date(FlowsSample[2].fields.TimeFlowEnd * 1000);
+    // table should be sorted by date asc by default
+    expect(wrapper.find(NetflowTableRow).find(Td).at(timestampIdx).find('.datetime').at(0).text()).toBe(
+      expectedDate.toDateString() + ' ' + expectedDate.toLocaleTimeString()
+    );
+
     const button = wrapper.findWhere(node => {
       return node.type() === 'button' && node.text() === 'End Time';
     });
-    const timestampIdx = ShuffledDefaultColumns.findIndex(c => c.id === ColumnsId.endtime);
     button.simulate('click');
-    const expectedDate = new Date(FlowsSample[2].fields.TimeFlowEnd * 1000);
-    const expectedDateText = expectedDate.toDateString() + ' ' + expectedDate.toLocaleTimeString();
+    expectedDate = new Date(FlowsSample[1].fields.TimeFlowEnd * 1000);
+    // then should sort date desc on click
     expect(wrapper.find(NetflowTableRow).find(Td).at(timestampIdx).find('.datetime').at(0).text()).toBe(
-      expectedDateText
+      expectedDate.toDateString() + ' ' + expectedDate.toLocaleTimeString()
     );
-    const expectedSrcAddress = FlowsSample[2].fields.SrcAddr;
+
+    const expectedSrcAddress = FlowsSample[1].fields.SrcAddr;
     expect(wrapper.find(NetflowTableRow).at(0).text()).toContain(expectedSrcAddress);
-    const expectedDstAddress = FlowsSample[2].fields.DstAddr;
+    const expectedDstAddress = FlowsSample[1].fields.DstAddr;
     expect(wrapper.find(NetflowTableRow).at(0).text()).toContain(expectedDstAddress);
   });
   it('should render a spinning slide and then the netflow rows', async () => {

--- a/web/src/components/netflow-table/netflow-table.tsx
+++ b/web/src/components/netflow-table/netflow-table.tsx
@@ -17,7 +17,7 @@ import * as _ from 'lodash';
 import { Record } from '../../api/ipfix';
 import { NetflowTableHeader } from './netflow-table-header';
 import NetflowTableRow from './netflow-table-row';
-import { Column } from '../../utils/columns';
+import { Column, ColumnsId } from '../../utils/columns';
 import { Size } from '../dropdowns/display-dropdown';
 import { usePrevious } from '../../utils/previous-hook';
 import './netflow-table.css';
@@ -55,6 +55,13 @@ const NetflowTable: React.FC<{
       return;
     }
   }, [flows]);
+
+  //reset sort index & directions to default on columns update
+  React.useEffect(() => {
+    const endTimeColumn = columns.find(c => c.id === ColumnsId.endtime);
+    setActiveSortIndex(endTimeColumn ? columns.indexOf(endTimeColumn) : -1);
+    setActiveSortDirection('asc');
+  }, [columns]);
 
   //get row height from display size
   //these values match netflow-table.css and record-field.css


### PR DESCRIPTION
This PR will sort table by `ColumnsId.endtime` if available. 

![image](https://user-images.githubusercontent.com/91894519/166703141-9a406807-5dcd-46f7-b5ad-b9f13f4a2247.png)

Sorting is also reset when selected columns are updated.