### PR TITLE
Fix "time range in seconds" calculation in flow query stats

### DIFF
--- a/web/src/components/netflow-topology/netflow-topology.tsx
+++ b/web/src/components/netflow-topology/netflow-topology.tsx
@@ -36,7 +36,6 @@ import {
   TopologyGroupTypes,
   TopologyOptions
 } from '../../model/topology';
-import { TimeRange } from '../../utils/datetime';
 import { usePrevious } from '../../utils/previous-hook';
 import LokiError from '../messages/loki-error';
 import { SearchEvent, SearchHandle } from '../search/search';
@@ -58,7 +57,6 @@ const FIT_PADDING = 80;
 
 export const TopologyContent: React.FC<{
   k8sModels: { [key: string]: K8sModel };
-  range: number | TimeRange;
   metricFunction: MetricFunction;
   metricType: MetricType;
   metricScope: MetricScope;
@@ -75,7 +73,6 @@ export const TopologyContent: React.FC<{
   isDark?: boolean;
 }> = ({
   k8sModels,
-  range,
   metricFunction,
   metricType,
   metricScope,
@@ -253,23 +250,17 @@ export const TopologyContent: React.FC<{
     }
   }, [controller]);
 
-  //get options with updated time range and max edge value
+  //get options with updated max edge value, metric type and function
   const getOptions = React.useCallback(() => {
-    let rangeInSeconds: number;
-    if (typeof range === 'number') {
-      rangeInSeconds = range;
-    } else {
-      rangeInSeconds = (range.from - range.to) / 1000;
-    }
     const maxEdgeStat = Math.max(...metrics.map(m => getStat(m.stats, metricFunction)));
-    return {
+    const opts: TopologyOptions = {
       ...options,
-      rangeInSeconds,
       maxEdgeStat,
       metricFunction,
       metricType
-    } as TopologyOptions;
-  }, [range, metrics, options, metricFunction, metricType]);
+    };
+    return opts;
+  }, [metrics, options, metricFunction, metricType]);
 
   //update graph details level
   const setDetailsLevel = React.useCallback(() => {
@@ -483,7 +474,6 @@ export const NetflowTopology: React.FC<{
   loading?: boolean;
   k8sModels: { [key: string]: K8sModel };
   error?: string;
-  range: number | TimeRange;
   metricFunction: MetricFunction;
   metricType: MetricType;
   metricScope: MetricScope;
@@ -502,7 +492,6 @@ export const NetflowTopology: React.FC<{
   loading,
   k8sModels,
   error,
-  range,
   metricFunction,
   metricType,
   metricScope,
@@ -544,7 +533,6 @@ export const NetflowTopology: React.FC<{
       <VisualizationProvider data-test="visualization-provider" controller={controller}>
         <TopologyContent
           k8sModels={k8sModels}
-          range={range}
           metricFunction={metricFunction}
           metricType={metricType}
           metricScope={metricScope}

--- a/web/src/components/netflow-traffic.tsx
+++ b/web/src/components/netflow-traffic.tsx
@@ -831,7 +831,6 @@ export const NetflowTraffic: React.FC<{
             loading={loading}
             k8sModels={k8sModels}
             error={error}
-            range={range}
             metricFunction={metricFunction}
             metricType={metricType}
             metricScope={metricScope}

--- a/web/src/components/query-summary/flows-query-summary.tsx
+++ b/web/src/components/query-summary/flows-query-summary.tsx
@@ -1,7 +1,7 @@
 import { Card, Flex, FlexItem, Text, TextVariants, Tooltip } from '@patternfly/react-core';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { TimeRange } from '../../utils/datetime';
+import { rangeToSeconds, TimeRange } from '../../utils/datetime';
 import { Record } from '../../api/ipfix';
 import { InfoCircleIcon } from '@patternfly/react-icons';
 import './query-summary.css';
@@ -21,13 +21,7 @@ export const FlowsQuerySummaryContent: React.FC<{
 }> = ({ flows, limitReached, range, lastRefresh, direction, className, isShowQuerySummary, toggleQuerySummary }) => {
   const { t } = useTranslation('plugin__netobserv-plugin');
 
-  let rangeInSeconds: number;
-  if (typeof range === 'number') {
-    rangeInSeconds = range;
-  } else {
-    rangeInSeconds = (range.to - range.from) / 1000;
-  }
-
+  const rangeInSeconds = rangeToSeconds(range);
   const counters = React.useCallback(() => {
     const bytes = flows.map(f => f.fields.Bytes).reduce((a, b) => a + b, 0);
     const packets = flows.map(f => f.fields.Packets).reduce((a, b) => a + b, 0);

--- a/web/src/model/topology.ts
+++ b/web/src/model/topology.ts
@@ -15,7 +15,7 @@ import {
 import _ from 'lodash';
 import { MetricStats, TopologyMetricPeer, TopologyMetrics } from '../api/loki';
 import { Filter, FilterDefinition, findFromFilters } from '../model/filters';
-import { defaultMetricFunction, defaultMetricType, defaultTimeRange } from '../utils/router';
+import { defaultMetricFunction, defaultMetricType } from '../utils/router';
 import { findFilter } from '../utils/filter-definitions';
 import { TFunction } from 'i18next';
 import { K8sModel } from '@openshift-console/dynamic-plugin-sdk';
@@ -74,7 +74,6 @@ export enum TopologyTruncateLength {
 }
 
 export interface TopologyOptions {
-  rangeInSeconds: number;
   maxEdgeStat: number;
   nodeBadges?: boolean;
   edges?: boolean;
@@ -90,7 +89,6 @@ export interface TopologyOptions {
 }
 
 export const DefaultOptions: TopologyOptions = {
-  rangeInSeconds: defaultTimeRange,
   nodeBadges: true,
   edges: true,
   edgeTags: true,


### PR DESCRIPTION
Also remove time range props from NetflowTopology component as it isn't used there anymore

Related to NETOBSERV-602