### PR TITLE
NETOBSERV-317 fix rendering performances issue

### DIFF
--- a/web/moduleMapper/dummy.tsx
+++ b/web/moduleMapper/dummy.tsx
@@ -47,12 +47,12 @@ export const ResourceLink: React.FC<ResourceLinkProps> = ({
   return (
     //TODO: add icon here
     <span className={className}>
-      <span
+      {k8sModels[kind!] && <span
         className="co-m-resource-icon"
         style={{ backgroundColor: k8sModels[kind!].color }}
         title={kind}>
         {k8sModels[kind!].abbr}
-      </span>
+      </span>}
       <span className="co-resource-item__resource-name" data-test-id={value} data-test={dataTest}>
         {value}
       </span>

--- a/web/src/components/netflow-table/__tests__/netflow-table-row.spec.tsx
+++ b/web/src/components/netflow-table/__tests__/netflow-table-row.spec.tsx
@@ -13,7 +13,8 @@ describe('<NetflowTableRow />', () => {
   const mocks = {
     size: 'm' as Size,
     onSelect: jest.fn(),
-    tableWidth: 100
+    tableWidth: 100,
+    showContent: true
   };
   it('should render component', async () => {
     flows = FlowsSample;

--- a/web/src/components/netflow-table/netflow-table-row.css
+++ b/web/src/components/netflow-table/netflow-table-row.css
@@ -1,9 +1,9 @@
 /* table stripping from pf-color-black-150 value */
-.light-stripped:nth-child(even) {
+:not(.newflow-appear).light-stripped:nth-child(even) {
   background-color: #f5f5f5;
 }
 
-.dark-stripped:nth-child(even) {
+:not(.newflow-appear).dark-stripped:nth-child(even) {
   background-color: #050505;
 }
 

--- a/web/src/components/netflow-table/netflow-table-row.tsx
+++ b/web/src/components/netflow-table/netflow-table-row.tsx
@@ -16,39 +16,34 @@ const NetflowTableRow: React.FC<{
   onSelect: (record?: Record) => void;
   highlight: boolean;
   height?: number;
+  showContent?: boolean;
   tableWidth: number;
-}> = ({ flow, selectedRecord, columns, size, onSelect, highlight, height, tableWidth }) => {
+}> = ({ flow, selectedRecord, columns, size, onSelect, highlight, height, showContent, tableWidth }) => {
   const onRowClick = () => {
     onSelect(flow);
   };
 
-  const shouldHighlight = React.useRef(highlight);
-
   return (
-    <Tr
-      data-test={`tr-${flow.key}`}
-      isRowSelected={flow.key === selectedRecord?.key}
-      onRowClick={onRowClick}
-      className={`${isDark() ? 'dark' : 'light'}-stripped`}
-    >
-      {columns.map(c => (
-        <CSSTransition
-          key={c.id}
-          in={shouldHighlight.current}
-          appear={shouldHighlight.current}
-          timeout={100}
-          classNames="newflow"
-        >
-          <Td
-            data-test={`td-${flow.key}`}
-            key={c.id}
-            style={{ height, width: `${Math.floor((100 * c.width) / tableWidth)}%` }}
-          >
-            {<RecordField flow={flow} column={c} size={size}></RecordField>}
-          </Td>
-        </CSSTransition>
-      ))}
-    </Tr>
+    <CSSTransition in={highlight} appear={highlight} timeout={100} classNames="newflow">
+      <Tr
+        data-test={`tr-${flow.key}`}
+        isRowSelected={flow.key === selectedRecord?.key}
+        onRowClick={onRowClick}
+        className={`${isDark() ? 'dark' : 'light'}-stripped`}
+        style={{ height }}
+      >
+        {showContent &&
+          columns.map(c => (
+            <Td
+              data-test={`td-${flow.key}`}
+              key={c.id}
+              style={{ height: '100%', width: `${Math.floor((100 * c.width) / tableWidth)}%` }}
+            >
+              {<RecordField flow={flow} column={c} size={size}></RecordField>}
+            </Td>
+          ))}
+      </Tr>
+    </CSSTransition>
   );
 };
 

--- a/web/src/components/netflow-table/netflow-table.tsx
+++ b/web/src/components/netflow-table/netflow-table.tsx
@@ -148,29 +148,26 @@ const NetflowTable: React.FC<{
 
   const getBody = React.useCallback(() => {
     const rowHeight = getRowHeight();
-    return getSortedFlows().map((f, i) =>
-      scrollPosition <= i * rowHeight && scrollPosition + containerHeight > i * rowHeight ? (
-        <NetflowTableRow
-          key={f.key}
-          flow={f}
-          columns={columns}
-          size={size}
-          selectedRecord={selectedRecord}
-          onSelect={onSelect}
-          highlight={
-            previousContainerHeight === containerHeight &&
-            previousScrollPosition === scrollPosition &&
-            previousActiveSortDirection === activeSortDirection &&
-            previousActiveSortIndex === activeSortId &&
-            !firstRender.current
-          }
-          height={rowHeight}
-          tableWidth={width}
-        />
-      ) : (
-        <tr className={`empty-row`} style={{ height: rowHeight }} key={f.key} />
-      )
-    );
+    return getSortedFlows().map((f, i) => (
+      <NetflowTableRow
+        key={f.key}
+        flow={f}
+        columns={columns}
+        size={size}
+        selectedRecord={selectedRecord}
+        onSelect={onSelect}
+        highlight={
+          previousContainerHeight === containerHeight &&
+          previousScrollPosition === scrollPosition &&
+          previousActiveSortDirection === activeSortDirection &&
+          previousActiveSortIndex === activeSortId &&
+          !firstRender.current
+        }
+        height={rowHeight}
+        showContent={scrollPosition <= i * rowHeight && scrollPosition + containerHeight > i * rowHeight}
+        tableWidth={width}
+      />
+    ));
   }, [
     activeSortDirection,
     activeSortId,

--- a/web/src/utils/k8s-models-hook.ts
+++ b/web/src/utils/k8s-models-hook.ts
@@ -75,6 +75,5 @@ export function useK8sModelsWithColors() {
     setColor('Ingress', '#1F0066');
   }
 
-  console.log(k8sModels);
   return k8sModels;
 }


### PR DESCRIPTION
Following https://github.com/netobserv/network-observability-console-plugin/pull/169 some performances issues occurs depending on your resolution / window size changes. Browser freeze and a prompt ask to exit page in worst cases.

This PR change the way rows are skipped keeping PF table `Tr` with their attributes and only remove their content.
Also, `CSSTransition` has been moved on `Tr` level to avoid repeating these on each `Td`