### PR TITLE
NETOBSERV-223: filter by empty IP and numbers

### DIFF
--- a/pkg/server/server_flows_test.go
+++ b/pkg/server/server_flows_test.go
@@ -185,6 +185,12 @@ func TestLokiFiltering(t *testing.T) {
 		outputQueries: []string{
 			"?query={app=\"netobserv-flowcollector\"}|json|SrcK8S_Type=\"\"+or+SrcK8S_Type=\"Pod\"",
 		},
+	}, {
+		inputPath: "?filters=" + url.QueryEscape(`SrcAddr=""|DstAddr=""`),
+		outputQueries: []string{
+			"?query={app=\"netobserv-flowcollector\"}|json|DstAddr=\"\"",
+			"?query={app=\"netobserv-flowcollector\"}|json|SrcAddr=\"\"",
+		},
 	}}
 
 	numberQueriesExpected := 0

--- a/web/locales/en/plugin__network-observability-plugin.json
+++ b/web/locales/en/plugin__network-observability-plugin.json
@@ -205,6 +205,7 @@
   "A single IPv4 or IPv6 address like 192.0.2.0, ::1": "A single IPv4 or IPv6 address like 192.0.2.0, ::1",
   "An IP address range like 192.168.0.1-192.189.10.12, 2001:db8::1-2001:db8::8": "An IP address range like 192.168.0.1-192.189.10.12, 2001:db8::1-2001:db8::8",
   "A CIDR specification like 192.51.100.0/24, 2001:db8::/32": "A CIDR specification like 192.51.100.0/24, 2001:db8::/32",
+  "Empty double quotes \"\" for an empty IP": "Empty double quotes \"\" for an empty IP",
   "Not a valid IPv4 or IPv6, nor a CIDR, nor an IP range separated by hyphen": "Not a valid IPv4 or IPv6, nor a CIDR, nor an IP range separated by hyphen",
   "Owner Name": "Owner Name",
   "Incomplete resource name, either kind, namespace or name is missing.": "Incomplete resource name, either kind, namespace or name is missing.",

--- a/web/src/utils/__tests__/ip.spec.ts
+++ b/web/src/utils/__tests__/ip.spec.ts
@@ -69,4 +69,7 @@ describe('validate IP filter', () => {
     expect(validateIPFilter('1.3.3.4/')).toBe(false);
     expect(validateIPFilter('1.3.3.4/3.2.1.0')).toBe(false);
   });
+  it('should validate empty IPs', () => {
+    expect(validateIPFilter('""')).toBe(true);
+  });
 });

--- a/web/src/utils/filter-definitions.ts
+++ b/web/src/utils/filter-definitions.ts
@@ -24,6 +24,9 @@ import {
   cap10
 } from './filter-options';
 
+// Convenience string to filter by for empty or null field values
+export const emptyField = '""';
+
 type Field = keyof Fields | keyof Labels;
 
 const singleFieldMapping = (field: Field) => {
@@ -133,7 +136,8 @@ export const getFilterDefinitions = (t: TFunction): FilterDefinition[] => {
     const ipExamples = `${t('Specify IP following one of these rules:')}
     - ${t('A single IPv4 or IPv6 address like 192.0.2.0, ::1')}
     - ${t('An IP address range like 192.168.0.1-192.189.10.12, 2001:db8::1-2001:db8::8')}
-    - ${t('A CIDR specification like 192.51.100.0/24, 2001:db8::/32')}`;
+    - ${t('A CIDR specification like 192.51.100.0/24, 2001:db8::/32')}
+    - ${t('Empty double quotes "" for an empty IP')}`;
 
     const invalidIPMessage = t('Not a valid IPv4 or IPv6, nor a CIDR, nor an IP range separated by hyphen');
 

--- a/web/src/utils/ip.ts
+++ b/web/src/utils/ip.ts
@@ -1,3 +1,5 @@
+import { emptyField } from './filter-definitions';
+
 export const compareIPs = (ip1: string, ip2: string) => {
   const splitIp2 = ip2.split('.');
   const tmpRes = ip1.split('.').map((num, i) => Number(num) - Number(splitIp2[i]));
@@ -14,10 +16,11 @@ export const compareIPs = (ip1: string, ip2: string) => {
  * - A single IPv4 or IPv6 address. Examples: 192.0.2.0, ::1
  * - A range within the IP address. Examples: 192.168.0.1-192.189.10.12, 2001:db8::1-2001:db8::8
  * - A CIDR specification. Examples: 192.51.100.0/24, 2001:db8::/32
+ * - Empty double quotes "" for empty/null IP
  */
 export const validateIPFilter = (ipFilter: string) => {
   ipFilter = ipFilter.trim();
-  if (ipv4.test(ipFilter) || ipv6.test(ipFilter)) {
+  if (ipFilter == emptyField || ipv4.test(ipFilter) || ipv6.test(ipFilter)) {
     return true;
   }
   const ips = ipFilter.split('-');


### PR DESCRIPTION
* Allows filtering by empty IP if `""` is set as filter.
* Allows filtering by empty (non-existing) numbers if `""` is set as filter.