### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ Plugin can be served locally using the following command:
 make serve
 ```
 
-(It's the same as running ./http-server.sh)
 
 Make sure you are logged in your OpenShift cluster before with the CLI (`oc login -u kubeadmin` ...)
 


### PR DESCRIPTION
Omit the reference to `http-server.sh` as it was removed long time ago in https://github.com/netobserv/network-observability-console-plugin/pull/8