### PR TITLE
NETOBSERV-298 Custom time range forgets the seconds

### DIFF
--- a/web/src/components/modals/__tests__/time-range-modal.spec.tsx
+++ b/web/src/components/modals/__tests__/time-range-modal.spec.tsx
@@ -40,9 +40,10 @@ describe('<ColumnsModal />', () => {
     //set start date & time and press button
     act(() => {
       datePickers.at(0).props().onChange!('2021-12-01', new Date('2021-12-01'));
-      timePickers.at(0).props().onChange!('10:15');
+      // set hours minutes and seconds
+      timePickers.at(0).props().onChange!('10:15:30');
     });
-    nowRange.from = new Date('2021-12-01').setHours(10, 15, 0, 0) / 1000;
+    nowRange.from = new Date('2021-12-01').setHours(10, 15, 30, 0) / 1000;
 
     wrapper.find('.pf-c-button.pf-m-primary').at(0).simulate('click');
     expect(props.setRange).toHaveBeenNthCalledWith(2, nowRange);
@@ -50,6 +51,7 @@ describe('<ColumnsModal />', () => {
     //set end date & time and press button
     act(() => {
       datePickers.at(1).props().onChange!('2021-12-15', new Date('2021-12-15'));
+      // set only hours and minutes, seconds should be automatically set to 0
       timePickers.at(1).props().onChange!('23:00');
     });
     nowRange.to = new Date('2021-12-15').setHours(23, 0, 0, 0) / 1000;

--- a/web/src/components/modals/time-range-modal.tsx
+++ b/web/src/components/modals/time-range-modal.tsx
@@ -26,6 +26,10 @@ export interface TimeRangeModalProps {
   id?: string;
 }
 
+//keep displayed values separated. These will be set at startup to avoid TimePicker to loose value on every render
+let displayedFromTime: string | undefined;
+let displayedToTime: string | undefined;
+
 export const TimeRangeModal: React.FC<TimeRangeModalProps> = ({ id, isModalOpen, setModalOpen, range, setRange }) => {
   const { t } = useTranslation();
   const [error, setError] = React.useState<string | undefined>();
@@ -58,9 +62,9 @@ export const TimeRangeModal: React.FC<TimeRangeModalProps> = ({ id, isModalOpen,
     }
 
     setFromDate(toISODateString(from));
-    setFromTime(twentyFourHourTime(from));
+    setFromTime(twentyFourHourTime(from, true));
     setToDate(toISODateString(to));
-    setToTime(twentyFourHourTime(to));
+    setToTime(twentyFourHourTime(to, true));
   }, [range]);
 
   const onCancel = React.useCallback(() => {
@@ -69,6 +73,9 @@ export const TimeRangeModal: React.FC<TimeRangeModalProps> = ({ id, isModalOpen,
   }, [resetInputs, setModalOpen]);
 
   const onSave = React.useCallback(() => {
+    //update time inputs
+    displayedFromTime = fromTime;
+    displayedToTime = toTime;
     const from = getDateMsInSeconds(Date.parse(`${fromDate} ${fromTime}`));
     const to = getDateMsInSeconds(Date.parse(`${toDate} ${toTime}`));
     setRange({ from, to });
@@ -92,6 +99,16 @@ export const TimeRangeModal: React.FC<TimeRangeModalProps> = ({ id, isModalOpen,
   React.useEffect(() => {
     resetInputs();
   }, [range, resetInputs]);
+
+  //set display values
+  React.useEffect(() => {
+    if (!displayedFromTime) {
+      displayedFromTime = fromTime;
+    }
+    if (!displayedToTime) {
+      displayedToTime = toTime;
+    }
+  }, [fromTime, toTime]);
 
   return (
     <Modal
@@ -135,7 +152,13 @@ export const TimeRangeModal: React.FC<TimeRangeModalProps> = ({ id, isModalOpen,
               />
             </FlexItem>
             <FlexItem>
-              <TimePicker is24Hour onChange={setFromTime} time={fromTime} />
+              <TimePicker
+                is24Hour
+                includeSeconds
+                placeholder="hh:mm:ss"
+                onChange={setFromTime}
+                time={displayedFromTime}
+              />
             </FlexItem>
           </Flex>
         </FlexItem>
@@ -151,7 +174,7 @@ export const TimeRangeModal: React.FC<TimeRangeModalProps> = ({ id, isModalOpen,
               />
             </FlexItem>
             <FlexItem>
-              <TimePicker is24Hour onChange={setToTime} time={toTime} />
+              <TimePicker is24Hour includeSeconds placeholder="hh:mm:ss" onChange={setToTime} time={displayedToTime} />
             </FlexItem>
           </Flex>
         </FlexItem>


### PR DESCRIPTION
This PR add seconds to time pickers in custom time range modal

Seconds are not mandatory and will be set to 00 if not specified (as same as minutes)

It also fix a refresh issue while typing from keyboard

![image](https://user-images.githubusercontent.com/91894519/167798515-664793ec-3c42-4765-b8d4-d9ca2c5d099e.png)
