### PR TITLE
NETOBSERV-399 Table rows display issue after update

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,11 +8,11 @@
       "name": "network-observability-plugin",
       "version": "0.0.0",
       "dependencies": {
-        "@patternfly/patternfly": "4.194.4",
-        "@patternfly/react-charts": "^6.67.1",
-        "@patternfly/react-core": "^4.214.1",
-        "@patternfly/react-table": "4.83.1",
-        "@patternfly/react-topology": "4.61.1",
+        "@patternfly/patternfly": "4.196.7",
+        "@patternfly/react-charts": "6.74.3",
+        "@patternfly/react-core": "4.221.3",
+        "@patternfly/react-table": "4.90.3",
+        "@patternfly/react-topology": "4.68.3",
         "history": "^5.1.0",
         "i18next": "^19.8.3",
         "i18next-http-backend": "^1.0.21",
@@ -3060,6 +3060,52 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/@openshift-console/dynamic-plugin-sdk/node_modules/@patternfly/react-core": {
+      "version": "4.214.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.214.1.tgz",
+      "integrity": "sha512-XHEqXpnBEDyLVdAEDOYlGqFHnN43eNLSD5HABB99xO6541JV9MRnbxs0+v9iYnfhcKh/8bhA9ITXnUi3f2PEvg==",
+      "dev": true,
+      "dependencies": {
+        "@patternfly/react-icons": "^4.65.1",
+        "@patternfly/react-styles": "^4.64.1",
+        "@patternfly/react-tokens": "^4.66.1",
+        "focus-trap": "6.2.2",
+        "react-dropzone": "9.0.0",
+        "tippy.js": "5.1.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@openshift-console/dynamic-plugin-sdk/node_modules/@patternfly/react-table": {
+      "version": "4.83.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.83.1.tgz",
+      "integrity": "sha512-mkq13x9funh+Nh2Uzj2ZQBOacNYc+a60yUAHZMXgNcljCJ3LTQUoYy6EonvYrqwSrpC7vj8nLt8+/XbDNc0Aig==",
+      "dev": true,
+      "dependencies": {
+        "@patternfly/react-core": "^4.214.1",
+        "@patternfly/react-icons": "^4.65.1",
+        "@patternfly/react-styles": "^4.64.1",
+        "@patternfly/react-tokens": "^4.66.1",
+        "lodash": "^4.17.19",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@openshift-console/dynamic-plugin-sdk/node_modules/focus-trap": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.2.2.tgz",
+      "integrity": "sha512-qWovH9+LGoKqREvJaTCzJyO0hphQYGz+ap5Hc4NqXHNhZBdxCi5uBPPcaOUw66fHmzXLVwvETLvFgpwPILqKpg==",
+      "dev": true,
+      "dependencies": {
+        "tabbable": "^5.1.4"
+      }
+    },
     "node_modules/@openshift-console/dynamic-plugin-sdk/node_modules/history": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
@@ -3114,9 +3160,9 @@
       }
     },
     "node_modules/@patternfly/patternfly": {
-      "version": "4.194.4",
-      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-4.194.4.tgz",
-      "integrity": "sha512-SJxr502v0xXk1N5OiPLunD9pdKvHp5XXJLXcD5lIPrimjjUcy46m48X8YONjDvnC/Y5xV92UI2KxoCVucE34eA=="
+      "version": "4.196.7",
+      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-4.196.7.tgz",
+      "integrity": "sha512-hA7Oww411e1p0/IXjC1I+4/1NNis9V+NVBxfUIpRwyuLbCIDHBdtMu2qAPLdKxXjuibV9EE6ZdlT7ra/kcFuJQ=="
     },
     "node_modules/@patternfly/quickstarts": {
       "version": "2.0.1",
@@ -3159,12 +3205,12 @@
       "dev": true
     },
     "node_modules/@patternfly/react-charts": {
-      "version": "6.67.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-6.67.1.tgz",
-      "integrity": "sha512-Kgle3jRgeMrKoa3S7CZZ5AU/efTrffzJSFayQT7lXO0je7ItsjUumjRZ3dxU+X+03vBP8XkcFYMdRwX70rX2dw==",
+      "version": "6.74.3",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-6.74.3.tgz",
+      "integrity": "sha512-kMjLUQkdgWOR2ZsKFdsCLAu8Z4aXg6Cl/Wz2alm08mr8KR/R05CzFbQTME/blhsZmreTpUW+59Rx+h3Q0/tMJw==",
       "dependencies": {
-        "@patternfly/react-styles": "^4.64.1",
-        "@patternfly/react-tokens": "^4.66.1",
+        "@patternfly/react-styles": "^4.71.3",
+        "@patternfly/react-tokens": "^4.73.3",
         "hoist-non-react-statics": "^3.3.0",
         "lodash": "^4.17.19",
         "tslib": "^2.0.0",
@@ -3190,14 +3236,14 @@
       }
     },
     "node_modules/@patternfly/react-core": {
-      "version": "4.214.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.214.1.tgz",
-      "integrity": "sha512-XHEqXpnBEDyLVdAEDOYlGqFHnN43eNLSD5HABB99xO6541JV9MRnbxs0+v9iYnfhcKh/8bhA9ITXnUi3f2PEvg==",
+      "version": "4.221.3",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.221.3.tgz",
+      "integrity": "sha512-I33TnX5Xn8ypXYjHc7G5kIVsYjB4PnDxxmJG6rBLqFslrnGUBzvb0sflnP43QlI0camamVIoaBRjedj8WXqaRg==",
       "dependencies": {
-        "@patternfly/react-icons": "^4.65.1",
-        "@patternfly/react-styles": "^4.64.1",
-        "@patternfly/react-tokens": "^4.66.1",
-        "focus-trap": "6.2.2",
+        "@patternfly/react-icons": "^4.72.3",
+        "@patternfly/react-styles": "^4.71.3",
+        "@patternfly/react-tokens": "^4.73.3",
+        "focus-trap": "6.9.2",
         "react-dropzone": "9.0.0",
         "tippy.js": "5.1.2",
         "tslib": "^2.0.0"
@@ -3208,28 +3254,28 @@
       }
     },
     "node_modules/@patternfly/react-icons": {
-      "version": "4.65.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.65.1.tgz",
-      "integrity": "sha512-CUYFRPztFkR7qrXq/0UAhLjeHd8FdjLe4jBjj8tfKc7OXwxDeZczqNFyRMATZpPaduTH7BU2r3OUjQrgAbquWg==",
+      "version": "4.72.3",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.72.3.tgz",
+      "integrity": "sha512-bZCPsOsxtFXTmZQqDKNebkBywud3E0ID3446AWI1RO5Ypufdc0FTkehSzBPANfJPYjjK9/EYaIy8rF0yiJdFPQ==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0",
         "react-dom": "^16.8.0 || ^17.0.0"
       }
     },
     "node_modules/@patternfly/react-styles": {
-      "version": "4.64.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.64.1.tgz",
-      "integrity": "sha512-+GxULkP2o5Vpr9w+J4NiGOGzhTfNniYzdPGEF/yC+oDoAXB6Q1HJyQnEj+kJH31xNvwmw3G3VFtwRLX4ZWr0oA=="
+      "version": "4.71.3",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.71.3.tgz",
+      "integrity": "sha512-JpMBIrJfco3JwK9KbJvjr+tKZidVhbkGrQT7GyWbYAwZ2bOmCmeCPJYc0xhAWcvNumn9a7AhYzAWPJVlQQue3g=="
     },
     "node_modules/@patternfly/react-table": {
-      "version": "4.83.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.83.1.tgz",
-      "integrity": "sha512-mkq13x9funh+Nh2Uzj2ZQBOacNYc+a60yUAHZMXgNcljCJ3LTQUoYy6EonvYrqwSrpC7vj8nLt8+/XbDNc0Aig==",
+      "version": "4.90.3",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.90.3.tgz",
+      "integrity": "sha512-RsSvs1IdvzOFcWgNc42COHfPJ/Dhl8gCHgwnC0ER/yD+IXOOdP+0u7+ZHGfF9+anAHZhQRJ2lGlQnp2HZM8b3A==",
       "dependencies": {
-        "@patternfly/react-core": "^4.214.1",
-        "@patternfly/react-icons": "^4.65.1",
-        "@patternfly/react-styles": "^4.64.1",
-        "@patternfly/react-tokens": "^4.66.1",
+        "@patternfly/react-core": "^4.221.3",
+        "@patternfly/react-icons": "^4.72.3",
+        "@patternfly/react-styles": "^4.71.3",
+        "@patternfly/react-tokens": "^4.73.3",
         "lodash": "^4.17.19",
         "tslib": "^2.0.0"
       },
@@ -3239,18 +3285,18 @@
       }
     },
     "node_modules/@patternfly/react-tokens": {
-      "version": "4.66.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.66.1.tgz",
-      "integrity": "sha512-k0IWqpufM6ezT+3gWlEamqQ7LW9yi8e8cBBlude5IU8eIEqIG6AccwR1WNBEK1wCVWGwVxakLMdf0XBLl4k52Q=="
+      "version": "4.73.3",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.73.3.tgz",
+      "integrity": "sha512-WyEcV9jiMZzscQMBhlDkypHw9qg0wbX7r/fe8HcWws+jnYWGVjwUdnr18ktI9aw/h/oQS46sirf8xbNTlIiQFg=="
     },
     "node_modules/@patternfly/react-topology": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-topology/-/react-topology-4.61.1.tgz",
