### PR TITLE
NETOBSERV-409 - Total flows chart

### DIFF
--- a/cmd/plugin-backend.go
+++ b/cmd/plugin-backend.go
@@ -30,7 +30,7 @@ var (
 	lokiStatusURL        = flag.String("loki-status", "", "URL for loki /ready /metrics /config endpoints. (default: loki flag value")
 	lokiLabels           = flag.String("loki-labels", "SrcK8S_Namespace,SrcK8S_OwnerName,DstK8S_Namespace,DstK8S_OwnerName,FlowDirection", "Loki labels, comma separated")
 	lokiTimeout          = flag.Duration("loki-timeout", 10*time.Second, "Timeout of the Loki query to retrieve logs")
-	lokiTenantID         = flag.String("loki-tenant-id", "", "Tenant organization ID for multi-tenant-loki (submitted as the X-Scope-OrgID HTTP header)")
+	lokiTenantID         = flag.String("loki-tenant-id", "netobserv", "Tenant organization ID for multi-tenant-loki (submitted as the X-Scope-OrgID HTTP header)")
 	lokiTokenPath        = flag.String("loki-token-path", "", "Path to Bearer authorization header for loki gateway)")
 	lokiForwardUserToken = flag.Bool("loki-forward-user-token", false, "Forward the user Bearer authorization header for loki gateway), this override loki-token-path option")
 	lokiCAPath           = flag.String("loki-ca-path", "", "Path to loki CA certificate")

--- a/pkg/loki/topology_query.go
+++ b/pkg/loki/topology_query.go
@@ -52,6 +52,8 @@ func NewTopologyQuery(cfg *Config, start, end, limit, rateInterval, step, metric
 func getFields(scope, groups string) string {
 	var fields []string
 	switch scope {
+	case "app":
+		fields = []string{"app"}
 	case "host":
 		fields = []string{"SrcK8S_HostName", "DstK8S_HostName"}
 	case "namespace":

--- a/web/locales/en/plugin__netobserv-plugin.json
+++ b/web/locales/en/plugin__netobserv-plugin.json
@@ -99,6 +99,7 @@
   "Total {{type}}": "Total {{type}}",
   "External": "External",
   "Unknown": "Unknown",
+  "Collected flows": "Collected flows",
   "Manage columns": "Manage columns",
   "Selected columns will appear in the table.": "Selected columns will appear in the table.",
   "Click and drag the items to reorder the columns in the table.": "Click and drag the items to reorder the columns in the table.",

--- a/web/src/components/metrics/metrics-content.tsx
+++ b/web/src/components/metrics/metrics-content.tsx
@@ -18,7 +18,7 @@ import { useTranslation } from 'react-i18next';
 import { MetricScopeOptions } from '../../model/metrics';
 import { TopologyMetricPeer, TopologyMetrics } from '../../api/loki';
 import { MetricFunction, MetricType } from '../../model/flow-query';
-import { getDateFromUnix } from '../../utils/datetime';
+import { getDateFromUnix, getFormattedDate } from '../../utils/datetime';
 import './metrics-content.css';
 import { getFormattedValue, getFormattedRateValue, matchPeer } from '../../utils/metrics';
 import { getStat, NodeData } from '../../model/topology';
@@ -74,6 +74,7 @@ export const MetricsContent: React.FC<{
   }, [metricFunction, metricType, t]);
 
   const chart = React.useCallback(() => {
+    //TODO: NETOBSERV-635 add this as tab options
     // function truncate(input: string) {
     //   const length = doubleWidth ? 64 : showDonut ? 10 : 18;
     //   if (input.length > length) {
@@ -98,12 +99,15 @@ export const MetricsContent: React.FC<{
       return peer.displayName || (scope === MetricScopeOptions.HOST ? t('External') : t('Unknown'));
     };
 
-    function getName(source: TopologyMetricPeer, dest: TopologyMetricPeer) {
-      const srcName = getPeerName(source);
-      const dstName = getPeerName(dest);
-      if (data && matchPeer(data, source)) {
+    function getName(source?: TopologyMetricPeer, dest?: TopologyMetricPeer) {
+      if (id === 'total_timeseries') {
+        return t('Collected flows');
+      }
+      const srcName = getPeerName(source!);
+      const dstName = getPeerName(dest!);
+      if (data && matchPeer(data, source!)) {
         return `${t('To')} ${dstName}`;
-      } else if (data && matchPeer(data, dest)) {
+      } else if (data && matchPeer(data, dest!)) {
         return `${t('From')} ${srcName}`;
       }
       return `${srcName} -> ${dstName}`;
@@ -127,9 +131,9 @@ export const MetricsContent: React.FC<{
         }: {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           datum: any;
-        }) => `${datum.y !== null ? datum.y : 'no data'}`}
+        }) => `${datum.y !== null ? getFormattedRateValue(datum.y, metricType) : 'no data'}`}
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        labelComponent={<ChartLegendTooltip legendData={legendData} title={(datum: any) => datum.x} />}
+        labelComponent={<ChartLegendTooltip legendData={legendData} title={(datum: any) => datum.date} />}
         mouseFollowTooltips
         voronoiDimension="x"
         voronoiPadding={50}
@@ -195,7 +199,7 @@ export const MetricsContent: React.FC<{
             domainPadding={{ x: 0, y: 0 }}
             padding={{
               bottom: legendData.length * 25 + 50,
-              left: 75,
+              left: 90,
               right: 50,
               top: 50
             }}
@@ -210,6 +214,7 @@ export const MetricsContent: React.FC<{
                     key={`bar-${metrics.indexOf(m)}`}
                     data={m.values.map(v => ({
                       name: getName(m.source, m.destination),
+                      date: getFormattedDate(getDateFromUnix(v[0])),
                       x: getDateFromUnix(v[0]),
                       y: Number(v[1])
                     }))}
@@ -225,6 +230,7 @@ export const MetricsContent: React.FC<{
                     key={`area-${metrics.indexOf(m)}`}
                     data={m.values.map(v => ({
                       name: getName(m.source, m.destination),
+                      date: getFormattedDate(getDateFromUnix(v[0])),
                       x: getDateFromUnix(v[0]),
                       y: Number(v[1])
                     }))}
@@ -241,6 +247,7 @@ export const MetricsContent: React.FC<{
                     key={`scatter-${metrics.indexOf(m)}`}
                     data={m.values.map(v => ({
                       name: getName(m.source, m.destination),
+                      date: getFormattedDate(getDateFromUnix(v[0])),
                       x: getDateFromUnix(v[0]),
                       y: Number(v[1])
                     }))}

--- a/web/src/components/netflow-overview/__tests__/netflow-overview-panel.spec.tsx
+++ b/web/src/components/netflow-overview/__tests__/netflow-overview-panel.spec.tsx
@@ -17,7 +17,8 @@ describe('<NetflowOverviewPanel />', () => {
     metricFunction: 'sum' as MetricFunction,
     metricType: 'bytes' as MetricType,
     metricScope: MetricScopeOptions.HOST,
-    metrics: [] as TopologyMetrics[]
+    metrics: [] as TopologyMetrics[],
+    appMetrics: [] as TopologyMetrics[]
   };
   it('should render component', async () => {
     const wrapper = shallow(<NetflowOverviewPanel {...props} />);

--- a/web/src/components/netflow-overview/__tests__/netflow-overview.spec.tsx
+++ b/web/src/components/netflow-overview/__tests__/netflow-overview.spec.tsx
@@ -21,6 +21,7 @@ describe('<NetflowOverview />', () => {
     metricType: 'bytes' as MetricType,
     metricScope: MetricScopeOptions.HOST,
     metrics: [] as TopologyMetrics[],
+    appMetrics: [] as TopologyMetrics[],
     clearFilters: jest.fn()
   };
   it('should render component', async () => {

--- a/web/src/components/netflow-overview/netflow-overview-panel.tsx
+++ b/web/src/components/netflow-overview/netflow-overview-panel.tsx
@@ -15,8 +15,9 @@ export const NetflowOverviewPanel: React.FC<{
   metricType: MetricType;
   metricScope: MetricScope;
   metrics: TopologyMetrics[];
+  appMetrics: TopologyMetrics[];
   doubleWidth?: boolean;
-}> = ({ limit, panel, metricFunction, metricType, metricScope, metrics, doubleWidth }) => {
+}> = ({ limit, panel, metricFunction, metricType, metricScope, metrics, appMetrics, doubleWidth }) => {
   const { t } = useTranslation('plugin__netobserv-plugin');
 
   const getContent = React.useCallback(() => {
@@ -34,7 +35,7 @@ export const NetflowOverviewPanel: React.FC<{
             sizePx={600}
             metricFunction={metricFunction}
             metricType={metricType}
-            metrics={metrics}
+            metrics={panel.id === 'total_timeseries' ? appMetrics : metrics}
             scope={metricScope as MetricScopeOptions}
             showDonut={panel.id === 'top_donut'}
             showBar={panel.id === 'top_bar'}
@@ -53,7 +54,7 @@ export const NetflowOverviewPanel: React.FC<{
       default:
         return t('Error: Unknown panel type');
     }
-  }, [panel.id, metricFunction, metricType, metrics, metricScope, doubleWidth, t]);
+  }, [panel.id, metricFunction, metricType, appMetrics, metrics, metricScope, doubleWidth, t]);
 
   return (
     <Panel variant="raised">

--- a/web/src/components/netflow-overview/netflow-overview.tsx
+++ b/web/src/components/netflow-overview/netflow-overview.tsx
@@ -30,10 +30,22 @@ export const NetflowOverview: React.FC<{
   metricType: MetricType;
   metricScope: MetricScope;
   metrics: TopologyMetrics[];
+  appMetrics: TopologyMetrics[];
   loading?: boolean;
   error?: string;
   clearFilters: () => void;
-}> = ({ limit, panels, metricFunction, metricType, metricScope, metrics, loading, error, clearFilters }) => {
+}> = ({
+  limit,
+  panels,
+  metricFunction,
+  metricType,
+  metricScope,
+  metrics,
+  appMetrics,
+  loading,
+  error,
+  clearFilters
+}) => {
   const { t } = useTranslation('plugin__netobserv-plugin');
 
   if (error) {
@@ -102,6 +114,7 @@ export const NetflowOverview: React.FC<{
                 metricType={metricType}
                 metricScope={metricScope}
                 metrics={filteredMetrics}
+                appMetrics={appMetrics}
                 doubleWidth={isDoubleWidth(panel.id)}
               />
             </FlexItem>

--- a/web/src/components/query-summary/__tests__/query-summary.spec.tsx
+++ b/web/src/components/query-summary/__tests__/query-summary.spec.tsx
@@ -9,11 +9,14 @@ describe('<QuerySummary />', () => {
   const mocks = {
     toggleQuerySummary: jest.fn(),
     flows: FlowsSample,
-    range: 300,
+    metrics: undefined,
+    appMetrics: undefined,
     stats: {
       limitReached: false,
       numQueries: 1
     },
+    appStats: undefined,
+    range: 300,
     lastRefresh: now
   };
 

--- a/web/src/components/query-summary/__tests__/summary-panel.spec.tsx
+++ b/web/src/components/query-summary/__tests__/summary-panel.spec.tsx
@@ -8,11 +8,14 @@ describe('<SummaryPanel />', () => {
   const mocks = {
     onClose: jest.fn(),
     flows: FlowsSample,
-    range: 300,
+    metrics: undefined,
+    appMetrics: undefined,
     stats: {
       limitReached: false,
       numQueries: 1
     },
+    appStats: undefined,
+    range: 300,
     lastRefresh: new Date(),
     id: 'summary-panel'
   };

--- a/web/src/components/query-summary/query-summary.tsx
+++ b/web/src/components/query-summary/query-summary.tsx
@@ -6,7 +6,7 @@ import { Record } from '../../api/ipfix';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import './query-summary.css';
 import { bytesPerSeconds, humanFileSize } from '../../utils/bytes';
-import { Stats } from '../../api/loki';
+import { Stats, TopologyMetrics } from '../../api/loki';
 
 export const QuerySummaryContent: React.FC<{
   flows: Record[];
@@ -91,7 +91,10 @@ export const QuerySummaryContent: React.FC<{
 
 export const QuerySummary: React.FC<{
   flows: Record[] | undefined;
+  metrics: TopologyMetrics[] | undefined;
+  appMetrics: TopologyMetrics[] | undefined;
   stats: Stats | undefined;
+  appStats: Stats | undefined;
   range: number | TimeRange;
   lastRefresh: Date | undefined;
   toggleQuerySummary: () => void;

--- a/web/src/components/query-summary/summary-panel.tsx
+++ b/web/src/components/query-summary/summary-panel.tsx
@@ -25,7 +25,7 @@ import { QuerySummaryContent } from './query-summary';
 import { comparePorts, formatPort } from '../../utils/port';
 import { formatProtocol } from '../../utils/protocol';
 import { compareIPs } from '../../utils/ip';
-import { Stats } from '../../api/loki';
+import { Stats, TopologyMetrics } from '../../api/loki';
 import './summary-panel.css';
 
 type TypeCardinality = {
@@ -243,7 +243,10 @@ export const SummaryPanelContent: React.FC<{
 export const SummaryPanel: React.FC<{
   onClose: () => void;
   flows: Record[] | undefined;
+  metrics: TopologyMetrics[] | undefined;
+  appMetrics: TopologyMetrics[] | undefined;
   stats: Stats | undefined;
+  appStats: Stats | undefined;
   range: number | TimeRange;
   lastRefresh: Date | undefined;
   id?: string;

--- a/web/src/model/flow-query.ts
+++ b/web/src/model/flow-query.ts
@@ -5,7 +5,7 @@ export type Layer = 'infrastructure' | 'application' | 'both';
 export type Match = 'all' | 'any';
 export type MetricFunction = 'sum' | 'avg' | 'max' | 'last';
 export type MetricType = 'bytes' | 'packets';
-export type MetricScope = 'host' | 'namespace' | 'owner' | 'resource';
+export type MetricScope = 'app' | 'host' | 'namespace' | 'owner' | 'resource';
 export type NodeType = MetricScope | 'unknown';
 export type Groups = 'hosts' | 'hosts+namespaces' | 'hosts+owners' | 'namespaces' | 'namespaces+owners' | 'owners';
 export interface FlowQuery {


### PR DESCRIPTION
This PR replaces previous https://github.com/netobserv/network-observability-console-plugin/pull/194 after computed metrics fix https://github.com/netobserv/network-observability-console-plugin/pull/195

It adds an `appQuery` that runs in parallel to fill `Total flows time series`.

![image](https://user-images.githubusercontent.com/91894519/195066261-8ee2134c-0a74-4fce-8b3f-ff4efeb15774.png)