### PR TITLE
NETOBSERV-554 - Topology test ids generation

### DIFF
--- a/web/src/model/topology.ts
+++ b/web/src/model/topology.ts
@@ -18,6 +18,7 @@ import { defaultTimeRange } from '../utils/router';
 import { findFilter } from '../utils/filter-definitions';
 import { TFunction } from 'i18next';
 import { K8sModel } from '@openshift-console/dynamic-plugin-sdk';
+import { getTopologyEdgeId, getTopologyGroupId, getTopologyNodeId } from '../utils/ids';
 
 export enum LayoutName {
   Cola = 'Cola',
@@ -201,7 +202,7 @@ export const generateNode = (
   t: TFunction,
   k8sModels: { [key: string]: K8sModel }
 ): NodeModel => {
-  const id = `${data.type}.${data.namespace}.${data.name}.${data.addr}.${data.host}`;
+  const id = getTopologyNodeId(data.type, data.namespace, data.name, data.addr, data.host);
   const label = data.name
     ? data.name
     : data.addr
@@ -330,7 +331,7 @@ export const generateEdge = (
   const id = `${sourceId}.${targetId}`;
   const highlighted = !shadowed && !_.isEmpty(highlightedId) && id.includes(highlightedId);
   return {
-    id: `${sourceId}.${targetId}`,
+    id: getTopologyEdgeId(sourceId, targetId),
     type: 'edge',
     source: sourceId,
     target: targetId,
@@ -371,7 +372,7 @@ export const generateDataModel = (
     let group = nodes.find(g => g.type === 'group' && g.id === id);
     if (!group) {
       group = {
-        id,
+        id: getTopologyGroupId(type, name),
         children: [],
         type: 'group',
         group: true,

--- a/web/src/utils/ids.ts
+++ b/web/src/utils/ids.ts
@@ -1,0 +1,63 @@
+/* This file contains id generation reused by QE team
+ *  Please keep them updated of any change
+ */
+
+/**
+ * getTopologyGroupId gets a unique group id
+ * @param groupType string that represent group type.
+ * This could either be 'Node', 'Namespace' or any valid K8S Owner / Resource type
+ * @param name string that represent group name
+ * This could either be Host, Namespace or Owner name
+ * @returns string that identify the group
+ */
+export const getTopologyGroupId = (groupType: string, name: string) => {
+  return `${groupType}.${name}`.toLowerCase();
+};
+
+/**
+ * getTopologyEdgeId gets a unique edge id between two nodes
+ * source / target can be inverted. If one of these pairs already exists, the opposit will not be created
+ * @param sourceId string that represent a NodeId
+ * @param targetId string that represent another NodeId
+ * @returns string that identify the edge
+ */
+export const getTopologyEdgeId = (sourceId: string, targetId: string) => {
+  return `${sourceId}.${targetId}`.toLowerCase();
+};
+
+/**
+ * getTopologyNodeId gets a unique node id
+ * @param nodeType string that represent node type
+ * This could either be 'Node', 'Namespace' or any valid K8S Ower / Resource type
+ * @param namespace string that represent namespace (may be empty for external / host)
+ * @param name string that represent name (may be empty for external)
+ * @param addr string containing ip address (may be empty for external when scope is not ressources)
+ * @param host string containing host (may be empty for services / external)
+ * @returns string that identify the node
+ */
+export const getTopologyNodeId = (
+  nodeType?: string,
+  namespace?: string,
+  name?: string,
+  addr?: string,
+  host?: string
+) => {
+  const strs: string[] = [];
+
+  function addStr(str?: string) {
+    if (str) {
+      strs.push(str);
+    }
+  }
+
+  addStr(nodeType);
+  addStr(namespace);
+  addStr(name);
+  addStr(addr);
+  addStr(host);
+
+  if (strs.length) {
+    return strs.join('.').toLowerCase();
+  }
+  return 'external';
+};


### PR DESCRIPTION
This PR put topology ids generation in a separate file to allow QE to easy reuse these.

![image](https://user-images.githubusercontent.com/91894519/191037180-3fa9f4ce-f9d6-442c-82c0-1ed167590380.png)

It also remove all the `.undefined.` parts in these and document the possibilities