-      "integrity": "sha512-sZ73Rj9and2a9PXZZ7MjesRdqbnXUoKrZnCc9u6lKi0xk/UCl0fukfDDtIv69k00znz2YjrXXLGsYNk/X9HeZA==",
+      "version": "4.68.3",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-topology/-/react-topology-4.68.3.tgz",
+      "integrity": "sha512-Le4H1Mm+FyBLmK/t1kbwunyFX0A6OKTOIZGtbofFwJWynYtQXB61/IkbNAR1z5lLVFs97LL4eEmALRTGX57lQA==",
       "dependencies": {
-        "@patternfly/react-core": "^4.214.1",
-        "@patternfly/react-icons": "^4.65.1",
-        "@patternfly/react-styles": "^4.64.1",
+        "@patternfly/react-core": "^4.221.3",
+        "@patternfly/react-icons": "^4.72.3",
+        "@patternfly/react-styles": "^4.71.3",
         "@types/d3": "^5.7.2",
         "@types/d3-force": "^1.2.1",
         "@types/dagre": "0.7.42",
@@ -9212,11 +9258,11 @@
       }
     },
     "node_modules/focus-trap": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.2.2.tgz",
-      "integrity": "sha512-qWovH9+LGoKqREvJaTCzJyO0hphQYGz+ap5Hc4NqXHNhZBdxCi5uBPPcaOUw66fHmzXLVwvETLvFgpwPILqKpg==",
+      "version": "6.9.2",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.9.2.tgz",
+      "integrity": "sha512-gBEuXOPNOKPrLdZpMFUSTyIo1eT2NSZRrwZ9r/0Jqw5tmT3Yvxfmu8KBHw8xW2XQkw6E/JoG+OlEq7UDtSUNgw==",
       "dependencies": {
-        "tabbable": "^5.1.4"
+        "tabbable": "^5.3.2"
       }
     },
     "node_modules/follow-redirects": {
@@ -17259,9 +17305,9 @@
       "dev": true
     },
     "node_modules/tabbable": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.2.1.tgz",
