### PR TITLE
NETOBSERV-290 fix tick race issues

### DIFF
--- a/web/src/components/__tests__/netflow-traffic.spec.tsx
+++ b/web/src/components/__tests__/netflow-traffic.spec.tsx
@@ -37,14 +37,12 @@ describe('<NetflowTraffic />', () => {
 
   it('should refresh on button click', async () => {
     const wrapper = mount(<NetflowTrafficParent />);
-    //should show flows at first load
-    expect(getFlowsMock).toHaveBeenCalledTimes(1);
     act(() => {
       //should have called getFlow twice after click
       wrapper.find('#refresh-button').at(0).simulate('click');
     });
     await waitFor(() => {
-      expect(getFlowsMock).toHaveBeenCalledTimes(2);
+      expect(getFlowsMock).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/web/src/components/netflow-traffic.tsx
+++ b/web/src/components/netflow-traffic.tsx
@@ -150,7 +150,7 @@ export const NetflowTraffic: React.FC<{
   React.useEffect(() => {
     // Init state from URL
     if (!forcedFilters) {
-      getFiltersFromURL(t)?.then(setFilters);
+      getFiltersFromURL(t)?.then(updateTableFilters);
     }
     // disabling exhaustive-deps: tests hang when "t" passed as dependency (useTranslation not stable?)
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/web/src/utils/poll-hook.ts
+++ b/web/src/utils/poll-hook.ts
@@ -14,8 +14,6 @@ export const usePoll = (callback: () => void, delay?: number, dependencies?: Rea
   useEffect(() => {
     const tick = () => (savedCallback?.current ? savedCallback.current() : null);
 
-    tick(); // Run first tick immediately.
-
     if (delay) {
       // Only start interval if a delay is provided.
       const id = setInterval(tick, delay);


### PR DESCRIPTION
This PR fix `tick` race issue found by @memodi. 
It seems that `jest` behavior has changed but I'm open to any suggestion