### PR TITLE
NETOBSERV-414 change clipboard copy components to read only

### DIFF
--- a/web/src/components/netflow-record/record-panel.tsx
+++ b/web/src/components/netflow-record/record-panel.tsx
@@ -195,6 +195,7 @@ export const RecordPanel: React.FC<RecordDrawerProps> = ({
               <ClipboardCopy
                 data-test="drawer-json-copy"
                 isCode
+                isReadOnly
                 isExpanded
                 hoverTip={t('Copy')}
                 clickTip={t('Copied')}


### PR DESCRIPTION
Force `ClipboardCopy` to `ReadOnly`