-      "integrity": "sha512-40pEZ2mhjaZzK0BnI+QGNjJO8UYx9pP5v7BGe17SORTO0OEuuaAwQTkAp8whcZvqon44wKFOikD+Al11K3JICQ=="
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
+      "integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA=="
     },
     "node_modules/tapable": {
       "version": "2.2.1",
@@ -21559,6 +21605,44 @@
         "whatwg-fetch": "2.x"
       },
       "dependencies": {
+        "@patternfly/react-core": {
+          "version": "4.214.1",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.214.1.tgz",
+          "integrity": "sha512-XHEqXpnBEDyLVdAEDOYlGqFHnN43eNLSD5HABB99xO6541JV9MRnbxs0+v9iYnfhcKh/8bhA9ITXnUi3f2PEvg==",
+          "dev": true,
+          "requires": {
+            "@patternfly/react-icons": "^4.65.1",
+            "@patternfly/react-styles": "^4.64.1",
+            "@patternfly/react-tokens": "^4.66.1",
+            "focus-trap": "6.2.2",
+            "react-dropzone": "9.0.0",
+            "tippy.js": "5.1.2",
+            "tslib": "^2.0.0"
+          }
+        },
+        "@patternfly/react-table": {
+          "version": "4.83.1",
+          "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.83.1.tgz",
+          "integrity": "sha512-mkq13x9funh+Nh2Uzj2ZQBOacNYc+a60yUAHZMXgNcljCJ3LTQUoYy6EonvYrqwSrpC7vj8nLt8+/XbDNc0Aig==",
+          "dev": true,
+          "requires": {
+            "@patternfly/react-core": "^4.214.1",
+            "@patternfly/react-icons": "^4.65.1",
+            "@patternfly/react-styles": "^4.64.1",
+            "@patternfly/react-tokens": "^4.66.1",
+            "lodash": "^4.17.19",
+            "tslib": "^2.0.0"
+          }
+        },
+        "focus-trap": {
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.2.2.tgz",
+          "integrity": "sha512-qWovH9+LGoKqREvJaTCzJyO0hphQYGz+ap5Hc4NqXHNhZBdxCi5uBPPcaOUw66fHmzXLVwvETLvFgpwPILqKpg==",
+          "dev": true,
+          "requires": {
+            "tabbable": "^5.1.4"
+          }
+        },
         "history": {
           "version": "4.10.1",
           "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
@@ -21633,9 +21717,9 @@
       }
     },
     "@patternfly/patternfly": {
-      "version": "4.194.4",
-      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-4.194.4.tgz",
-      "integrity": "sha512-SJxr502v0xXk1N5OiPLunD9pdKvHp5XXJLXcD5lIPrimjjUcy46m48X8YONjDvnC/Y5xV92UI2KxoCVucE34eA=="
+      "version": "4.196.7",
+      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-4.196.7.tgz",
+      "integrity": "sha512-hA7Oww411e1p0/IXjC1I+4/1NNis9V+NVBxfUIpRwyuLbCIDHBdtMu2qAPLdKxXjuibV9EE6ZdlT7ra/kcFuJQ=="
     },
     "@patternfly/quickstarts": {
       "version": "2.0.1",
@@ -21670,12 +21754,12 @@
       }
     },
     "@patternfly/react-charts": {
-      "version": "6.67.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-6.67.1.tgz",
-      "integrity": "sha512-Kgle3jRgeMrKoa3S7CZZ5AU/efTrffzJSFayQT7lXO0je7ItsjUumjRZ3dxU+X+03vBP8XkcFYMdRwX70rX2dw==",
+      "version": "6.74.3",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-charts/-/react-charts-6.74.3.tgz",
+      "integrity": "sha512-kMjLUQkdgWOR2ZsKFdsCLAu8Z4aXg6Cl/Wz2alm08mr8KR/R05CzFbQTME/blhsZmreTpUW+59Rx+h3Q0/tMJw==",
       "requires": {
-        "@patternfly/react-styles": "^4.64.1",
-        "@patternfly/react-tokens": "^4.66.1",
+        "@patternfly/react-styles": "^4.71.3",
+        "@patternfly/react-tokens": "^4.73.3",
         "hoist-non-react-statics": "^3.3.0",
         "lodash": "^4.17.19",
         "tslib": "^2.0.0",
@@ -21697,56 +21781,56 @@
       }
     },
     "@patternfly/react-core": {
-      "version": "4.214.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.214.1.tgz",
-      "integrity": "sha512-XHEqXpnBEDyLVdAEDOYlGqFHnN43eNLSD5HABB99xO6541JV9MRnbxs0+v9iYnfhcKh/8bhA9ITXnUi3f2PEvg==",
+      "version": "4.221.3",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.221.3.tgz",
+      "integrity": "sha512-I33TnX5Xn8ypXYjHc7G5kIVsYjB4PnDxxmJG6rBLqFslrnGUBzvb0sflnP43QlI0camamVIoaBRjedj8WXqaRg==",
       "requires": {
-        "@patternfly/react-icons": "^4.65.1",
-        "@patternfly/react-styles": "^4.64.1",
-        "@patternfly/react-tokens": "^4.66.1",
-        "focus-trap": "6.2.2",
+        "@patternfly/react-icons": "^4.72.3",
+        "@patternfly/react-styles": "^4.71.3",
+        "@patternfly/react-tokens": "^4.73.3",
+        "focus-trap": "6.9.2",
         "react-dropzone": "9.0.0",
         "tippy.js": "5.1.2",
         "tslib": "^2.0.0"
       }
     },
     "@patternfly/react-icons": {
-      "version": "4.65.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.65.1.tgz",
-      "integrity": "sha512-CUYFRPztFkR7qrXq/0UAhLjeHd8FdjLe4jBjj8tfKc7OXwxDeZczqNFyRMATZpPaduTH7BU2r3OUjQrgAbquWg==",
+      "version": "4.72.3",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.72.3.tgz",
+      "integrity": "sha512-bZCPsOsxtFXTmZQqDKNebkBywud3E0ID3446AWI1RO5Ypufdc0FTkehSzBPANfJPYjjK9/EYaIy8rF0yiJdFPQ==",
       "requires": {}
     },
     "@patternfly/react-styles": {
-      "version": "4.64.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.64.1.tgz",
-      "integrity": "sha512-+GxULkP2o5Vpr9w+J4NiGOGzhTfNniYzdPGEF/yC+oDoAXB6Q1HJyQnEj+kJH31xNvwmw3G3VFtwRLX4ZWr0oA=="
+      "version": "4.71.3",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.71.3.tgz",
+      "integrity": "sha512-JpMBIrJfco3JwK9KbJvjr+tKZidVhbkGrQT7GyWbYAwZ2bOmCmeCPJYc0xhAWcvNumn9a7AhYzAWPJVlQQue3g=="
     },
     "@patternfly/react-table": {
-      "version": "4.83.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.83.1.tgz",
-      "integrity": "sha512-mkq13x9funh+Nh2Uzj2ZQBOacNYc+a60yUAHZMXgNcljCJ3LTQUoYy6EonvYrqwSrpC7vj8nLt8+/XbDNc0Aig==",
+      "version": "4.90.3",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.90.3.tgz",
+      "integrity": "sha512-RsSvs1IdvzOFcWgNc42COHfPJ/Dhl8gCHgwnC0ER/yD+IXOOdP+0u7+ZHGfF9+anAHZhQRJ2lGlQnp2HZM8b3A==",
       "requires": {
-        "@patternfly/react-core": "^4.214.1",
-        "@patternfly/react-icons": "^4.65.1",
-        "@patternfly/react-styles": "^4.64.1",
-        "@patternfly/react-tokens": "^4.66.1",
+        "@patternfly/react-core": "^4.221.3",
+        "@patternfly/react-icons": "^4.72.3",
+        "@patternfly/react-styles": "^4.71.3",
+        "@patternfly/react-tokens": "^4.73.3",
         "lodash": "^4.17.19",
         "tslib": "^2.0.0"
       }
     },
     "@patternfly/react-tokens": {
-      "version": "4.66.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.66.1.tgz",
-      "integrity": "sha512-k0IWqpufM6ezT+3gWlEamqQ7LW9yi8e8cBBlude5IU8eIEqIG6AccwR1WNBEK1wCVWGwVxakLMdf0XBLl4k52Q=="
+      "version": "4.73.3",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.73.3.tgz",
+      "integrity": "sha512-WyEcV9jiMZzscQMBhlDkypHw9qg0wbX7r/fe8HcWws+jnYWGVjwUdnr18ktI9aw/h/oQS46sirf8xbNTlIiQFg=="
     },
     "@patternfly/react-topology": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-topology/-/react-topology-4.61.1.tgz",
