### PR TITLE
NETOBSERV-347 UX filtering: be able to turn off an active filter

### DIFF
--- a/web/src/components/filters/__tests__/filters-toolbar.spec.tsx
+++ b/web/src/components/filters/__tests__/filters-toolbar.spec.tsx
@@ -1,12 +1,4 @@
-import {
-  Accordion,
-  AccordionItem,
-  Button,
-  Dropdown,
-  Toolbar,
-  ToolbarFilter,
-  ToolbarItem
-} from '@patternfly/react-core';
+import { Accordion, AccordionItem, Button, Dropdown, Toolbar, ToolbarItem } from '@patternfly/react-core';
 import { mount, shallow } from 'enzyme';
 import * as React from 'react';
 import { Filter } from '../../../model/filters';
@@ -47,17 +39,17 @@ describe('<FiltersToolbar />', () => {
 
   it('should render filters', async () => {
     const wrapper = shallow(<FiltersToolbar {...props} />);
-    expect(wrapper.find(ToolbarFilter)).toHaveLength(props.filters!.length);
+    expect(wrapper.find('.custom-chip-group')).toHaveLength(props.filters!.length);
 
     //add a bunch of filters
     props.filters = FiltersSample;
     wrapper.setProps({ filters: props.filters });
-    expect(wrapper.find(ToolbarFilter)).toHaveLength(props.filters.length);
+    expect(wrapper.find('.custom-chip-group')).toHaveLength(props.filters.length);
 
     //update props to set a single filter
     props.filters = [FiltersSample[0]];
     wrapper.setProps({ filters: props.filters });
-    expect(wrapper.find(ToolbarFilter)).toHaveLength(props.filters.length);
+    expect(wrapper.find('.custom-chip-group')).toHaveLength(props.filters.length);
   });
 
   it('should open and close', async () => {

--- a/web/src/components/filters/filters-toolbar.css
+++ b/web/src/components/filters/filters-toolbar.css
@@ -56,6 +56,11 @@ button.pf-c-button.pf-m-link.pf-m-inline:empty {
   padding: 5px 0px 0px 5px;
 }
 
+#filters {
+  width: 100%;
+  margin-top: 1em;
+}
+
 /* force new row for forced filters group*/
 #forced-filters {
   flex-basis: 100%;
@@ -68,4 +73,118 @@ div#filter-toolbar-search-filters {
 
 .pf-c-toolbar__item.pf-m-align-right {
   margin-right: 0;
+}
+
+.custom-chip-group,
+.custom-chip {
+  border-radius: 3px;
+  box-shadow: 0 0.0625rem 0.125rem 0 rgb(3 3 3 / 12%), 0 0 0.125rem 0 rgb(3 3 3 / 6%);
+  display: inline-flex;
+  align-items: center;
+}
+
+.custom-chip-group {
+  padding: 0.2em 0.5em 0.2em 0.5em;
+  margin: 0 1em 0 0;
+  color: #000;
+  background-color: #f0f0f0;
+}
+
+.custom-chip-group>p {
+  font-size: 0.85rem;
+}
+
+.custom-chip {
+  min-height: 2em;
+  padding: 0;
+  padding-left: 1em;
+  margin-right: 0.5em;
+  color: #000;
+  background-color: #fff;
+}
+
+.disabled-group,
+.disabled-value {
+  opacity: 0.75;
+}
+
+.custom-chip-group.disabled-group,
+.custom-chip-group.disabled-group>button,
+.custom-chip-group.disabled-group>* {
+  color: #000;
+  background-color: #D2D2D2;
+}
+
+.custom-chip.disabled-value,
+.custom-chip.disabled-value>button,
+.custom-chip.disabled-value>* {
+  color: #fff;
+  background-color: #6A6E73;
+}
+
+.pf-theme-dark .custom-chip-group,
+.pf-theme-dark .custom-chip-group>button,
+.pf-theme-dark .custom-chip-group>* {
+  color: #fff;
+  background-color: #004080;
+}
+
+.pf-theme-dark .custom-chip,
+.pf-theme-dark .custom-chip>button,
+.pf-theme-dark .custom-chip>* {
+  color: #fff;
+  background-color: #06c;
+}
+
+.pf-theme-dark .custom-chip-group.disabled-group,
+.pf-theme-dark .custom-chip-group.disabled-group>button,
+.pf-theme-dark .custom-chip-group.disabled-group>* {
+  color: #fff;
+  background-color: #6A6E73;
+}
+
+.pf-theme-dark .custom-chip.disabled-value,
+.pf-theme-dark .custom-chip.disabled-value>button,
+.pf-theme-dark .custom-chip.disabled-value>* {
+  color: #000;
+  background-color: #D2D2D2;
+}
+
+.custom-chip>p {
+  font-size: 0.75rem;
+}
+
+.custom-chip-group>*:hover {
+  color: #06c;
+}
+
+.custom-chip>*:hover {
+  color: #004080;
+}
+
+.custom-chip-group.disabled-group>*:hover,
+.custom-chip.disabled-value>*:hover {
+  color: #4F5255
+}
+
+.custom-chip-group>button,
+.custom-chip>button {
+  padding: 0.3em 0.5em 0.3em 0.5em;
+}
+
+.custom-chip-group>p,
+.custom-chip>p {
+  cursor: pointer;
+  user-select: none;
+  max-width: 18ch;
+  margin-right: 0.5rem;
+  overflow: hidden;
+  display: inline-block;
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+#clear-all-filters-button {
+  padding: 0;
 }

--- a/web/src/components/filters/filters-toolbar.tsx
+++ b/web/src/components/filters/filters-toolbar.tsx
@@ -1,36 +1,35 @@
-import * as React from 'react';
-import * as _ from 'lodash';
 import {
   Button,
-  Chip,
-  ChipGroup,
   InputGroup,
   OverflowMenu,
   OverflowMenuContent,
   OverflowMenuControl,
   OverflowMenuGroup,
+  Text,
+  TextVariants,
   Toolbar,
   ToolbarContent,
-  ToolbarFilter,
   ToolbarGroup,
   ToolbarItem,
   Tooltip,
   ValidatedOptions
 } from '@patternfly/react-core';
+import { TimesIcon, TimesCircleIcon } from '@patternfly/react-icons';
+import * as _ from 'lodash';
+import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import { Filter, FilterComponent, FilterDefinition, FilterValue } from '../../model/filters';
+import { autoCompleteCache } from '../../utils/autocomplete-cache';
+import { findFilter } from '../../utils/filter-definitions';
+import { getPathWithParams, netflowTrafficPath } from '../../utils/url';
 import { QueryOptionsDropdown, QueryOptionsDropdownProps } from '../dropdowns/query-options-dropdown';
+import AutocompleteFilter from './autocomplete-filter';
 import { FilterHints } from './filter-hints';
 import FiltersDropdown from './filters-dropdown';
 import { getFilterFullName, Indicator } from './filters-helper';
-import TextFilter from './text-filter';
-import AutocompleteFilter from './autocomplete-filter';
-import { autoCompleteCache } from '../../utils/autocomplete-cache';
-import { getPathWithParams, netflowTrafficPath } from '../../utils/url';
-import { findFilter } from '../../utils/filter-definitions';
-
 import './filters-toolbar.css';
+import TextFilter from './text-filter';
 
 export interface FiltersToolbarProps {
   id: string;
@@ -113,20 +112,136 @@ export const FiltersToolbar: React.FC<FiltersToolbarProps> = ({
     }
   }, [selectedFilter, addFilter, indicator, setIndicator, setMessageWithDelay]);
 
-  const hasFilterValues = React.useCallback(() => {
-    return filters?.some(f => f.values.length !== 0);
-  }, [filters]);
+  const getFiltersChips = React.useCallback(() => {
+    const isForced = !_.isEmpty(forcedFilters);
+    const chipFilters = isForced ? forcedFilters : filters;
+
+    if (_.isEmpty(chipFilters)) {
+      return null;
+    }
+
+    return (
+      <ToolbarGroup
+        className="flex-start"
+        data-test={`${isForced ? 'forced-' : ''}filters`}
+        id={`${isForced ? 'forced-' : ''}filters`}
+        variant="filter-group"
+      >
+        <ToolbarItem className="flex-start">
+          {chipFilters &&
+            chipFilters.map((chipFilter, cfIndex) => (
+              <div key={cfIndex} className={`custom-chip-group ${chipFilter.disabled ? 'disabled-group' : ''}`}>
+                <Tooltip
+                  content={`${chipFilter.disabled ? t('Enable') : t('Disable')} '${getFilterFullName(
+                    chipFilter.def,
+                    t
+                  )}' ${t('group filter')}`}
+                >
+                  <Text
+                    className="pf-c-chip-group__label"
+                    component={TextVariants.p}
+                    onClick={() => {
+                      chipFilter.disabled = !chipFilter.disabled;
+                      //restore all valus if no remaining
+                      if (!chipFilter.values.find(fv => fv.disabled !== true)) {
+                        chipFilter.values.forEach(fv => {
+                          fv.disabled = false;
+                        });
+                      }
+                      setFilters(_.cloneDeep(filters!));
+                    }}
+                  >
+                    {getFilterFullName(chipFilter.def, t)}
+                  </Text>
+                </Tooltip>
+                {chipFilter.values.map((chipFilterValue, fvIndex) => (
+                  <div
+                    key={fvIndex}
+                    className={`custom-chip ${chipFilter.disabled || chipFilterValue.disabled ? 'disabled-value' : ''}`}
+                  >
+                    <Tooltip
+                      content={`${
+                        chipFilter.disabled || chipFilterValue.disabled ? t('Enable') : t('Disable')
+                      } ${getFilterFullName(chipFilter.def, t)} '${chipFilterValue.display || chipFilterValue.v}' ${t(
+                        'filter'
+                      )}`}
+                    >
+                      <Text
+                        component={TextVariants.p}
+                        onClick={() => {
+                          //restore group filter & value if disabled
+                          if (chipFilter.disabled) {
+                            chipFilter.disabled = false;
+                            chipFilterValue.disabled = false;
+                          } else {
+                            //else switch value
+                            chipFilterValue.disabled = !chipFilterValue.disabled;
+                            //disable parent if no value remaining
+                            if (!chipFilter.values.find(fv => fv.disabled !== true)) {
+                              chipFilter.disabled = true;
+                            }
+                          }
+                          setFilters(_.cloneDeep(filters!));
+                        }}
+                      >
+                        {chipFilterValue.display ? chipFilterValue.display : chipFilterValue.v}
+                      </Text>
+                    </Tooltip>
+                    {!isForced && (
+                      <Button
+                        variant="plain"
+                        onClick={() => {
+                          chipFilter.values = chipFilter.values.filter(val => val.v !== chipFilterValue.v);
+                          if (_.isEmpty(chipFilter.values)) {
+                            setFilters(filters!.filter(f => f.def.id !== chipFilter.def.id));
+                          } else {
+                            setFilters(_.cloneDeep(filters!));
+                          }
+                        }}
+                      >
+                        <TimesIcon />
+                      </Button>
+                    )}
+                  </div>
+                ))}
+                {!isForced && (
+                  <Button
+                    variant="plain"
+                    onClick={() => setFilters(filters!.filter(f => f.def.id !== chipFilter.def.id))}
+                  >
+                    <TimesCircleIcon />
+                  </Button>
+                )}
+              </div>
+            ))}
+        </ToolbarItem>
+        {isForced ? (
+          <Button
+            id="edit-filters-button"
+            data-test="edit-filters-button"
+            onClick={() => push(getPathWithParams(netflowTrafficPath))}
+          >
+            {t('Edit filters')}
+          </Button>
+        ) : (
+          <Button
+            id="clear-all-filters-button"
+            data-test="clear-all-filters-button"
+            variant="link"
+            onClick={() => {
+              clearFilters();
+              autoCompleteCache.clear();
+            }}
+          >
+            {t('Clear all filters')}
+          </Button>
+        )}
+      </ToolbarGroup>
+    );
+  }, [clearFilters, filters, forcedFilters, push, setFilters, t]);
 
   return (
-    <Toolbar
-      data-test={id}
-      id={id}
-      clearAllFilters={() => {
-        clearFilters();
-        autoCompleteCache.clear();
-      }}
-      clearFiltersButtonText={hasFilterValues() ? t('Clear all filters') : ''}
-    >
+    <Toolbar data-test={id} id={id}>
       <ToolbarContent data-test={`${id}-search-filters`} id={`${id}-search-filters`} toolbarId={id}>
         <ToolbarItem className="flex-start">
           <QueryOptionsDropdown {...props.queryOptionsProps} />
@@ -171,53 +286,7 @@ export const FiltersToolbar: React.FC<FiltersToolbarProps> = ({
             {actions}
           </ToolbarItem>
         )}
-        {_.isEmpty(forcedFilters) ? (
-          filters &&
-          filters.map((filter, index) => (
-            <ToolbarFilter
-              key={index}
-              deleteChipGroup={() => setFilters(filters.filter(f => f.def.id !== filter.def.id))}
-              chips={filter.values.map(value => value.display || value.v)}
-              deleteChip={(f, value: string) => {
-                filter.values = filter.values.filter(val => (val.display ? val.display !== value : val.v !== value));
-                if (_.isEmpty(filter.values)) {
-                  setFilters(filters.filter(f => f.def.id !== filter.def.id));
-                } else {
-                  // CHECK / FIXME cloneDeep won't work?
-                  setFilters(_.cloneDeep(filters));
-                }
-              }}
-              categoryName={getFilterFullName(filter.def, t)}
-            >
-              {
-                // set empty children to have a single filter with multiple categories
-                <div></div>
-              }
-            </ToolbarFilter>
-          ))
-        ) : (
-          <ToolbarGroup data-test="forced-filters" id="forced-filters" variant="filter-group">
-            <ToolbarItem className="flex-start">
-              {forcedFilters &&
-                forcedFilters.map((forcedFilter, ffIndex) => (
-                  <ChipGroup key={ffIndex} isClosable={false} categoryName={getFilterFullName(forcedFilter.def, t)}>
-                    {forcedFilter.values.map((forcedValue, fvIndex) => (
-                      <Chip key={fvIndex} isReadOnly={true}>
-                        {forcedValue.display ? forcedValue.display : forcedValue.v}
-                      </Chip>
-                    ))}
-                  </ChipGroup>
-                ))}
-            </ToolbarItem>
-            <ToolbarItem className="flex-start">
-              <OverflowMenu breakpoint="md">
-                <OverflowMenuGroup groupType="button" isPersistent>
-                  <Button onClick={() => push(getPathWithParams(netflowTrafficPath))}>{t('Edit filters')}</Button>
-                </OverflowMenuGroup>
-              </OverflowMenu>
-            </ToolbarItem>
-          </ToolbarGroup>
-        )}
+        {getFiltersChips()}
       </ToolbarContent>
     </Toolbar>
   );

--- a/web/src/model/filters.ts
+++ b/web/src/model/filters.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import { Fields, Labels } from '../api/ipfix';
 
 type Field = keyof Fields | keyof Labels;
@@ -67,11 +68,13 @@ export interface FilterDefinition {
 
 export interface FilterValue {
   v: string;
+  disabled?: boolean;
   display?: string;
 }
 
 export interface Filter {
   def: FilterDefinition;
+  disabled?: boolean;
   values: FilterValue[];
 }
 
@@ -85,4 +88,37 @@ export const createFilterValue = (def: FilterDefinition, value: string): Promise
     const option = opts.find(opt => opt.name === value || opt.value === value);
     return option ? { v: option.value, display: option.name } : { v: value };
   });
+};
+
+export const getEnabledFilters = (filters: Filter[]) => {
+  //clone to avoid values updated in filters
+  const clonedFilters = _.cloneDeep(filters);
+  return clonedFilters
+    .filter(f => f.disabled !== true)
+    .map(f => {
+      f.values = f.values.filter(fv => fv.disabled !== true);
+      return f;
+    });
+};
+
+export type DisabledFilters = Record<string, string>;
+export const GroupDisabledKey = 'all';
+
+export const getDisabledFiltersRecord = (filters: Filter[]) => {
+  const disabledFilters: DisabledFilters = {};
+  filters.forEach(f => {
+    if (f.disabled === true) {
+      disabledFilters[f.def.id] = GroupDisabledKey;
+    } else {
+      const values = f.values
+        .filter(fv => fv.disabled === true)
+        .map(fv => fv.v)
+        .join(',');
+      if (!_.isEmpty(values)) {
+        disabledFilters[f.def.id] = values;
+      }
+    }
+  });
+  console.log('disabledFilters', disabledFilters);
+  return disabledFilters;
 };

--- a/web/src/utils/local-storage-hook.ts
+++ b/web/src/utils/local-storage-hook.ts
@@ -9,6 +9,7 @@ export const LOCAL_STORAGE_SIZE_KEY = 'netflow-traffic-size-size';
 export const LOCAL_STORAGE_VIEW_ID_KEY = 'netflow-traffic-view-id';
 export const LOCAL_STORAGE_TOPOLOGY_OPTIONS_KEY = 'netflow-traffic-topology-options';
 export const LOCAL_STORAGE_QUERY_PARAMS_KEY = 'netflow-traffic-query-params';
+export const LOCAL_STORAGE_DISABLED_FILTERS_KEY = 'netflow-traffic-disabled-filters';
 export const LOCAL_STORAGE_SORT_ID_KEY = 'netflow-traffic-sort-id';
 export const LOCAL_STORAGE_SORT_DIRECTION_KEY = 'netflow-traffic-sort-direction';
 


### PR DESCRIPTION
This brings ability to click on group / value filter text to enable / disable it without loosing the values.

State is saved in `localStorage` so the url params are kept as before.
![image](https://user-images.githubusercontent.com/91894519/173062465-fc142f65-be04-4c99-bbd7-2bef2ee95586.png)
![image](https://user-images.githubusercontent.com/91894519/173062528-43a49f03-16c1-49b5-b4ac-c5f6cdb16903.png)
![image](https://user-images.githubusercontent.com/91894519/173063082-7b0582ab-4f27-4afb-adbf-64b3e11edd7b.png)

We decided to follow PF colors for now but feel free to suggest alternatives in related [slack conversation](https://coreos.slack.com/archives/C02939DP5L5/p1654855230111639)