### PR TITLE
Increase loki default timeout

### DIFF
--- a/cmd/plugin-backend.go
+++ b/cmd/plugin-backend.go
@@ -29,7 +29,7 @@ var (
 	lokiURL              = flag.String("loki", "http://localhost:3100", "URL of the loki querier host")
 	lokiStatusURL        = flag.String("loki-status", "", "URL for loki /ready /metrics /config endpoints. (default: loki flag value")
 	lokiLabels           = flag.String("loki-labels", "SrcK8S_Namespace,SrcK8S_OwnerName,DstK8S_Namespace,DstK8S_OwnerName,FlowDirection", "Loki labels, comma separated")
-	lokiTimeout          = flag.Duration("loki-timeout", 10*time.Second, "Timeout of the Loki query to retrieve logs")
+	lokiTimeout          = flag.Duration("loki-timeout", 30*time.Second, "Timeout of the Loki query to retrieve logs")
 	lokiTenantID         = flag.String("loki-tenant-id", "netobserv", "Tenant organization ID for multi-tenant-loki (submitted as the X-Scope-OrgID HTTP header)")
 	lokiTokenPath        = flag.String("loki-token-path", "", "Path to Bearer authorization header for loki gateway)")
 	lokiForwardUserToken = flag.Bool("loki-forward-user-token", false, "Forward the user Bearer authorization header for loki gateway), this override loki-token-path option")


### PR DESCRIPTION
This set default `lokiTimeout` to 30s as same as our backend server timeout and OCP console proxy one.

https://github.com/openshift/console/blob/f65133a3a85fcbe13ac4227798dae4bfc8ed3cdb/server/proxy.go#L39