-      "integrity": "sha512-sZ73Rj9and2a9PXZZ7MjesRdqbnXUoKrZnCc9u6lKi0xk/UCl0fukfDDtIv69k00znz2YjrXXLGsYNk/X9HeZA==",
+      "version": "4.68.3",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-topology/-/react-topology-4.68.3.tgz",
+      "integrity": "sha512-Le4H1Mm+FyBLmK/t1kbwunyFX0A6OKTOIZGtbofFwJWynYtQXB61/IkbNAR1z5lLVFs97LL4eEmALRTGX57lQA==",
       "requires": {
-        "@patternfly/react-core": "^4.214.1",
-        "@patternfly/react-icons": "^4.65.1",
-        "@patternfly/react-styles": "^4.64.1",
+        "@patternfly/react-core": "^4.221.3",
+        "@patternfly/react-icons": "^4.72.3",
+        "@patternfly/react-styles": "^4.71.3",
         "@types/d3": "^5.7.2",
         "@types/d3-force": "^1.2.1",
         "@types/dagre": "0.7.42",
@@ -26571,11 +26655,11 @@
       }
     },
     "focus-trap": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.2.2.tgz",
-      "integrity": "sha512-qWovH9+LGoKqREvJaTCzJyO0hphQYGz+ap5Hc4NqXHNhZBdxCi5uBPPcaOUw66fHmzXLVwvETLvFgpwPILqKpg==",
+      "version": "6.9.2",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.9.2.tgz",
+      "integrity": "sha512-gBEuXOPNOKPrLdZpMFUSTyIo1eT2NSZRrwZ9r/0Jqw5tmT3Yvxfmu8KBHw8xW2XQkw6E/JoG+OlEq7UDtSUNgw==",
       "requires": {
-        "tabbable": "^5.1.4"
+        "tabbable": "^5.3.2"
       }
     },
     "follow-redirects": {
@@ -32730,9 +32814,9 @@
       "dev": true
     },
     "tabbable": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.2.1.tgz",
