### PR TITLE
NETOBSERV-363 Bidirectional edges doesn't work anymore

### DIFF
--- a/web/src/components/netflow-topology/element-panel.tsx
+++ b/web/src/components/netflow-topology/element-panel.tsx
@@ -202,7 +202,7 @@ export const ElementPanelContent: React.FC<{
             const srcNamespace = m.metric.SrcK8S_Namespace ? m.metric.SrcK8S_Namespace : t('Unknown');
             const dstNamespace = m.metric.DstK8S_Namespace ? m.metric.DstK8S_Namespace : t('Unknown');
             return nodeData?.namespace
-              ? m.metric.SrcK8S_Namespace === nodeData.namespace
+              ? m.metric.SrcK8S_Namespace === nodeData.name
                 ? `${t('To')} ${dstNamespace}`
                 : `${t('From')} ${srcNamespace}`
               : `${srcNamespace} -> ${dstNamespace}`;
@@ -419,8 +419,8 @@ export const ElementPanelContent: React.FC<{
           );
         case TopologyScopes.NAMESPACE:
           return (
-            (m.metric.SrcK8S_Namespace === srcData.namespace && m.metric.DstK8S_Namespace === tgtData.namespace) ||
-            (m.metric.SrcK8S_Namespace === tgtData.namespace && m.metric.DstK8S_Namespace === srcData.namespace)
+            (m.metric.SrcK8S_Namespace === srcData.name && m.metric.DstK8S_Namespace === tgtData.name) ||
+            (m.metric.SrcK8S_Namespace === tgtData.name && m.metric.DstK8S_Namespace === srcData.name)
           );
         case TopologyScopes.OWNER:
           return (

--- a/web/src/model/topology.ts
+++ b/web/src/model/topology.ts
@@ -441,6 +441,8 @@ export const generateDataModel = (
       edge.data = {
         ...edge.data,
         shadowed,
+        //edges are directed from src to dst. It will become bidirectionnal if inverted pair is found
+        startTerminalType: edge.data.sourceId !== sourceId ? EdgeTerminalType.directional : edge.data.startTerminalType,
         tag: getEdgeTag(totalCount, options),
         tagStatus: getTagStatus(totalCount, options.maxEdgeValue),
         count: totalCount


### PR DESCRIPTION
Fix bidirectionnal edges in topology view

This was broken since refresh model changes in https://issues.redhat.com/browse/NETOBSERV-293