### PR TITLE
NETOBSERV-546 formatProtocol crash on unknown protocol number

### DIFF
--- a/web/src/utils/protocol.ts
+++ b/web/src/utils/protocol.ts
@@ -2,7 +2,7 @@ import protocols from 'protocol-numbers';
 import { compareStrings } from './base-compare';
 
 export const formatProtocol = (p: number) => {
-  if (p !== undefined) {
+  if (p !== undefined && protocols[p]) {
     return protocols[p].name;
   } else {
     return 'N/A';


### PR DESCRIPTION
This ensure `formatProtocol` to get existing protocol name without crashing.
Else it returns 'N/A'

![image](https://user-images.githubusercontent.com/91894519/187175192-ef0ba2c7-f043-4a50-9e67-1f42d4044881.png)
