### PR TITLE
NETOBSERV-581 & NETOBSERV-554 fix group id

### DIFF
--- a/web/src/model/topology.ts
+++ b/web/src/model/topology.ts
@@ -350,11 +350,11 @@ export const generateDataModel = (
   const opts = { ...DefaultOptions, ...options };
 
   function addGroup(name: string, type: string, parent?: NodeModel, secondaryLabelPadding = false) {
-    const id = `${parent ? parent.id + '.' : ''}${type}.${name}`;
+    const id = getTopologyGroupId(type, name, parent ? parent.id : undefined);
     let group = nodes.find(g => g.type === 'group' && g.id === id);
     if (!group) {
       group = {
-        id: getTopologyGroupId(type, name),
+        id,
         children: [],
         type: 'group',
         group: true,

--- a/web/src/utils/ids.ts
+++ b/web/src/utils/ids.ts
@@ -10,8 +10,8 @@
  * This could either be Host, Namespace or Owner name
  * @returns string that identify the group
  */
-export const getTopologyGroupId = (groupType: string, name: string) => {
-  return `${groupType}.${name}`.toLowerCase();
+export const getTopologyGroupId = (groupType: string, name: string, parentId?: string) => {
+  return `${parentId ? parentId + '.' : ''}${groupType}.${name}`.toLowerCase();
 };
 
 /**


### PR DESCRIPTION
https://github.com/netobserv/network-observability-console-plugin/pull/193 introduced a bug in multy grouping because of the id generation.

This PR restore parent id in groups that fixes this issue