### PR TITLE
NETOBSERV-487 - deselecting "Export all datas" causes few columns to be missed

### DIFF
--- a/web/src/components/netflow-traffic.tsx
+++ b/web/src/components/netflow-traffic.tsx
@@ -878,7 +878,7 @@ export const NetflowTraffic: React.FC<{
         isModalOpen={isExportModalOpen}
         setModalOpen={setExportModalOpen}
         flowQuery={buildFlowQuery()}
-        columns={columns.filter(c => c.fieldName)}
+        columns={columns.filter(c => c.fieldName && !c.fieldName.startsWith('Time'))}
         range={range}
         filters={forcedFilters ? forcedFilters : filters}
       />


### PR DESCRIPTION
This PR force `TimeFlowStartMs`,  `TimeFlowEndMs` & `TimeReceived` to be exported  as firsts columns in the csv file.

These are not listed anymore on front end side in the export popup.

It also fixes a bug on labels.

![image](https://user-images.githubusercontent.com/91894519/193836906-bd95b598-be11-438f-bb08-467c3f2d2808.png)
![image](https://user-images.githubusercontent.com/91894519/193837010-8d6cfbd7-f5f9-488d-9ed9-8638f30a4b09.png)
