### PR TITLE
Updated Dockerfile to use node 16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,9 @@
-FROM registry.access.redhat.com/ubi8/nodejs-14:1 as web-builder
+FROM registry.access.redhat.com/ubi8/nodejs-16:1 as web-builder
 
 WORKDIR /opt/app-root
 
-RUN npm install npm@8.2.0 -g
-RUN mkdir web && chown $USER: web
-COPY Makefile Makefile
-COPY web web
+COPY --chown=default Makefile Makefile
+COPY --chown=default web web
 COPY mocks mocks
 
 RUN NPM_INSTALL=ci make build-frontend


### PR DESCRIPTION
This facilitate downstream build since we don't need to manually update npm anymore.

I tested the built image and did not see any difference.