### PR TITLE
Make RecordField resilient to NaN values in time fields

### DIFF
--- a/web/src/components/netflow-record/record-field.tsx
+++ b/web/src/components/netflow-record/record-field.tsx
@@ -176,7 +176,7 @@ export const RecordField: React.FC<{
       case ColumnsId.collectiontime:
       case ColumnsId.starttime:
       case ColumnsId.endtime:
-        return dateTimeContent(typeof value === 'number' ? new Date(value) : undefined);
+        return dateTimeContent(typeof value === 'number' && !isNaN(value) ? new Date(value) : undefined);
       case ColumnsId.collectionlatency:
       case ColumnsId.duration:
         return singleContainer(


### PR DESCRIPTION
When `TimeReceived` is missing in a flow, I get the following error when I click on a row in the Flow Table tab.
![image](https://user-images.githubusercontent.com/37826670/199541232-65d6b9ed-24aa-440a-84b5-29bfb16963de.png)
![image](https://user-images.githubusercontent.com/37826670/199541251-95cb90f0-2b61-459a-a4f8-bdd83d53adae.png)


In this case, `value` is NaN
https://github.com/netobserv/network-observability-console-plugin/blob/db1e8a7abd4609ae85e4afba4570cbf8933b6bcc/web/src/components/netflow-record/record-field.tsx#L174

because the value function of `CollectionTime` multiplies `undefined` by 1000 which happens to be NaN.
https://github.com/netobserv/network-observability-console-plugin/blob/91e6046b571bcdbe796030f173c3d6da1ec988ee/web/src/utils/columns.ts#L687

It turns out that the typeof `NaN` is `number` ([source](https://stackoverflow.com/q/2801601/2749989)) so I had to add a check for NaN values.