### PR TITLE
NETOBSERV-101 R&D: Kube enricher write path for downstream operator

### DIFF
--- a/cmd/plugin-backend.go
+++ b/cmd/plugin-backend.go
@@ -30,6 +30,7 @@ var (
 	lokiLabels     = flag.String("loki-labels", "SrcK8S_Namespace,SrcK8S_OwnerName,DstK8S_Namespace,DstK8S_OwnerName,FlowDirection", "Loki labels, comma separated")
 	lokiTimeout    = flag.Duration("loki-timeout", 10*time.Second, "Timeout of the Loki query to retrieve logs")
 	lokiTenantID   = flag.String("loki-tenant-id", "", "Tenant organization ID for multi-tenant-loki (submitted as the X-Scope-OrgID HTTP header)")
+	lokiTokenPath  = flag.String("loki-token-path", "", "Path to Bearer authorization header for loki gateway)")
 	lokiCAPath     = flag.String("loki-ca-path", "", "Path to loki CA certificate")
 	lokiSkipTLS    = flag.Bool("loki-skip-tls", false, "Skip TLS checks for loki HTTPS connection")
 	lokiMock       = flag.Bool("loki-mock", false, "Fake loki results using saved mocks")
@@ -76,7 +77,7 @@ func main() {
 		CORSAllowMethods: *corsMethods,
 		CORSAllowHeaders: *corsHeaders,
 		CORSMaxAge:       *corsMaxAge,
-		Loki:             loki.NewConfig(lURL, *lokiTimeout, *lokiTenantID, *lokiSkipTLS, *lokiCAPath, *lokiMock, *ingressMatcher, strings.Split(lLabels, ",")),
+		Loki:             loki.NewConfig(lURL, *lokiTimeout, *lokiTenantID, *lokiTokenPath, *lokiSkipTLS, *lokiCAPath, *lokiMock, *ingressMatcher, strings.Split(lLabels, ",")),
 		FrontendConfig:   *frontendConfig,
 	})
 }

--- a/pkg/handler/loki.go
+++ b/pkg/handler/loki.go
@@ -27,15 +27,18 @@ type LokiError struct {
 var hlog = logrus.WithField("module", "handler")
 
 const (
-	lokiOrgIDHeader = "X-Scope-OrgID"
+	lokiOrgIDHeader         = "X-Scope-OrgID"
+	lokiAuthorizationHeader = "Authorization"
 )
 
 func newLokiClient(cfg *loki.Config) httpclient.Caller {
-	var headers map[string][]string
+	headers := map[string][]string{}
 	if cfg.TenantID != "" {
-		headers = map[string][]string{
-			lokiOrgIDHeader: {cfg.TenantID},
-		}
+		headers[lokiOrgIDHeader] = []string{cfg.TenantID}
+	}
+
+	if cfg.Authorization != "" {
+		headers[lokiAuthorizationHeader] = []string{cfg.Authorization}
 	}
 
 	if cfg.UseMocks {

--- a/pkg/loki/config.go
+++ b/pkg/loki/config.go
@@ -1,16 +1,21 @@
 package loki
 
 import (
+	"io/ioutil"
 	"net/url"
 	"time"
 
 	"github.com/netobserv/network-observability-console-plugin/pkg/utils"
+	"github.com/sirupsen/logrus"
 )
+
+var log = logrus.WithField("module", "loki config")
 
 type Config struct {
 	URL            *url.URL
 	Timeout        time.Duration
 	TenantID       string
+	Authorization  string
 	SkipTLS        bool
 	CAPath         string
 	UseMocks       bool
@@ -18,11 +23,21 @@ type Config struct {
 	Labels         map[string]struct{}
 }
 
-func NewConfig(url *url.URL, timeout time.Duration, tenantID string, skipTLS bool, capath string, useMocks bool, ingressMatcher string, labels []string) Config {
+func NewConfig(url *url.URL, timeout time.Duration, tenantID string, tokenPath string, skipTLS bool, capath string, useMocks bool, ingressMatcher string, labels []string) Config {
+	authorization := ""
+	if tokenPath != "" {
+		bytes, err := ioutil.ReadFile(tokenPath)
+		if err != nil {
+			log.WithError(err).Fatalf("failed to parse authorization path: %s", tokenPath)
+		}
+		authorization = "Bearer " + string(bytes)
+	}
+
 	return Config{
 		URL:            url,
 		Timeout:        timeout,
 		TenantID:       tenantID,
+		Authorization:  authorization,
 		SkipTLS:        skipTLS,
 		CAPath:         capath,
 		UseMocks:       useMocks,

--- a/pkg/loki/query_test.go
+++ b/pkg/loki/query_test.go
@@ -12,7 +12,7 @@ import (
 func TestFlowQuery_AddLabelFilters(t *testing.T) {
 	lokiURL, err := url.Parse("/")
 	require.NoError(t, err)
-	cfg := NewConfig(lokiURL, time.Second, "", false, "", false, ".*-ingress$", []string{"foo", "flis"})
+	cfg := NewConfig(lokiURL, time.Second, "", "", false, "", false, ".*-ingress$", []string{"foo", "flis"})
 	query := NewFlowQueryBuilderWithDefaults(&cfg)
 	err = query.AddFilter("foo", `"bar"`)
 	require.NoError(t, err)
@@ -25,7 +25,7 @@ func TestFlowQuery_AddLabelFilters(t *testing.T) {
 func TestQuery_BackQuote_Error(t *testing.T) {
 	lokiURL, err := url.Parse("/")
 	require.NoError(t, err)
-	cfg := NewConfig(lokiURL, time.Second, "", false, "", false, ".*-ingress$", []string{"lab1", "lab2"})
+	cfg := NewConfig(lokiURL, time.Second, "", "", false, "", false, ".*-ingress$", []string{"lab1", "lab2"})
 	query := NewFlowQueryBuilderWithDefaults(&cfg)
 	assert.Error(t, query.AddFilter("key", "backquoted`val"))
 }

--- a/pkg/server/server_flows_test.go
+++ b/pkg/server/server_flows_test.go
@@ -230,6 +230,7 @@ func TestLokiFiltering(t *testing.T) {
 			lokiURL,
 			time.Second,
 			"",
+			"",
 			false,
 			"",
 			false,

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -280,9 +280,10 @@ func TestLokiConfiguration_MultiTenant(t *testing.T) {
 	// GIVEN a NOO console plugin backend configured for Multi tenant mode
 	backendRoutes := setupRoutes(&Config{
 		Loki: loki.Config{
-			URL:      lokiURL,
-			Timeout:  time.Second,
-			TenantID: "my-organisation",
+			URL:           lokiURL,
+			Timeout:       time.Second,
+			TenantID:      "my-organisation",
+			Authorization: "Bearer XXX",
 		},
 	})
 	backendSvc := httptest.NewServer(backendRoutes)
@@ -295,6 +296,7 @@ func TestLokiConfiguration_MultiTenant(t *testing.T) {
 	// THEN the query has been properly forwarded to Loki with the tenant ID header
 	req := lokiMock.Calls[0].Arguments[1].(*http.Request)
 	assert.Equal(t, "my-organisation", req.Header.Get("X-Scope-OrgID"))
+	assert.Equal(t, "Bearer XXX", req.Header.Get("Authorization"))
 }
 
 type httpMock struct {


### PR DESCRIPTION
This PR adds Authorization header to loki client from specified `loki-token-path`