### PR TITLE
Fix mocks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ start-standalone: build-backend install-frontend
 start-standalone-mock: build-backend install-frontend
 	@echo "### Starting backend on http://localhost:9002 using mock"
 	bash -c "trap 'fuser -k 9002/tcp' EXIT; \
-					./plugin-backend -port 9002 $(CMDLINE_ARGS) & cd web && npm run start:standalone"
+					./plugin-backend -port 9002 --loki-mock $(CMDLINE_ARGS) & cd web && npm run start:standalone"
 
 .PHONY: bridge
 bridge:

--- a/pkg/handler/topology.go
+++ b/pkg/handler/topology.go
@@ -110,6 +110,7 @@ func getTopologyFlows(cfg *loki.Config, client httpclient.Caller, params url.Val
 	}
 
 	qr := merger.Get()
+	qr.IsMock = cfg.UseMocks
 	hlog.Tracef("GetTopology response: %v", qr)
 	return qr, http.StatusOK, nil
 }

--- a/pkg/model/loki.go
+++ b/pkg/model/loki.go
@@ -20,6 +20,7 @@ type AggregatedQueryResponse struct {
 	ResultType ResultType      `json:"resultType"`
 	Result     ResultValue     `json:"result"`
 	Stats      AggregatedStats `json:"stats"`
+	IsMock     bool            `json:"isMock"`
 }
 
 // AggregatedStats represents the stats to one or more logQL queries

--- a/pkg/model/loki_test.go
+++ b/pkg/model/loki_test.go
@@ -44,11 +44,11 @@ func TestAggregatedQueryResponseMarshal(t *testing.T) {
 
 	js, err := json.Marshal(qr)
 	require.NoError(t, err)
-	assert.Equal(t, `{"resultType":"streams","result":[],"stats":{"numQueries":1,"limitReached":false,"queriesStats":null}}`, string(js))
+	assert.Equal(t, `{"resultType":"streams","result":[],"stats":{"numQueries":1,"limitReached":false,"queriesStats":null},"isMock":false}`, string(js))
 }
 
 func TestAggregatedQueryResponseUnmarshal(t *testing.T) {
-	js := `{"resultType":"streams","result":[],"stats":{"numQueries":1,"limitReached":false,"queriesStats":null}}`
+	js := `{"resultType":"streams","result":[],"stats":{"numQueries":1,"limitReached":false,"queriesStats":null},"isMock":false}`
 	var qr AggregatedQueryResponse
 	err := json.Unmarshal([]byte(js), &qr)
 	require.NoError(t, err)
@@ -95,11 +95,11 @@ func TestAggregatedQueryResponseMatrixMarshal(t *testing.T) {
 
 	js, err := json.Marshal(qr)
 	require.NoError(t, err)
-	assert.Equal(t, `{"resultType":"matrix","result":[],"stats":{"numQueries":1,"limitReached":false,"queriesStats":null}}`, string(js))
+	assert.Equal(t, `{"resultType":"matrix","result":[],"stats":{"numQueries":1,"limitReached":false,"queriesStats":null},"isMock":false}`, string(js))
 }
 
 func TestAggregatedQueryResponseMatrixUnmarshal(t *testing.T) {
-	js := `{"resultType":"matrix","result":[],"stats":{"numQueries":1,"limitReached":false,"queriesStats":null}}`
+	js := `{"resultType":"matrix","result":[],"stats":{"numQueries":1,"limitReached":false,"queriesStats":null},"isMock":false}`
 	var qr AggregatedQueryResponse
 	err := json.Unmarshal([]byte(js), &qr)
 	require.NoError(t, err)
@@ -126,5 +126,5 @@ func TestReencodeStats(t *testing.T) {
 	}
 	reencoded, err := json.Marshal(agg)
 	require.NoError(t, err)
-	assert.Equal(t, `{"resultType":"streams","result":[],"stats":{"numQueries":1,"limitReached":false,"queriesStats":[{"ingester":{"foo":"bar"}}]}}`, string(reencoded))
+	assert.Equal(t, `{"resultType":"streams","result":[],"stats":{"numQueries":1,"limitReached":false,"queriesStats":[{"ingester":{"foo":"bar"}}]},"isMock":false}`, string(reencoded))
 }

--- a/web/src/api/loki.ts
+++ b/web/src/api/loki.ts
@@ -6,6 +6,7 @@ export interface AggregatedQueryResponse {
   resultType: string;
   result: StreamResult[] | RawTopologyMetrics[];
   stats: Stats;
+  isMock: boolean;
 }
 
 export interface Stats {

--- a/web/src/api/routes.ts
+++ b/web/src/api/routes.ts
@@ -59,7 +59,7 @@ export const getTopology = (params: FlowQuery, range: number | TimeRange): Promi
       throw new Error(`${r.statusText} [code=${r.status}]`);
     }
     const aggQR: AggregatedQueryResponse = r.data;
-    const metrics = parseMetrics(aggQR.result as RawTopologyMetrics[], range, params.scope!);
+    const metrics = parseMetrics(aggQR.result as RawTopologyMetrics[], range, params.scope!, aggQR.isMock);
     return { metrics: metrics, stats: aggQR.stats };
   });
 };

--- a/web/src/utils/metrics.ts
+++ b/web/src/utils/metrics.ts
@@ -146,7 +146,7 @@ export const calibrateRange = (
     }
   }
 
-  // End time needs to be overridden to avoid huge range since mock is outdated compated to current date
+  // End time needs to be overridden to avoid huge range since mock is outdated compared to current date
   if (isMock) {
     endWithTolerance = Math.max(...raw.filter(dp => dp.length > 0).map(dp => dp[dp.length - 1][0]));
   }


### PR DESCRIPTION
Following previous merges, some bugs has been introduced:
- missing `--loki-mock` arg in `make start-standalone-mock`
- `calibrateRange` function generating start / end / step that implies huge amount of metrics in graphs making the UI freezing