-      "integrity": "sha512-40pEZ2mhjaZzK0BnI+QGNjJO8UYx9pP5v7BGe17SORTO0OEuuaAwQTkAp8whcZvqon44wKFOikD+Al11K3JICQ=="
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
+      "integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA=="
     },
     "tapable": {
       "version": "2.2.1",

--- a/web/package.json
+++ b/web/package.json
@@ -97,11 +97,11 @@
     }
   },
   "dependencies": {
-    "@patternfly/patternfly": "4.194.4",
-    "@patternfly/react-charts": "^6.67.1",
-    "@patternfly/react-core": "^4.214.1",
-    "@patternfly/react-table": "4.83.1",
-    "@patternfly/react-topology": "4.61.1",
+    "@patternfly/patternfly": "4.196.7",
+    "@patternfly/react-charts": "6.74.3",
+    "@patternfly/react-core": "4.221.3",
+    "@patternfly/react-table": "4.90.3",
+    "@patternfly/react-topology": "4.68.3",
     "history": "^5.1.0",
     "i18next": "^19.8.3",
     "i18next-http-backend": "^1.0.21",

--- a/web/src/components/netflow-table/netflow-table-row.tsx
+++ b/web/src/components/netflow-table/netflow-table-row.tsx
@@ -9,6 +9,7 @@ import CSSTransition from 'react-transition-group/CSSTransition';
 import { isDark } from '../../utils/theme';
 
 const NetflowTableRow: React.FC<{
+  lastRender?: string;
   flow: Record;
   selectedRecord?: Record;
   columns: Column[];
@@ -18,7 +19,7 @@ const NetflowTableRow: React.FC<{
   height?: number;
   showContent?: boolean;
   tableWidth: number;
-}> = ({ flow, selectedRecord, columns, size, onSelect, highlight, height, showContent, tableWidth }) => {
+}> = ({ lastRender, flow, selectedRecord, columns, size, onSelect, highlight, height, showContent, tableWidth }) => {
   const onRowClick = () => {
     onSelect(flow);
   };
@@ -26,6 +27,7 @@ const NetflowTableRow: React.FC<{
   return (
     <CSSTransition in={highlight} appear={highlight} timeout={100} classNames="newflow">
       <Tr
+        data-last-render={lastRender || ''}
         data-test={`tr-${flow.key}`}
         isRowSelected={flow.key === selectedRecord?.key}
         onRowClick={onRowClick}


### PR DESCRIPTION
This PR fixes the following issues that happens on query changes after scrolling:
![image](https://user-images.githubusercontent.com/91894519/174080941-b8e4890e-baaf-45a9-8d70-4b4b29730b4c.png)

It adds `data-last-render` attribute containing a `timestamp` on every `tr` and remove previous ones (if any) every time flows are updated.
This seems to be a bug in PF `TableComposable` that sometimes keeps previous rows when multiple refresh occurs on the same table instance.

I have also took the opportunity to update dependencies :smiley_cat: 