### PR TITLE
NETOBSERV-344 Can't click on node info from popup

### DIFF
--- a/web/src/components/netflow-topology/components/node.tsx
+++ b/web/src/components/netflow-topology/components/node.tsx
@@ -136,7 +136,7 @@ const BaseNode: React.FC<BaseNodeProps> = ({
   const [hovered, hoverRef] = useHover();
   const status = element.getNodeStatus();
   const { width, height } = element.getDimensions();
-  const isHover = hover !== undefined ? hover : hovered;
+  const isHover = hovered || hover;
 
   const statusDecorator = React.useMemo(() => {
     if (!status || !showStatusDecorator) {
@@ -215,7 +215,7 @@ const BaseNode: React.FC<BaseNodeProps> = ({
   }
 
   return (
-    <Layer id={dragging || hover || highlighted ? TOP_LAYER : undefined}>
+    <Layer id={dragging || isHover || highlighted ? TOP_LAYER : undefined}>
       <g ref={hoverRef as React.LegacyRef<SVGGElement> | undefined} className={groupClassName}>
         <NodeShadows />
         <g ref={dragNodeRef} onClick={onSelect} onContextMenu={onContextMenu}>
@@ -257,7 +257,7 @@ const BaseNode: React.FC<BaseNodeProps> = ({
           {children}
         </g>
         {statusDecorator}
-        {hovered && attachments}
+        {isHover && attachments}
       </g>
     </Layer>
   );

--- a/web/src/components/netflow-topology/netflow-topology.tsx
+++ b/web/src/components/netflow-topology/netflow-topology.tsx
@@ -16,6 +16,7 @@ import {
   defaultControlButtonsOptions,
   GraphElement,
   GRAPH_LAYOUT_END_EVENT,
+  GRAPH_POSITION_CHANGE_EVENT,
   Model,
   Node,
   SelectionEventListener,
@@ -278,6 +279,16 @@ const TopologyContent: React.FC<{
     }
   }, [fitView, options.layout]);
 
+  const onLayoutPositionChange = React.useCallback(() => {
+    if (controller && controller.hasGraph()) {
+      //hide popovers on pan / zoom
+      const popover = document.querySelector('[aria-labelledby="popover-decorator-header"]');
+      if (popover) {
+        (popover as HTMLElement).style.display = 'none';
+      }
+    }
+  }, [controller]);
+
   //get options with updated time range and max edge value
   const getOptions = React.useCallback(() => {
     let rangeInSeconds: number;
@@ -413,6 +424,7 @@ const TopologyContent: React.FC<{
   useEventListener(STEP_INTO_EVENT, onStepInto);
   useEventListener(HOVER_EVENT, onHover);
   useEventListener(GRAPH_LAYOUT_END_EVENT, onLayoutEnd);
+  useEventListener(GRAPH_POSITION_CHANGE_EVENT, onLayoutPositionChange);
 
   return (
     <TopologyView

--- a/web/src/components/netflow-topology/styles/styleNode.tsx
+++ b/web/src/components/netflow-topology/styles/styleNode.tsx
@@ -131,7 +131,20 @@ const renderPopoverDecorator = (
   return (
     (data.type || data.namespace || data.name || data.addr || data.host) && (
       <Popover
+        id="decorator"
         hideOnOutsideClick={true}
+        onShow={() => {
+          element.setData({
+            ...element.getData(),
+            hover: true //force hover state when popover is opened
+          });
+        }}
+        onHide={() => {
+          element.setData({
+            ...element.getData(),
+            hover: undefined //restore hover state when popover is closed
+          });
+        }}
         hasAutoWidth
         headerContent={
           data.type && data.name && data.namespace ? (

--- a/web/src/model/topology.ts
+++ b/web/src/model/topology.ts
@@ -460,7 +460,7 @@ export const generateDataModel = (
     const srcNode = manageNode('Src', d);
     const dstNode = manageNode('Dst', d);
 
-    if (options.edges && srcNode && dstNode) {
+    if (options.edges && srcNode && dstNode && srcNode.id !== dstNode.id) {
       addEdge(srcNode.id, dstNode.id, d.total, srcNode.data.shadowed || dstNode.data.shadowed);
     }
   });


### PR DESCRIPTION
This PR fix `Popovers` hiding too fast on topology:
- fixed hover state
- added and event to hide opened popover on pan / zoom
- fixed edges with same source / destination making hover blinking in some situations

You can now select `text` / click on `ResourceLink` in the Popover