### PR TITLE
NETOBSERV-290 Preserve settings in NetFlow table

### DIFF
--- a/web/src/components/modals/export-modal.tsx
+++ b/web/src/components/modals/export-modal.tsx
@@ -27,6 +27,7 @@ import { formatDuration, getDateSInMiliseconds } from '../../utils/duration';
 import { Filter } from '../../model/filters';
 import { getFilterFullName } from '../filters/filters-helper';
 import './export-modal.css';
+import { LOCAL_STORAGE_EXPORT_COLS_KEY, useLocalStorage } from '../../utils/local-storage-hook';
 
 export interface ExportModalProps {
   isModalOpen: boolean;
@@ -48,11 +49,21 @@ export const ExportModal: React.FC<ExportModalProps> = ({
   filters
 }) => {
   const { t } = useTranslation('plugin__network-observability-plugin');
-  const [selectedColumns, setSelectedColumns] = React.useState<Column[]>([]);
+  const [selectedColumns, setSelectedColumns] = useLocalStorage<Column[]>(
+    LOCAL_STORAGE_EXPORT_COLS_KEY,
+    //select all columns by default
+    columns.map(c => ({ ...c, isSelected: true })),
+    {
+      id: 'id',
+      criteria: 'isSelected'
+    }
+  );
   const [isSaveDisabled, setSaveDisabled] = React.useState<boolean>(true);
-
   const [isAllSelected, setAllSelected] = React.useState<boolean>(false);
-  const [isExportAll, setExportAll] = React.useState<boolean>(true);
+  const [isExportAll, setExportAll] = React.useState<boolean>(
+    //show columns details if not all columns are selected
+    selectedColumns.filter(c => c.isSelected).length === columns.length
+  );
   const options = getTimeRangeOptions(t);
 
   const getFieldNames = React.useCallback(() => {
@@ -96,10 +107,6 @@ export const ExportModal: React.FC<ExportModalProps> = ({
     });
     setSelectedColumns(result);
   }, [selectedColumns, setSelectedColumns, isAllSelected]);
-
-  React.useEffect(() => {
-    setSelectedColumns(_.cloneDeep(columns));
-  }, [columns]);
 
   React.useEffect(() => {
     let allSelected = true;

--- a/web/src/components/netflow-table/__tests__/netflow-table-header.spec.tsx
+++ b/web/src/components/netflow-table/__tests__/netflow-table-header.spec.tsx
@@ -1,4 +1,4 @@
-import { OnSort, TableComposable, Tbody, Th, Thead, Tr } from '@patternfly/react-table';
+import { SortByDirection, TableComposable, Tbody, Th, Thead, Tr } from '@patternfly/react-table';
 import { mount } from 'enzyme';
 import * as React from 'react';
 import { Column, ColumnsId } from '../../../utils/columns';
@@ -6,17 +6,17 @@ import { AllSelectedColumns, DefaultColumns, filterOrderedColumnsByIds } from '.
 import { NetflowTableHeader } from '../netflow-table-header';
 
 const NetflowTableHeaderWrapper: React.FC<{
-  onSort: OnSort;
-  sortIndex: number;
-  sortDirection: string;
+  onSort: (id: ColumnsId, direction: SortByDirection) => void;
+  sortId: ColumnsId;
+  sortDirection: SortByDirection;
   columns: Column[];
-}> = ({ onSort, sortIndex, sortDirection, columns }) => {
+}> = ({ onSort, sortId, sortDirection, columns }) => {
   return (
     <TableComposable aria-label="Misc table" variant="compact">
       <NetflowTableHeader
         onSort={onSort}
         sortDirection={sortDirection}
-        sortIndex={sortIndex}
+        sortId={sortId}
         columns={columns}
         tableWidth={100}
       />
@@ -28,8 +28,8 @@ const NetflowTableHeaderWrapper: React.FC<{
 describe('<NetflowTableHeader />', () => {
   const mocks = {
     onSort: jest.fn(),
-    sortIndex: 0,
-    sortDirection: 'asc',
+    sortId: ColumnsId.endtime,
+    sortDirection: SortByDirection.asc,
     tableWidth: 100
   };
   it('should render component', async () => {
@@ -51,7 +51,7 @@ describe('<NetflowTableHeader />', () => {
     const wrapper = mount(<NetflowTableHeaderWrapper {...mocks} columns={DefaultColumns} />);
     expect(wrapper.find(NetflowTableHeader)).toBeTruthy();
     wrapper.find('button').at(0).simulate('click');
-    expect(mocks.onSort).toHaveBeenCalledWith(expect.anything(), 0, 'desc', expect.anything());
+    expect(mocks.onSort).toHaveBeenCalledWith('StartTime', 'asc');
   });
   it('should nested consecutive group columns', async () => {
     const selectedIds = [ColumnsId.endtime, ColumnsId.srcname, ColumnsId.srcport, ColumnsId.dstname, ColumnsId.packets];

--- a/web/src/components/netflow-table/__tests__/netflow-table.spec.tsx
+++ b/web/src/components/netflow-table/__tests__/netflow-table.spec.tsx
@@ -66,19 +66,27 @@ describe('<NetflowTable />', () => {
     const flows = FlowsSample.slice(0, FlowsSample.length);
     const wrapper = mount(<NetflowTable flows={flows} columns={ShuffledDefaultColumns} {...mocks} />);
     expect(wrapper.find(NetflowTable)).toBeTruthy();
+
+    const timestampIdx = ShuffledDefaultColumns.findIndex(c => c.id === ColumnsId.endtime);
+    let expectedDate = new Date(FlowsSample[2].fields.TimeFlowEnd * 1000);
+    // table should be sorted by date asc by default
+    expect(wrapper.find(NetflowTableRow).find(Td).at(timestampIdx).find('.datetime').at(0).text()).toBe(
+      expectedDate.toDateString() + ' ' + expectedDate.toLocaleTimeString()
+    );
+
     const button = wrapper.findWhere(node => {
       return node.type() === 'button' && node.text() === 'End Time';
     });
-    const timestampIdx = ShuffledDefaultColumns.findIndex(c => c.id === ColumnsId.endtime);
     button.simulate('click');
-    const expectedDate = new Date(FlowsSample[2].fields.TimeFlowEnd * 1000);
-    const expectedDateText = expectedDate.toDateString() + ' ' + expectedDate.toLocaleTimeString();
+    expectedDate = new Date(FlowsSample[1].fields.TimeFlowEnd * 1000);
+    // then should sort date desc on click
     expect(wrapper.find(NetflowTableRow).find(Td).at(timestampIdx).find('.datetime').at(0).text()).toBe(
-      expectedDateText
+      expectedDate.toDateString() + ' ' + expectedDate.toLocaleTimeString()
     );
-    const expectedSrcAddress = FlowsSample[2].fields.SrcAddr;
+
+    const expectedSrcAddress = FlowsSample[1].fields.SrcAddr;
     expect(wrapper.find(NetflowTableRow).at(0).text()).toContain(expectedSrcAddress);
-    const expectedDstAddress = FlowsSample[2].fields.DstAddr;
+    const expectedDstAddress = FlowsSample[1].fields.DstAddr;
     expect(wrapper.find(NetflowTableRow).at(0).text()).toContain(expectedDstAddress);
   });
   it('should render a spinning slide and then the netflow rows', async () => {

--- a/web/src/components/netflow-table/netflow-table-header.tsx
+++ b/web/src/components/netflow-table/netflow-table-header.tsx
@@ -41,14 +41,13 @@ export const NetflowTableHeader: React.FC<{
     (c: Column) => {
       const showBorder =
         headersState.useNested && headersState.nestedHeaders.find(nh => _.last(nh.columns) === c) !== undefined;
-      const found = columns.find(c => c.id === sortId);
       return (
         <Th
           hasRightBorder={showBorder}
           key={c.id}
           sort={{
             sortBy: {
-              index: found ? columns.indexOf(found) : -1,
+              index: columns.findIndex(c => c.id === sortId),
               direction: SortByDirection[sortDirection as SortByDirection]
             },
             onSort: (event, index, direction) => onSort(c.id, direction),

--- a/web/src/components/netflow-table/netflow-table-header.tsx
+++ b/web/src/components/netflow-table/netflow-table-header.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { OnSort, SortByDirection, Th, Thead, Tr } from '@patternfly/react-table';
+import { SortByDirection, Th, Thead, Tr } from '@patternfly/react-table';
 import _ from 'lodash';
-import { Column, ColumnGroup, getColumnGroups, getFullColumnName } from '../../utils/columns';
+import { Column, ColumnGroup, ColumnsId, getColumnGroups, getFullColumnName } from '../../utils/columns';
 
 export type HeadersState = {
   nestedHeaders: ColumnGroup[];
@@ -10,12 +10,12 @@ export type HeadersState = {
 };
 
 export const NetflowTableHeader: React.FC<{
-  onSort: OnSort;
-  sortIndex: number;
-  sortDirection: string;
+  onSort: (id: ColumnsId, direction: SortByDirection) => void;
+  sortId: ColumnsId;
+  sortDirection: SortByDirection;
   columns: Column[];
   tableWidth: number;
-}> = ({ onSort, sortIndex, sortDirection, columns, tableWidth }) => {
+}> = ({ onSort, sortId, sortDirection, columns, tableWidth }) => {
   const [headersState, setHeadersState] = React.useState<HeadersState>({
     nestedHeaders: [],
     useNested: false,
@@ -41,16 +41,17 @@ export const NetflowTableHeader: React.FC<{
     (c: Column) => {
       const showBorder =
         headersState.useNested && headersState.nestedHeaders.find(nh => _.last(nh.columns) === c) !== undefined;
+      const found = columns.find(c => c.id === sortId);
       return (
         <Th
           hasRightBorder={showBorder}
           key={c.id}
           sort={{
             sortBy: {
-              index: sortIndex,
+              index: found ? columns.indexOf(found) : -1,
               direction: SortByDirection[sortDirection as SortByDirection]
             },
-            onSort: onSort,
+            onSort: (event, index, direction) => onSort(c.id, direction),
             columnIndex: columns.indexOf(c)
           }}
           modifier="wrap"
@@ -61,7 +62,7 @@ export const NetflowTableHeader: React.FC<{
         </Th>
       );
     },
-    [columns, headersState.nestedHeaders, headersState.useNested, onSort, sortDirection, sortIndex, tableWidth]
+    [columns, headersState.nestedHeaders, headersState.useNested, onSort, sortDirection, sortId, tableWidth]
   );
 
   React.useEffect(() => {

--- a/web/src/components/netflow-table/netflow-table.tsx
+++ b/web/src/components/netflow-table/netflow-table.tsx
@@ -17,7 +17,7 @@ import * as _ from 'lodash';
 import { Record } from '../../api/ipfix';
 import { NetflowTableHeader } from './netflow-table-header';
 import NetflowTableRow from './netflow-table-row';
-import { Column } from '../../utils/columns';
+import { Column, ColumnsId } from '../../utils/columns';
 import { Size } from '../dropdowns/display-dropdown';
 import { usePrevious } from '../../utils/previous-hook';
 import './netflow-table.css';
@@ -55,6 +55,13 @@ const NetflowTable: React.FC<{
       return;
     }
   }, [flows]);
+
+  //reset sort index & directions to default on columns update
+  React.useEffect(() => {
+    const endTimeColumn = columns.find(c => c.id === ColumnsId.endtime);
+    setActiveSortIndex(endTimeColumn ? columns.indexOf(endTimeColumn) : -1);
+    setActiveSortDirection('asc');
+  }, [columns]);
 
   //get row height from display size
   //these values match netflow-table.css and record-field.css

--- a/web/src/components/netflow-traffic.tsx
+++ b/web/src/components/netflow-traffic.tsx
@@ -37,8 +37,12 @@ import { getHTTPErrorDetails } from '../utils/errors';
 import { Filter } from '../model/filters';
 import {
   LOCAL_STORAGE_COLS_KEY,
+  LOCAL_STORAGE_QUERY_PARAMS_KEY,
   LOCAL_STORAGE_REFRESH_KEY,
   LOCAL_STORAGE_SIZE_KEY,
+  LOCAL_STORAGE_TOPOLOGY_LAYOUT_KEY,
+  LOCAL_STORAGE_TOPOLOGY_OPTIONS_KEY,
+  LOCAL_STORAGE_VIEW_ID_KEY,
   useLocalStorage
 } from '../utils/local-storage-hook';
 import { usePoll } from '../utils/poll-hook';
@@ -72,7 +76,7 @@ import { RecordPanel } from './netflow-record/record-panel';
 import NetflowTable from './netflow-table/netflow-table';
 import NetflowTopology from './netflow-topology/netflow-topology';
 import OptionsPanel from './netflow-topology/options-panel';
-import { netflowTrafficPath, removeURLParam, URLParam } from '../utils/url';
+import { getURLParams, hasEmptyParams, netflowTrafficPath, removeURLParam, setURLParams, URLParam } from '../utils/url';
 import { loadConfig } from '../utils/config';
 import SummaryPanel from './query-summary/summary-panel';
 import { GraphElement } from '@patternfly/react-topology';
@@ -92,12 +96,20 @@ export const NetflowTraffic: React.FC<{
   const { push } = useHistory();
   const { t } = useTranslation('plugin__network-observability-plugin');
   const [extensions] = useResolvedExtensions<ModelFeatureFlag>(isModelFeatureFlag);
+  const [queryParams, setQueryParams] = useLocalStorage<string>(LOCAL_STORAGE_QUERY_PARAMS_KEY);
+  // set url params from local storage saved items at startup if empty
+  if (hasEmptyParams() && queryParams) {
+    setURLParams(queryParams);
+  }
 
   const [loading, setLoading] = React.useState(true);
   const [flows, setFlows] = React.useState<Record[]>([]);
   const [stats, setStats] = React.useState<Stats | undefined>(undefined);
-  const [layout, setLayout] = React.useState<LayoutName>(LayoutName.ColaNoForce);
-  const [topologyOptions, setTopologyOptions] = React.useState<TopologyOptions>(DefaultOptions);
+  const [layout, setLayout] = useLocalStorage<LayoutName>(LOCAL_STORAGE_TOPOLOGY_LAYOUT_KEY, LayoutName.ColaNoForce);
+  const [topologyOptions, setTopologyOptions] = useLocalStorage<TopologyOptions>(
+    LOCAL_STORAGE_TOPOLOGY_OPTIONS_KEY,
+    DefaultOptions
+  );
   const [metrics, setMetrics] = React.useState<TopologyMetrics[]>([]);
   const [isShowTopologyOptions, setShowTopologyOptions] = React.useState<boolean>(false);
   const [isShowQuerySummary, setShowQuerySummary] = React.useState<boolean>(false);
@@ -107,7 +119,7 @@ export const NetflowTraffic: React.FC<{
   const [isColModalOpen, setColModalOpen] = React.useState(false);
   const [isExportModalOpen, setExportModalOpen] = React.useState(false);
   //TODO: move default view to an Overview like dashboard instead of table
-  const [selectedViewId, setSelectedViewId] = React.useState<ViewId>('table');
+  const [selectedViewId, setSelectedViewId] = useLocalStorage<ViewId>(LOCAL_STORAGE_VIEW_ID_KEY, 'table');
   const [filters, setFilters] = React.useState<Filter[]>([]);
   const [match, setMatch] = React.useState<Match>(getMatchFromURL());
   const [reporter, setReporter] = React.useState<Reporter>(getReporterFromURL());
@@ -268,10 +280,15 @@ export const NetflowTraffic: React.FC<{
     } else if (!metricType) {
       setMetricType(defaultMetricType);
     }
-  }, [metricFunction, metricType]);
-  React.useEffect(() => {
     setURLMetricType(metricType);
-  }, [metricType]);
+  }, [metricFunction, metricType]);
+
+  // update local storage saved query params
+  React.useEffect(() => {
+    if (!forcedFilters) {
+      setQueryParams(getURLParams().toString());
+    }
+  }, [filters, range, limit, match, reporter, metricFunction, metricType, setQueryParams, forcedFilters]);
 
   // updates table filters and clears up the table for proper visualization of the
   // updating process

--- a/web/src/utils/local-storage-hook.ts
+++ b/web/src/utils/local-storage-hook.ts
@@ -3,8 +3,15 @@ import * as React from 'react';
 
 export const LOCAL_STORAGE_PLUGIN_KEY = 'network-observability-plugin-settings';
 export const LOCAL_STORAGE_COLS_KEY = 'netflow-traffic-columns';
+export const LOCAL_STORAGE_EXPORT_COLS_KEY = 'netflow-traffic-export-columns';
 export const LOCAL_STORAGE_REFRESH_KEY = 'netflow-traffic-refresh';
-export const LOCAL_STORAGE_SIZE_KEY = 'netflow-traffic-size';
+export const LOCAL_STORAGE_SIZE_KEY = 'netflow-traffic-size-size';
+export const LOCAL_STORAGE_VIEW_ID_KEY = 'netflow-traffic-view-id';
+export const LOCAL_STORAGE_TOPOLOGY_LAYOUT_KEY = 'netflow-traffic-topology-layout';
+export const LOCAL_STORAGE_TOPOLOGY_OPTIONS_KEY = 'netflow-traffic-topology-options';
+export const LOCAL_STORAGE_QUERY_PARAMS_KEY = 'netflow-traffic-query-params';
+export const LOCAL_STORAGE_SORT_ID_KEY = 'netflow-traffic-sort-id';
+export const LOCAL_STORAGE_SORT_DIRECTION_KEY = 'netflow-traffic-sort-direction';
 
 export interface ArraySelectionOptions {
   id: string;

--- a/web/src/utils/url.ts
+++ b/web/src/utils/url.ts
@@ -1,4 +1,5 @@
 import { createBrowserHistory } from 'history';
+import _ from 'lodash';
 
 export const netflowTrafficPath = '/netflow-traffic';
 
@@ -19,16 +20,29 @@ export type URLParams = { [k in URLParam]?: unknown };
 
 export const history = createBrowserHistory();
 
+export const hasEmptyParams = () => {
+  return _.isEmpty(window.location.search);
+};
+
+export const getURLParams = () => {
+  return new URLSearchParams(window.location.search);
+};
+
 export const getURLParam = (arg: URLParam) => {
-  return new URLSearchParams(window.location.search).get(arg);
+  return getURLParams().get(arg);
 };
 
 export const getURLParamAsNumber = (arg: URLParam) => {
-  const q = new URLSearchParams(window.location.search).get(arg);
+  const q = getURLParam(arg);
   if (q && !isNaN(Number(q))) {
     return Number(q);
   }
   return null;
+};
+
+export const setURLParams = (params: string) => {
+  const url = new URL(window.location.href);
+  history.push(`${url.pathname}?${params}${url.hash}`);
 };
 
 export const setURLParam = (param: URLParam, value: string) => {
@@ -47,6 +61,6 @@ export const removeURLParam = (param: URLParam) => {
   }
 };
 
-export const getPathWithParams = (pathName: string) => {
+export const getPathWithParams = (pathName = '') => {
   return `${pathName}?${new URLSearchParams(window.location.search).toString()}`;
 };


### PR DESCRIPTION
Either wait for https://github.com/netobserv/network-observability-console-plugin/pull/148 or close it (already included here).
Also https://github.com/netobserv/network-observability-console-plugin/pull/131 will be impacted since topology display has been merged into options.

This PR adds missing parameters to local storage and restore them when page is loaded.

```
{
  "netflow-traffic-query-params": "filters=resource%3DPod.openshift-operator-lifecycle-manager.olm-operator-55d596d44-qhlxn&timeRange=300&limit=100&match=all&reporter=destination&function=sum&type=bytes",
  "netflow-traffic-sort-id": "EndTime",
  "netflow-traffic-sort-direction": "asc",
  "netflow-traffic-columns": [
    "EndTime",
    "SrcK8S_Type",
    "SrcPort"
  ],
  "netflow-traffic-size-size": "m",
  "netflow-traffic-view-id": "topology"
}
```

URL query parameters are also restored when the page is opened without parameters / forced filters.