### PR TITLE
NETOBSERV-361 Fix time range url issue

### DIFF
--- a/web/src/utils/router.ts
+++ b/web/src/utils/router.ts
@@ -82,9 +82,12 @@ export const setURLFilters = (filters: Filter[]) => {
 export const setURLRange = (range: number | TimeRange) => {
   if (typeof range === 'number') {
     setURLParam(URLParam.TimeRange, String(range));
+    removeURLParam(URLParam.StartTime);
+    removeURLParam(URLParam.EndTime);
   } else if (typeof range === 'object') {
     setURLParam(URLParam.StartTime, String(range.from));
     setURLParam(URLParam.EndTime, String(range.to));
+    removeURLParam(URLParam.TimeRange);
   }
 };
 


### PR DESCRIPTION
Currently we can have both `TimeRange` / `StartTime` and `EndTime` parameters in the url. This should not be allowed.