### PR TITLE
NETOBSERV-326 data-test attributes

### DIFF
--- a/web/src/components/dropdowns/display-dropdown.tsx
+++ b/web/src/components/dropdowns/display-dropdown.tsx
@@ -23,10 +23,11 @@ export const DisplayDropdown: React.FC<Props> = ({ id, setSize }) => {
 
   return (
     <Dropdown
+      data-test={id}
       id={id}
       isPlain
       dropdownItems={_.map(sizeOptions, (name, key) => (
-        <DropdownItem id={key} component="button" key={key} onClick={() => setSize(key as Size)}>
+        <DropdownItem data-test={key} id={key} component="button" key={key} onClick={() => setSize(key as Size)}>
           {name}
         </DropdownItem>
       ))}
@@ -34,6 +35,7 @@ export const DisplayDropdown: React.FC<Props> = ({ id, setSize }) => {
       onSelect={() => setIsOpen(false)}
       toggle={
         <DropdownToggle
+          data-test={`${id}-dropdown`}
           id={`${id}-dropdown`}
           className="overflow-button"
           icon={<ThIcon />}

--- a/web/src/components/dropdowns/group-dropdown.tsx
+++ b/web/src/components/dropdowns/group-dropdown.tsx
@@ -61,10 +61,12 @@ export const GroupDropdown: React.FC<{
 
   return (
     <Dropdown
+      data-test={id}
       id={id}
       position={DropdownPosition.right}
       toggle={
         <DropdownToggle
+          data-test={`${id}-dropdown`}
           id={`${id}-dropdown`}
           isDisabled={disabled}
           onToggle={() => setGroupDropdownOpen(!groupDropdownOpen)}
@@ -75,6 +77,7 @@ export const GroupDropdown: React.FC<{
       isOpen={groupDropdownOpen}
       dropdownItems={getAvailableGroups().map(v => (
         <DropdownItem
+          data-test={v}
           id={v}
           key={v}
           onClick={() => {

--- a/web/src/components/dropdowns/layout-dropdown.tsx
+++ b/web/src/components/dropdowns/layout-dropdown.tsx
@@ -32,16 +32,22 @@ export const LayoutDropdown: React.FC<{
 
   return (
     <Dropdown
+      data-test={id}
       id={id}
       position={DropdownPosition.right}
       toggle={
-        <DropdownToggle id={`${id}-dropdown`} onToggle={() => setLayoutDropdownOpen(!layoutDropdownOpen)}>
+        <DropdownToggle
+          data-test={`${id}-dropdown`}
+          id={`${id}-dropdown`}
+          onToggle={() => setLayoutDropdownOpen(!layoutDropdownOpen)}
+        >
           {getLayoutDisplay(selected)}
         </DropdownToggle>
       }
       isOpen={layoutDropdownOpen}
       dropdownItems={Object.values(LayoutName).map(v => (
         <DropdownItem
+          data-test={v}
           id={v}
           key={v}
           onClick={() => {

--- a/web/src/components/dropdowns/metric-function-dropdown.tsx
+++ b/web/src/components/dropdowns/metric-function-dropdown.tsx
@@ -28,16 +28,22 @@ export const MetricFunctionDropdown: React.FC<{
 
   return (
     <Dropdown
+      data-test={id}
       id={id}
       position={DropdownPosition.right}
       toggle={
-        <DropdownToggle id={`${id}-dropdown`} onToggle={() => setMetricDropdownOpen(!metricDropdownOpen)}>
+        <DropdownToggle
+          data-test={`${id}-dropdown`}
+          id={`${id}-dropdown`}
+          onToggle={() => setMetricDropdownOpen(!metricDropdownOpen)}
+        >
           {getMetricDisplay(selected)}
         </DropdownToggle>
       }
       isOpen={metricDropdownOpen}
       dropdownItems={Object.values(TopologyMetricFunctions).map(v => (
         <DropdownItem
+          data-test={v}
           id={v}
           key={v}
           onClick={() => {

--- a/web/src/components/dropdowns/metric-type-dropdown.tsx
+++ b/web/src/components/dropdowns/metric-type-dropdown.tsx
@@ -24,16 +24,22 @@ export const MetricTypeDropdown: React.FC<{
 
   return (
     <Dropdown
+      data-test={id}
       id={id}
       position={DropdownPosition.right}
       toggle={
-        <DropdownToggle id={`${id}-dropdown`} onToggle={() => setMetricDropdownOpen(!metricDropdownOpen)}>
+        <DropdownToggle
+          data-test={`${id}-dropdown`}
+          id={`${id}-dropdown`}
+          onToggle={() => setMetricDropdownOpen(!metricDropdownOpen)}
+        >
           {getMetricDisplay(selected)}
         </DropdownToggle>
       }
       isOpen={metricDropdownOpen}
       dropdownItems={Object.values(TopologyMetricTypes).map(v => (
         <DropdownItem
+          data-test={v}
           id={v}
           key={v}
           onClick={() => {

--- a/web/src/components/dropdowns/query-options-dropdown.tsx
+++ b/web/src/components/dropdowns/query-options-dropdown.tsx
@@ -86,6 +86,7 @@ export const QueryOptionsPanel: React.FC<QueryOptionsDropdownProps> = ({
                     name={`reporter-${opt.value}`}
                     onChange={() => setReporter(opt.value)}
                     label={opt.label}
+                    data-test={`reporter-${opt.value}`}
                     id={`reporter-${opt.value}`}
                     value={opt.value}
                   />
@@ -116,6 +117,7 @@ export const QueryOptionsPanel: React.FC<QueryOptionsDropdownProps> = ({
                 name={`match-${opt.value}`}
                 onChange={() => setMatch(opt.value)}
                 label={opt.label}
+                data-test={`match-${opt.value}`}
                 id={`match-${opt.value}`}
                 value={opt.value}
               />
@@ -140,6 +142,7 @@ export const QueryOptionsPanel: React.FC<QueryOptionsDropdownProps> = ({
           <div key={'limit-' + l}>
             <label className="pf-c-select__menu-item">
               <Radio
+                data-test={'limit-' + l}
                 id={'limit-' + l}
                 name={'limit-' + l}
                 isChecked={l === limit}
@@ -159,8 +162,9 @@ export const QueryOptionsDropdown: React.FC<QueryOptionsDropdownProps> = props =
   const { t } = useTranslation('plugin__network-observability-plugin');
   const [isOpen, setOpen] = React.useState<boolean>(false);
   return (
-    <div data-test-id="query-options-dropdown-container">
+    <div data-test="query-options-dropdown-container">
       <Select
+        data-test="query-options-dropdown"
         id="query-options-dropdown"
         placeholderText={<span>{t('Query Options')}</span>}
         isOpen={isOpen}

--- a/web/src/components/dropdowns/refresh-dropdown.tsx
+++ b/web/src/components/dropdowns/refresh-dropdown.tsx
@@ -46,16 +46,22 @@ export const RefreshDropdown: React.FC<RefreshDropdownProps> = ({ disabled, id, 
 
   return (
     <Dropdown
+      data-test={id}
       id={id}
       dropdownItems={_.map(refreshOptions, (name, key) => (
-        <DropdownItem id={key} component="button" key={key} onClick={() => onChange(key)}>
+        <DropdownItem data-test={key} id={key} component="button" key={key} onClick={() => onChange(key)}>
           {name}
         </DropdownItem>
       ))}
       isOpen={isOpen}
       onSelect={() => setIsOpen(false)}
       toggle={
-        <DropdownToggle id={`${id}-dropdown`} isDisabled={disabled} onToggle={() => setIsOpen(!isOpen)}>
+        <DropdownToggle
+          data-test={`${id}-dropdown`}
+          id={`${id}-dropdown`}
+          isDisabled={disabled}
+          onToggle={() => setIsOpen(!isOpen)}
+        >
           {refreshOptions[selectedKey as keyof typeof refreshOptions]}
         </DropdownToggle>
       }

--- a/web/src/components/dropdowns/scope-dropdown.tsx
+++ b/web/src/components/dropdowns/scope-dropdown.tsx
@@ -26,16 +26,22 @@ export const ScopeDropdown: React.FC<{
 
   return (
     <Dropdown
+      data-test={id}
       id={id}
       position={DropdownPosition.right}
       toggle={
-        <DropdownToggle id={`${id}-dropdown`} onToggle={() => setScopeDropdownOpen(!scopeDropdownOpen)}>
+        <DropdownToggle
+          data-test={`${id}-dropdown`}
+          id={`${id}-dropdown`}
+          onToggle={() => setScopeDropdownOpen(!scopeDropdownOpen)}
+        >
           {getScopeDisplay(selected)}
         </DropdownToggle>
       }
       isOpen={scopeDropdownOpen}
       dropdownItems={Object.values(TopologyScopes).map(v => (
         <DropdownItem
+          data-test={v}
           id={v}
           key={v}
           onClick={() => {

--- a/web/src/components/dropdowns/time-range-dropdown.tsx
+++ b/web/src/components/dropdowns/time-range-dropdown.tsx
@@ -57,9 +57,10 @@ export const TimeRangeDropdown: React.FC<TimeRangeDropdownProps> = ({ id, range,
 
   return (
     <Dropdown
+      data-test={id}
       id={id}
       dropdownItems={_.map(timeRangeOptions, (name, key) => (
-        <DropdownItem id={key} component="button" key={key} onClick={() => onChange(key)}>
+        <DropdownItem data-test={key} id={key} component="button" key={key} onClick={() => onChange(key)}>
           {name}
         </DropdownItem>
       ))}
@@ -71,7 +72,7 @@ export const TimeRangeDropdown: React.FC<TimeRangeDropdownProps> = ({ id, range,
           position="top"
           content={textContent()}
         >
-          <DropdownToggle id={`${id}-dropdown`} onToggle={() => setIsOpen(!isOpen)}>
+          <DropdownToggle data-test={`${id}-dropdown`} id={`${id}-dropdown`} onToggle={() => setIsOpen(!isOpen)}>
             {timeRangeOptions[selectedKey as keyof typeof timeRangeOptions]}
           </DropdownToggle>
         </Tooltip>

--- a/web/src/components/dropdowns/truncate-dropdown.tsx
+++ b/web/src/components/dropdowns/truncate-dropdown.tsx
@@ -30,10 +30,15 @@ export const TruncateDropdown: React.FC<{
 
   return (
     <Dropdown
+      data-test={id}
       id={id}
       position={DropdownPosition.right}
       toggle={
-        <DropdownToggle id={`${id}-dropdown`} onToggle={() => setTruncateDropdownOpen(!truncateDropdownOpen)}>
+        <DropdownToggle
+          data-test={`${id}-dropdown`}
+          id={`${id}-dropdown`}
+          onToggle={() => setTruncateDropdownOpen(!truncateDropdownOpen)}
+        >
           {getTruncateDisplay(selected)}
         </DropdownToggle>
       }
@@ -47,6 +52,7 @@ export const TruncateDropdown: React.FC<{
         TopologyTruncateLength.XL
       ].map((v: TopologyTruncateLength) => (
         <DropdownItem
+          data-test={String(v)}
           id={String(v)}
           key={v}
           onClick={() => {

--- a/web/src/components/filters/autocomplete-filter.tsx
+++ b/web/src/components/filters/autocomplete-filter.tsx
@@ -173,7 +173,7 @@ export const AutocompleteFilter: React.FC<AutocompleteFilterProps> = ({
 
   return (
     <>
-      <div ref={autocompleteContainerRef}>
+      <div data-test="autocomplete-container" ref={autocompleteContainerRef}>
         <Popper
           trigger={
             <TextInput
@@ -186,6 +186,7 @@ export const AutocompleteFilter: React.FC<AutocompleteFilterProps> = ({
               onChange={onAutoCompleteChange}
               onBlur={onBlur}
               ref={searchInputRef}
+              data-test="autocomplete-search"
               id="autocomplete-search"
             />
           }
@@ -194,7 +195,7 @@ export const AutocompleteFilter: React.FC<AutocompleteFilterProps> = ({
               <MenuContent>
                 <MenuList id={optionsMenuID}>
                   {autocompleteOptions.map(option => (
-                    <MenuItem itemId={option.value} key={option.name} onBlur={onBlur}>
+                    <MenuItem data-test={option.value} itemId={option.value} key={option.name} onBlur={onBlur}>
                       {option.name}
                     </MenuItem>
                   ))}
@@ -207,7 +208,13 @@ export const AutocompleteFilter: React.FC<AutocompleteFilterProps> = ({
           appendTo={autocompleteContainerRef.current!}
         />
       </div>
-      <Button id="search-button" variant="control" aria-label="search button for filter" onClick={() => onEnter()}>
+      <Button
+        data-test="search-button"
+        id="search-button"
+        variant="control"
+        aria-label="search button for filter"
+        onClick={() => onEnter()}
+      >
         <SearchIcon />
       </Button>
     </>

--- a/web/src/components/filters/filter-hints.tsx
+++ b/web/src/components/filters/filter-hints.tsx
@@ -13,7 +13,7 @@ export const FilterHints: React.FC<FilterHintsProps> = ({ def }) => {
     return null;
   }
   return (
-    <div id="tips">
+    <div data-test="tips" id="tips">
       <Text component={TextVariants.p}>{def.hint}</Text>
       {def.examples && (
         <Popover
@@ -23,7 +23,7 @@ export const FilterHints: React.FC<FilterHintsProps> = ({ def }) => {
           hasAutoWidth={true}
           position={'bottom'}
         >
-          <Button id="more" variant="link">
+          <Button data-test="more" id="more" variant="link">
             {t('Learn more')}
           </Button>
         </Popover>

--- a/web/src/components/filters/filters-dropdown.tsx
+++ b/web/src/components/filters/filters-dropdown.tsx
@@ -26,12 +26,13 @@ export const FiltersDropdown: React.FC<FiltersDropdownProps> = ({ selectedFilter
 
   const getFiltersDropdownItems = () => {
     return [
-      <Accordion key="accordion">
+      <Accordion data-test="filter-accordion" key="accordion">
         {groups.map((g, i) => (
           <AccordionItem key={`group-${i}`}>
             <AccordionToggle
               onClick={() => setExpandedGroup(expandedGroup !== i ? i : -1)}
               isExpanded={expandedGroup === i}
+              data-test={`group-${i}-toggle`}
               id={`group-${i}-toggle`}
             >
               {g.title && <h1 className="pf-c-dropdown__group-title">{g.title}</h1>}
@@ -39,6 +40,7 @@ export const FiltersDropdown: React.FC<FiltersDropdownProps> = ({ selectedFilter
             <AccordionContent isHidden={expandedGroup !== i}>
               {g.filters.map((f, index) => (
                 <DropdownItem
+                  data-test={f.id}
                   id={f.id}
                   className={`column-filter-item ${g.title ? 'grouped' : ''}`}
                   component="button"
@@ -60,11 +62,16 @@ export const FiltersDropdown: React.FC<FiltersDropdownProps> = ({ selectedFilter
 
   return (
     <Dropdown
+      data-test="column-filter-dropdown"
       id="column-filter-dropdown"
       dropdownItems={getFiltersDropdownItems()}
       isOpen={isSearchFiltersOpen}
       toggle={
-        <DropdownToggle id="column-filter-toggle" onToggle={() => setSearchFiltersOpen(!isSearchFiltersOpen)}>
+        <DropdownToggle
+          data-test="column-filter-toggle"
+          id="column-filter-toggle"
+          onToggle={() => setSearchFiltersOpen(!isSearchFiltersOpen)}
+        >
           {getFilterFullName(selectedFilter, t)}
         </DropdownToggle>
       }

--- a/web/src/components/filters/filters-toolbar.tsx
+++ b/web/src/components/filters/filters-toolbar.tsx
@@ -119,6 +119,7 @@ export const FiltersToolbar: React.FC<FiltersToolbarProps> = ({
 
   return (
     <Toolbar
+      data-test={id}
       id={id}
       clearAllFilters={() => {
         clearFilters();
@@ -126,7 +127,7 @@ export const FiltersToolbar: React.FC<FiltersToolbarProps> = ({
       }}
       clearFiltersButtonText={hasFilterValues() ? t('Clear all filters') : ''}
     >
-      <ToolbarContent id={`${id}-search-filters`} toolbarId={id}>
+      <ToolbarContent data-test={`${id}-search-filters`} id={`${id}-search-filters`} toolbarId={id}>
         <ToolbarItem className="flex-start">
           <QueryOptionsDropdown {...props.queryOptionsProps} />
         </ToolbarItem>
@@ -195,7 +196,7 @@ export const FiltersToolbar: React.FC<FiltersToolbarProps> = ({
             </ToolbarFilter>
           ))
         ) : (
-          <ToolbarGroup id="forced-filters" variant="filter-group">
+          <ToolbarGroup data-test="forced-filters" id="forced-filters" variant="filter-group">
             <ToolbarItem className="flex-start">
               {forcedFilters &&
                 forcedFilters.map((forcedFilter, ffIndex) => (

--- a/web/src/components/modals/columns-modal.tsx
+++ b/web/src/components/modals/columns-modal.tsx
@@ -102,6 +102,7 @@ export const ColumnsModal: React.FC<{
         key={'data-list-item-' + i}
         aria-labelledby={'table-column-management-item' + i}
         className="data-list-item"
+        data-test={'data-' + i}
         id={'data-' + i}
       >
         <DataListItemRow key={'data-list-item-row-' + i}>
@@ -128,6 +129,7 @@ export const ColumnsModal: React.FC<{
 
   return (
     <Modal
+      data-test={id}
       id={id}
       title={t('Manage columns')}
       isOpen={isModalOpen}
@@ -146,14 +148,20 @@ export const ColumnsModal: React.FC<{
       }
       footer={
         <div className="footer">
-          <Button key="reset" variant="link" onClick={() => onReset()}>
+          <Button data-test="columns-reset-button" key="reset" variant="link" onClick={() => onReset()}>
             {t('Restore default columns')}
           </Button>
-          <Button key="cancel" variant="link" onClick={() => setModalOpen(false)}>
+          <Button data-test="columns-cancel-button" key="cancel" variant="link" onClick={() => setModalOpen(false)}>
             {t('Cancel')}
           </Button>
           <Tooltip content={t('At least one column must be selected')} isVisible={isSaveDisabled}>
-            <Button isDisabled={isSaveDisabled} key="confirm" variant="primary" onClick={() => onSave()}>
+            <Button
+              data-test="columns-save-button"
+              isDisabled={isSaveDisabled}
+              key="confirm"
+              variant="primary"
+              onClick={() => onSave()}
+            >
               {t('Save')}
             </Button>
           </Tooltip>
@@ -163,7 +171,12 @@ export const ColumnsModal: React.FC<{
       <div className="co-m-form-row">
         <DragDrop onDrop={onDrop}>
           <Droppable hasNoWrapper>
-            <DataList aria-label="Table column management" id="table-column-management" isCompact>
+            <DataList
+              aria-label="Table column management"
+              data-test="table-column-management"
+              id="table-column-management"
+              isCompact
+            >
               {draggableItems}
             </DataList>
           </Droppable>

--- a/web/src/components/modals/export-modal.tsx
+++ b/web/src/components/modals/export-modal.tsx
@@ -135,7 +135,7 @@ export const ExportModal: React.FC<ExportModalProps> = ({
           <TextContent>
             <Text component={TextVariants.p}>{t('Following query will be exported as CSV format:')}&nbsp;</Text>
           </TextContent>
-          <div id="export-chips">
+          <div data-test="export-chips" id="export-chips">
             <ChipGroup isClosable={false} categoryName={t('Time Range')}>
               <Chip isReadOnly={true}>{rangeText()}</Chip>
             </ChipGroup>
@@ -159,10 +159,11 @@ export const ExportModal: React.FC<ExportModalProps> = ({
       }
       footer={
         <div className="footer">
-          <Button key="close" variant="link" onClick={() => setModalOpen(false)}>
+          <Button data-test="export-close-button" key="close" variant="link" onClick={() => setModalOpen(false)}>
             {t('Close')}
           </Button>
           <Button
+            data-test="export-button"
             key="confirm"
             isDisabled={isSaveDisabled}
             variant="primary"
@@ -182,6 +183,7 @@ export const ExportModal: React.FC<ExportModalProps> = ({
     >
       <div>
         <Checkbox
+          data-test="export-all"
           id="export-all"
           isChecked={isExportAll}
           onChange={checked => setExportAll(checked)}
@@ -206,6 +208,7 @@ export const ExportModal: React.FC<ExportModalProps> = ({
                       key={'data-list-item-' + i}
                       aria-labelledby={'table-column-management-item' + i}
                       className="data-list-item"
+                      data-test={'data-' + i}
                       id={'data-' + i}
                     >
                       <DataListItemRow key={'data-list-item-row-' + i}>
@@ -213,6 +216,7 @@ export const ExportModal: React.FC<ExportModalProps> = ({
                           <DataListCheck
                             aria-labelledby={'table-column-management-item-' + i}
                             checked={column.isSelected}
+                            data-test={column.id}
                             id={column.id}
                             onChange={onCheck}
                           />

--- a/web/src/components/modals/modal.tsx
+++ b/web/src/components/modals/modal.tsx
@@ -19,6 +19,7 @@ const CustomModal: React.FC<{
 }> = ({ id, scrollable, isOpen, onClose, title, description, children, footer }) => {
   return isOpen ? (
     <Modal
+      data-test={id}
       id={id}
       isOpen={isOpen}
       className={'modal-dialog'}
@@ -27,12 +28,13 @@ const CustomModal: React.FC<{
       overlayClassName="co-overlay"
     >
       <div className="modal-content modal-content--no-inner-scroll">
-        <div className="modal-header">
+        <div data-test={`${id}-header`} className="modal-header">
           <TextContent>
             <Text component={TextVariants.h1}>
               {title}
               {onClose && (
                 <Button
+                  data-test={`${id}-close-button`}
                   className={'co-close-button co-close-button--float-right'}
                   onClick={e => {
                     e.stopPropagation();
@@ -48,9 +50,15 @@ const CustomModal: React.FC<{
           {description && <div className="modal-description">{description}</div>}
         </div>
         {children && (
-          <div className={`${'modal-body'} ${scrollable ? 'scrollable' : 'overflow-visible'}`}>{children}</div>
+          <div data-test={`${id}-body`} className={`${'modal-body'} ${scrollable ? 'scrollable' : 'overflow-visible'}`}>
+            {children}
+          </div>
         )}
-        {footer && <div className="modal-footer">{footer}</div>}
+        {footer && (
+          <div data-test={`${id}-footer`} className="modal-footer">
+            {footer}
+          </div>
+        )}
       </div>
     </Modal>
   ) : (

--- a/web/src/components/modals/time-range-modal.tsx
+++ b/web/src/components/modals/time-range-modal.tsx
@@ -112,6 +112,7 @@ export const TimeRangeModal: React.FC<TimeRangeModalProps> = ({ id, isModalOpen,
 
   return (
     <Modal
+      data-test={id}
       id={id}
       title={t('Custom time range')}
       isOpen={isModalOpen}
@@ -119,7 +120,7 @@ export const TimeRangeModal: React.FC<TimeRangeModalProps> = ({ id, isModalOpen,
       onClose={() => onCancel()}
       footer={
         <div>
-          <Button key="cancel" variant="link" onClick={() => onCancel()}>
+          <Button data-test="time-range-cancel" key="cancel" variant="link" onClick={() => onCancel()}>
             {t('Cancel')}
           </Button>
           <Tooltip
@@ -128,7 +129,13 @@ export const TimeRangeModal: React.FC<TimeRangeModalProps> = ({ id, isModalOpen,
             content={error}
             isVisible={error !== undefined}
           >
-            <Button isDisabled={error !== undefined} key="confirm" variant="primary" onClick={() => onSave()}>
+            <Button
+              data-test="time-range-save"
+              isDisabled={error !== undefined}
+              key="confirm"
+              variant="primary"
+              onClick={() => onSave()}
+            >
               {t('Save')}
             </Button>
           </Tooltip>
@@ -146,6 +153,7 @@ export const TimeRangeModal: React.FC<TimeRangeModalProps> = ({ id, isModalOpen,
           <Flex direction={{ default: 'row' }}>
             <FlexItem>
               <DatePicker
+                data-test="from-date-picker"
                 validators={[date => dateValidator(true, date)]}
                 onChange={str => setFromDate(str)}
                 value={fromDate}
@@ -153,6 +161,7 @@ export const TimeRangeModal: React.FC<TimeRangeModalProps> = ({ id, isModalOpen,
             </FlexItem>
             <FlexItem>
               <TimePicker
+                data-test="from-time-picker"
                 is24Hour
                 includeSeconds
                 placeholder="hh:mm:ss"
@@ -167,6 +176,7 @@ export const TimeRangeModal: React.FC<TimeRangeModalProps> = ({ id, isModalOpen,
           <Flex direction={{ default: 'row' }}>
             <FlexItem>
               <DatePicker
+                data-test="to-date-picker"
                 validators={[date => dateValidator(false, date)]}
                 rangeStart={fromDate ? new Date(Date.parse(fromDate)) : undefined}
                 onChange={str => setToDate(str)}
@@ -174,7 +184,14 @@ export const TimeRangeModal: React.FC<TimeRangeModalProps> = ({ id, isModalOpen,
               />
             </FlexItem>
             <FlexItem>
-              <TimePicker is24Hour includeSeconds placeholder="hh:mm:ss" onChange={setToTime} time={displayedToTime} />
+              <TimePicker
+                data-test="to-time-picker"
+                is24Hour
+                includeSeconds
+                placeholder="hh:mm:ss"
+                onChange={setToTime}
+                time={displayedToTime}
+              />
             </FlexItem>
           </Flex>
         </FlexItem>

--- a/web/src/components/netflow-record/record-field.tsx
+++ b/web/src/components/netflow-record/record-field.tsx
@@ -41,7 +41,7 @@ export const RecordField: React.FC<{
   const simpleTextWithTooltip = (text?: string) => {
     if (text) {
       return (
-        <div>
+        <div data-test={`field-text-${text}`}>
           <span>{text}</span>
           <div className="record-field-tooltip">{text}</div>
         </div>
@@ -54,7 +54,7 @@ export const RecordField: React.FC<{
     // Note: namespace is not mandatory here (e.g. Node objects)
     if (value && kind) {
       return (
-        <div className="force-truncate">
+        <div data-test={`field-resource-${kind}.${ns}.${value}`} className="force-truncate">
           <ResourceLink className={size} inline={true} kind={kind} name={value} namespace={ns} />
           <div className="record-field-tooltip">
             {ns && (
@@ -85,7 +85,7 @@ export const RecordField: React.FC<{
   const kindContent = (kind: 'Namespace' | 'Node', value?: string) => {
     if (value) {
       return (
-        <div className="force-truncate">
+        <div data-test={`field-kind-${kind}.${value}`} className="force-truncate">
           <ResourceLink className={size} inline={true} kind={kind} name={value} />
           <div className="record-field-tooltip">
             <h4>{t(kind)}</h4>
@@ -109,7 +109,7 @@ export const RecordField: React.FC<{
     const dateText = date?.toDateString() || emptyText();
     const timeText = date?.toLocaleTimeString() || emptyText();
     return singleContainer(
-      <div>
+      <div data-test={`field-date-${dateText}-${timeText}`}>
         <div className={`datetime ${size}`}>
           <span>{dateText}</span> <span className="text-muted">{timeText}</span>
         </div>

--- a/web/src/components/netflow-record/record-panel.tsx
+++ b/web/src/components/netflow-record/record-panel.tsx
@@ -156,30 +156,44 @@ export const RecordPanel: React.FC<RecordDrawerProps> = ({
     )
   );
   return (
-    <DrawerPanelContent id={id} isResizable defaultSize={defaultSize} minSize={minSize} maxSize={maxSize}>
-      <DrawerHead>
-        <Text component={TextVariants.h2}>{t('Flow Details')}</Text>
+    <DrawerPanelContent
+      data-test={id}
+      id={id}
+      isResizable
+      defaultSize={defaultSize}
+      minSize={minSize}
+      maxSize={maxSize}
+    >
+      <DrawerHead data-test="drawer-head">
+        <Text data-test="drawer-head-text" component={TextVariants.h2}>
+          {t('Flow Details')}
+        </Text>
         <DrawerActions>
-          <DrawerCloseButton onClick={onClose} />
+          <DrawerCloseButton data-test="drawer-close-button" onClick={onClose} />
         </DrawerActions>
       </DrawerHead>
-      <DrawerPanelBody>
+      <DrawerPanelBody data-test="drawer-body">
         {record && (
           <>
             {groups.map((g, i) => (
-              <div className="record-group-container" key={`group-${i}`}>
+              <div className="record-group-container" key={`group-${i}`} data-test={`drawer-group-${g.title}`}>
                 {g.title && <Text component={TextVariants.h3}>{g.title}</Text>}
                 {g.columns.map(c => (
-                  <TextContent className={`record-field-container ${g.title ? 'grouped' : ''}`} key={c.id}>
+                  <TextContent
+                    className={`record-field-container ${g.title ? 'grouped' : ''}`}
+                    key={c.id}
+                    data-test={`drawer-field-${c.id}`}
+                  >
                     <Text component={TextVariants.h4}>{c.name}</Text>
                     <RecordField flow={record} column={c} filter={getFilter(c)} size={'s'} />
                   </TextContent>
                 ))}
               </div>
             ))}
-            <TextContent className="record-field-container">
+            <TextContent className="record-field-container" data-test="drawer-json-container">
               <Text component={TextVariants.h4}>{t('JSON')}</Text>
               <ClipboardCopy
+                data-test="drawer-json-copy"
                 isCode
                 isExpanded
                 hoverTip={t('Copy')}

--- a/web/src/components/netflow-table/netflow-table-header.tsx
+++ b/web/src/components/netflow-table/netflow-table-header.tsx
@@ -26,6 +26,7 @@ export const NetflowTableHeader: React.FC<{
     (nh: ColumnGroup) => {
       return (
         <Th
+          data-test={`nested-th-${nh.title || 'empty'}`}
           key={`nested-${nh.title}-${headersState.nestedHeaders.indexOf(nh)}`}
           hasRightBorder={_.last(headersState.nestedHeaders) !== nh}
           colSpan={nh.columns.length}
@@ -43,6 +44,7 @@ export const NetflowTableHeader: React.FC<{
         headersState.useNested && headersState.nestedHeaders.find(nh => _.last(nh.columns) === c) !== undefined;
       return (
         <Th
+          data-test={`th-${c.id}`}
           hasRightBorder={showBorder}
           key={c.id}
           sort={{
@@ -72,9 +74,9 @@ export const NetflowTableHeader: React.FC<{
   }, [columns]);
 
   return (
-    <Thead hasNestedHeader={headersState.useNested}>
+    <Thead data-test="thead" hasNestedHeader={headersState.useNested}>
       {headersState.useNested && <Tr>{headersState.nestedHeaders.map(nh => getNestedTableHeader(nh))}</Tr>}
-      <Tr>{headersState.headers.map(c => getTableHeader(c))}</Tr>
+      <Tr data-test="thead-tr">{headersState.headers.map(c => getTableHeader(c))}</Tr>
     </Thead>
   );
 };

--- a/web/src/components/netflow-table/netflow-table-row.tsx
+++ b/web/src/components/netflow-table/netflow-table-row.tsx
@@ -26,6 +26,7 @@ const NetflowTableRow: React.FC<{
 
   return (
     <Tr
+      data-test={`tr-${flow.key}`}
       isRowSelected={flow.key === selectedRecord?.key}
       onRowClick={onRowClick}
       className={`${isDark() ? 'dark' : 'light'}-stripped`}
@@ -38,7 +39,11 @@ const NetflowTableRow: React.FC<{
           timeout={100}
           classNames="newflow"
         >
-          <Td key={c.id} style={{ height, width: `${Math.floor((100 * c.width) / tableWidth)}%` }}>
+          <Td
+            data-test={`td-${flow.key}`}
+            key={c.id}
+            style={{ height, width: `${Math.floor((100 * c.width) / tableWidth)}%` }}
+          >
             {<RecordField flow={flow} column={c} size={size}></RecordField>}
           </Td>
         </CSSTransition>

--- a/web/src/components/netflow-table/netflow-table.tsx
+++ b/web/src/components/netflow-table/netflow-table.tsx
@@ -227,15 +227,22 @@ const NetflowTable: React.FC<{
 
   return (
     <div id="table-container">
-      <TableComposable aria-label="Netflow table" variant="compact" style={{ minWidth: `${width}em` }} isStickyHeader>
+      <TableComposable
+        data-test="table-composable"
+        aria-label="Netflow table"
+        variant="compact"
+        style={{ minWidth: `${width}em` }}
+        isStickyHeader
+      >
         <NetflowTableHeader
+          data-test="table-header"
           onSort={onSort}
           sortDirection={activeSortDirection}
           sortId={activeSortId}
           columns={columns}
           tableWidth={width}
         />
-        <Tbody>{getBody()}</Tbody>
+        <Tbody data-test="table-body">{getBody()}</Tbody>
       </TableComposable>
     </div>
   );

--- a/web/src/components/netflow-topology/components/edge.tsx
+++ b/web/src/components/netflow-topology/components/edge.tsx
@@ -113,7 +113,7 @@ const BaseEdge: React.FC<BaseEdgeProps> = ({
     <Layer id={dragging || hover || highlighted ? TOP_LAYER : undefined}>
       <g
         ref={hoverRef as React.LegacyRef<SVGGElement> | undefined}
-        data-test-id="edge-handler"
+        data-test="edge-handler"
         className={groupClassName}
         onClick={onSelect}
         onContextMenu={onContextMenu}

--- a/web/src/components/netflow-topology/element-panel.tsx
+++ b/web/src/components/netflow-topology/element-panel.tsx
@@ -498,7 +498,14 @@ export const ElementPanel: React.FC<{
   }, [data.type, element, t]);
 
   return (
-    <DrawerPanelContent id={id} isResizable defaultSize={defaultSize} minSize={minSize} maxSize={maxSize}>
+    <DrawerPanelContent
+      data-test={id}
+      id={id}
+      isResizable
+      defaultSize={defaultSize}
+      minSize={minSize}
+      maxSize={maxSize}
+    >
       <DrawerHead>
         {titleContent()}
         <DrawerActions>

--- a/web/src/components/netflow-topology/netflow-topology.tsx
+++ b/web/src/components/netflow-topology/netflow-topology.tsx
@@ -415,8 +415,10 @@ export const TopologyContent: React.FC<{
 
   return (
     <TopologyView
+      data-test="topology-view"
       controlBar={
         <TopologyControlBar
+          data-test="topology-control-bar"
           controlButtons={createTopologyControlButtons({
             ...defaultControlButtonsOptions,
             fitToScreen: false,
@@ -461,10 +463,11 @@ export const TopologyContent: React.FC<{
         />
       }
     >
-      <VisualizationSurface state={{ selectedIds }} />
-      <div id="topology-search-container">
+      <VisualizationSurface data-test="visualization-surface" state={{ selectedIds }} />
+      <div id="topology-search-container" data-test="topology-search-container">
         <InputGroup>
           <TextInput
+            data-test="search-topology-element-input"
             id="search-topology-element-input"
             className={'search'}
             placeholder={t('Find in view')}
@@ -477,12 +480,18 @@ export const TopologyContent: React.FC<{
             validated={searchValidated}
           />
           {!_.isEmpty(searchResultCount) ? (
-            <TextInput value={searchResultCount} isDisabled id="topology-search-result-count" />
+            <TextInput
+              value={searchResultCount}
+              isDisabled
+              id="topology-search-result-count"
+              data-test="topology-search-result-count"
+            />
           ) : (
             <></>
           )}
           {_.isEmpty(searchResultCount) ? (
             <Button
+              data-test="search-topology-element-button"
               id="search-topology-element-button"
               variant="plain"
               aria-label="search for element button"
@@ -493,7 +502,8 @@ export const TopologyContent: React.FC<{
           ) : (
             <>
               <Button
-                id="search-topology-element-button"
+                data-test="prev-search-topology-element-button"
+                id="prev-search-topology-element-button"
                 variant="plain"
                 aria-label="previous button for search element"
                 onClick={() => onSearch(searchValue, false)}
@@ -501,7 +511,8 @@ export const TopologyContent: React.FC<{
                 <AngleUpIcon />
               </Button>
               <Button
-                id="search-topology-element-button"
+                data-test="next-search-topology-element-button"
+                id="next-search-topology-element-button"
                 variant="plain"
                 aria-label="next button for search element"
                 onClick={() => onSearch(searchValue)}
@@ -509,7 +520,8 @@ export const TopologyContent: React.FC<{
                 <AngleDownIcon />
               </Button>
               <Button
-                id="search-topology-element-button"
+                data-test="clear-search-topology-element-button"
+                id="clear-search-topology-element-button"
                 variant="plain"
                 aria-label="clear button for search element"
                 onClick={() => onChangeSearch()}
@@ -585,7 +597,7 @@ export const NetflowTopology: React.FC<{
     );
   } else {
     return (
-      <VisualizationProvider controller={controller}>
+      <VisualizationProvider data-test="visualization-provider" controller={controller}>
         <TopologyContent
           k8sModels={k8sModels}
           range={range}

--- a/web/src/components/netflow-topology/options-panel.tsx
+++ b/web/src/components/netflow-topology/options-panel.tsx
@@ -63,7 +63,14 @@ export const OptionsPanel: React.FC<RecordDrawerProps> = ({ id, options, setOpti
   };
 
   return (
-    <DrawerPanelContent id={id} isResizable defaultSize={defaultSize} minSize={minSize} maxSize={maxSize}>
+    <DrawerPanelContent
+      data-test={id}
+      id={id}
+      isResizable
+      defaultSize={defaultSize}
+      minSize={minSize}
+      maxSize={maxSize}
+    >
       <DrawerHead>
         <Text component={TextVariants.h2}>{t('Options')}</Text>
         <DrawerActions>

--- a/web/src/components/netflow-traffic-parent.tsx
+++ b/web/src/components/netflow-traffic-parent.tsx
@@ -27,7 +27,7 @@ class NetflowTrafficParent extends React.Component<Props, State> {
   render() {
     if (this.state.error) {
       return (
-        <div style={{ padding: 10 }}>
+        <div data-test="error-message" style={{ padding: 10 }}>
           <h1>Unexpected error</h1>
           <p>{this.state.error.toString()}</p>
           <p>(check logs for more information)</p>

--- a/web/src/components/netflow-traffic.tsx
+++ b/web/src/components/netflow-traffic.tsx
@@ -343,6 +343,7 @@ export const NetflowTraffic: React.FC<{
     return (
       <ToggleGroup>
         <ToggleGroupItem
+          data-test="table-view-button"
           icon={<TableIcon />}
           text={t('Flow Table')}
           buttonId="tableViewButton"
@@ -350,6 +351,7 @@ export const NetflowTraffic: React.FC<{
           onChange={() => selectView('table')}
         />
         <ToggleGroupItem
+          data-test="topology-view-button"
           icon={<TopologyIcon />}
           text={t('Topology')}
           buttonId="topologyViewButton"
@@ -364,24 +366,37 @@ export const NetflowTraffic: React.FC<{
     return (
       <div className="co-actions">
         {selectedViewId === 'topology' && (
-          <MetricFunctionDropdown id="metricFunction" selected={metricFunction} setMetricFunction={setMetricFunction} />
+          <MetricFunctionDropdown
+            data-test="metricFunction"
+            id="metricFunction"
+            selected={metricFunction}
+            setMetricFunction={setMetricFunction}
+          />
         )}
         {selectedViewId === 'topology' && metricFunction !== 'rate' && (
-          <MetricTypeDropdown id="metricType" selected={metricType} setMetricType={setMetricType} />
+          <MetricTypeDropdown
+            data-test="metricType"
+            id="metricType"
+            selected={metricType}
+            setMetricType={setMetricType}
+          />
         )}
         <TimeRangeDropdown
+          data-test="time-range-dropdown"
           id="time-range-dropdown"
           range={range}
           setRange={setRange}
           openCustomModal={() => setTRModalOpen(true)}
         />
         <RefreshDropdown
+          data-test="refresh-dropdown"
           id="refresh-dropdown"
           disabled={typeof range !== 'number'}
           interval={interval}
           setInterval={setInterval}
         />
         <Button
+          data-test="refresh-button"
           id="refresh-button"
           className="co-action-refresh-button"
           variant="primary"
@@ -404,6 +419,7 @@ export const NetflowTraffic: React.FC<{
       items.push(
         <OverflowMenuItem isPersistent key="columns">
           <Button
+            data-test="manage-columns-button"
             id="manage-columns-button"
             variant="link"
             className="overflow-button"
@@ -416,12 +432,13 @@ export const NetflowTraffic: React.FC<{
       );
       items.push(
         <OverflowMenuItem key="display">
-          <DisplayDropdown id="display" setSize={setSize} />
+          <DisplayDropdown data-test="display" id="display" setSize={setSize} />
         </OverflowMenuItem>
       );
       items.push(
         <OverflowMenuItem key="export">
           <Button
+            data-test="export-button"
             id="export-button"
             variant="link"
             className="overflow-button"
@@ -437,6 +454,7 @@ export const NetflowTraffic: React.FC<{
     items.push(
       <OverflowMenuItem key="fullscreen" isPersistent={selectedViewId === 'topology'}>
         <Button
+          data-test="fullscreen-button"
           id="fullscreen-button"
           variant="link"
           className="overflow-button"
@@ -456,10 +474,12 @@ export const NetflowTraffic: React.FC<{
     }
     return (
       <Dropdown
+        data-test="more-options-dropdown"
         id="more-options-dropdown"
         onSelect={() => setOverflowMenuOpen(false)}
         toggle={
           <Button
+            data-test="more-options-button"
             id="more-options-button"
             variant="link"
             className="overflow-button"
@@ -524,7 +544,6 @@ export const NetflowTraffic: React.FC<{
       );
     } else if (isShowQuerySummary) {
       return (
-        //TODO: bind this panel to topology query after merge
         <SummaryPanel
           id="summaryPanel"
           flows={flows}

--- a/web/src/components/query-summary/summary-panel.tsx
+++ b/web/src/components/query-summary/summary-panel.tsx
@@ -248,7 +248,14 @@ export const SummaryPanel: React.FC<{
   const { t } = useTranslation('plugin__network-observability-plugin');
 
   return (
-    <DrawerPanelContent id={id} isResizable defaultSize={defaultSize} minSize={minSize} maxSize={maxSize}>
+    <DrawerPanelContent
+      data-test={id}
+      id={id}
+      isResizable
+      defaultSize={defaultSize}
+      minSize={minSize}
+      maxSize={maxSize}
+    >
       <DrawerHead>
         <Text component={TextVariants.h2}>{t('Query summary')}</Text>
         <DrawerActions>


### PR DESCRIPTION
I have added a lot of missing `data-test` on butons / dropdowns. 
We can remove `id` field in these cases and update jest tests if you prefer or keep them as is.
 
Also added `data-test` /  ~~`data-test-id`~~ on table components including rows & fields and on side panel

For topology you can already rely on data-XXX content like:
```
<g data-id="Namespace.undefined.openshift-network-diagnostics.undefined.undefined" data-kind="node" data-type="node" 
```