### PR TITLE
Define the SHELL variable in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ BUILD_DATE := $(shell date +%Y-%m-%d\ %H:%M)
 # You can add GO Build flags like -gcflags=all="-N -l" here to remove optimizations for debugging
 BUILD_FLAGS ?= -ldflags "-X 'main.buildVersion=${BUILD_VERSION}' -X 'main.buildDate=${BUILD_DATE}'"
 BUILD_SHA := $(shell git rev-parse --short HEAD)
+SHELL := /bin/bash
 
 BASE_IMAGE ?= quay.io/${IMG_USER}/network-observability-console-plugin
 IMAGE ?= ${BASE_IMAGE}:${TAG}


### PR DESCRIPTION
This PR defines the `SHELL` variable in the Makefile.
This is needed to make `make bridge` work in Ubuntu. Otherwise, it fails with:
```
/bin/sh: 1: source: not found
```

It turns out that by default, `make` is using `/bin/sh` as the shell. ([source](https://www.gnu.org/software/make/manual/html_node/Choosing-the-Shell.html))
While in Ubuntu, `/bin/sh` is a symlink to dash. ([source](https://wiki.ubuntu.com/DashAsBinSh))
The problem is that dash doesn't support the source command. ([source](https://stackoverflow.com/a/13702876/2749989))