### PR TITLE
NETOBSERV-609 UI: Resize a column in flow table

### DIFF
--- a/web/src/components/modals/__tests__/columns-modal.spec.tsx
+++ b/web/src/components/modals/__tests__/columns-modal.spec.tsx
@@ -10,6 +10,7 @@ describe('<ColumnsModal />', () => {
     setModalOpen: jest.fn(),
     columns: ShuffledDefaultColumns,
     setColumns: jest.fn(),
+    setColumnSizes: jest.fn(),
     id: 'columns-modal'
   };
   it('should render component', async () => {

--- a/web/src/components/modals/columns-modal.tsx
+++ b/web/src/components/modals/columns-modal.tsx
@@ -31,6 +31,7 @@ export const ColumnsModal: React.FC<{
   setColumnSizes: (v: ColumnSizeMap) => void;
   id?: string;
 }> = ({ id, isModalOpen, setModalOpen, columns, setColumns, setColumnSizes }) => {
+  const [resetClicked, setResetClicked] = React.useState<boolean>(false);
   const [updatedColumns, setUpdatedColumns] = React.useState<Column[]>([]);
   const [isSaveDisabled, setSaveDisabled] = React.useState<boolean>(true);
   const [isAllSelected, setAllSelected] = React.useState<boolean>(false);
@@ -81,9 +82,9 @@ export const ColumnsModal: React.FC<{
   );
 
   const onReset = React.useCallback(() => {
-    setColumnSizes({});
+    setResetClicked(true);
     setUpdatedColumns(getDefaultColumns(t));
-  }, [setColumnSizes, setUpdatedColumns, t]);
+  }, [setResetClicked, setUpdatedColumns, t]);
 
   const onSelectAll = React.useCallback(() => {
     const result = [...updatedColumns];
@@ -93,10 +94,18 @@ export const ColumnsModal: React.FC<{
     setUpdatedColumns(result);
   }, [updatedColumns, setUpdatedColumns, isAllSelected]);
 
-  const onSave = React.useCallback(() => {
-    setColumns(updatedColumns);
+  const onClose = React.useCallback(() => {
+    setResetClicked(false);
     setModalOpen(false);
-  }, [updatedColumns, setColumns, setModalOpen]);
+  }, [setModalOpen]);
+
+  const onSave = React.useCallback(() => {
+    if (resetClicked) {
+      setColumnSizes({});
+    }
+    setColumns(updatedColumns);
+    onClose();
+  }, [resetClicked, setColumns, updatedColumns, onClose, setColumnSizes]);
 
   const draggableItems = updatedColumns.map((column, i) => (
     <Draggable key={i} hasNoWrapper>
@@ -136,7 +145,7 @@ export const ColumnsModal: React.FC<{
       title={t('Manage columns')}
       isOpen={isModalOpen}
       scrollable={true}
-      onClose={() => setModalOpen(false)}
+      onClose={onClose}
       description={
         <TextContent>
           <Text component={TextVariants.p}>
@@ -153,10 +162,10 @@ export const ColumnsModal: React.FC<{
           <Button data-test="columns-reset-button" key="reset" variant="link" onClick={() => onReset()}>
             {t('Restore default columns')}
           </Button>
-          <Button data-test="columns-cancel-button" key="cancel" variant="link" onClick={() => setModalOpen(false)}>
+          <Button data-test="columns-cancel-button" key="cancel" variant="link" onClick={() => onClose()}>
             {t('Cancel')}
           </Button>
-          <Tooltip content={t('At least one column must be selected')} isVisible={isSaveDisabled}>
+          <Tooltip content={t('At least one column must be selected')} trigger="" isVisible={isSaveDisabled}>
             <Button
               data-test="columns-save-button"
               isDisabled={isSaveDisabled}

--- a/web/src/components/modals/columns-modal.tsx
+++ b/web/src/components/modals/columns-modal.tsx
@@ -1,35 +1,36 @@
-import * as React from 'react';
 import {
   Button,
   DataList,
-  DataListControl,
-  DataListItem,
-  DataListItemRow,
-  DataListDragButton,
-  DataListCheck,
   DataListCell,
+  DataListCheck,
+  DataListControl,
+  DataListDragButton,
+  DataListItem,
+  DataListItemCells,
+  DataListItemRow,
   DragDrop,
   Draggable,
   Droppable,
-  DataListItemCells,
   Text,
   TextContent,
   TextVariants,
   Tooltip
 } from '@patternfly/react-core';
-import Modal from './modal';
-import { useTranslation } from 'react-i18next';
-import { Column, getDefaultColumns, getFullColumnName } from '../../utils/columns';
 import * as _ from 'lodash';
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Column, ColumnSizeMap, getDefaultColumns, getFullColumnName } from '../../utils/columns';
 import './columns-modal.css';
+import Modal from './modal';
 
 export const ColumnsModal: React.FC<{
   isModalOpen: boolean;
   setModalOpen: (v: boolean) => void;
   columns: Column[];
   setColumns: (v: Column[]) => void;
+  setColumnSizes: (v: ColumnSizeMap) => void;
   id?: string;
-}> = ({ id, isModalOpen, setModalOpen, columns, setColumns }) => {
+}> = ({ id, isModalOpen, setModalOpen, columns, setColumns, setColumnSizes }) => {
   const [updatedColumns, setUpdatedColumns] = React.useState<Column[]>([]);
   const [isSaveDisabled, setSaveDisabled] = React.useState<boolean>(true);
   const [isAllSelected, setAllSelected] = React.useState<boolean>(false);
@@ -80,8 +81,9 @@ export const ColumnsModal: React.FC<{
   );
 
   const onReset = React.useCallback(() => {
+    setColumnSizes({});
     setUpdatedColumns(getDefaultColumns(t));
-  }, [setUpdatedColumns, t]);
+  }, [setColumnSizes, setUpdatedColumns, t]);
 
   const onSelectAll = React.useCallback(() => {
     const result = [...updatedColumns];

--- a/web/src/components/netflow-table/__tests__/netflow-table-header.spec.tsx
+++ b/web/src/components/netflow-table/__tests__/netflow-table-header.spec.tsx
@@ -1,7 +1,7 @@
 import { SortByDirection, TableComposable, Tbody, Th, Thead, Tr } from '@patternfly/react-table';
 import { mount } from 'enzyme';
 import * as React from 'react';
-import { Column, ColumnsId } from '../../../utils/columns';
+import { Column, ColumnsId, ColumnSizeMap } from '../../../utils/columns';
 import { AllSelectedColumns, DefaultColumns, filterOrderedColumnsByIds } from '../../__tests-data__/columns';
 import { NetflowTableHeader } from '../netflow-table-header';
 
@@ -11,7 +11,9 @@ const NetflowTableHeaderWrapper: React.FC<{
   sortDirection: SortByDirection;
   columns: Column[];
   setColumns: (v: Column[]) => void;
-}> = ({ onSort, sortId, sortDirection, columns, setColumns }) => {
+  columnSizes: ColumnSizeMap;
+  setColumnSizes: (v: ColumnSizeMap) => void;
+}> = ({ onSort, sortId, sortDirection, columns, setColumns, columnSizes, setColumnSizes }) => {
   return (
     <TableComposable aria-label="Misc table" variant="compact">
       <NetflowTableHeader
@@ -20,6 +22,8 @@ const NetflowTableHeaderWrapper: React.FC<{
         sortId={sortId}
         columns={columns}
         setColumns={setColumns}
+        columnSizes={columnSizes}
+        setColumnSizes={setColumnSizes}
         tableWidth={100}
       />
       <Tbody></Tbody>
@@ -33,7 +37,9 @@ describe('<NetflowTableHeader />', () => {
     sortId: ColumnsId.endtime,
     sortDirection: SortByDirection.asc,
     tableWidth: 100,
-    setColumns: jest.fn()
+    setColumns: jest.fn(),
+    columnSizes: {},
+    setColumnSizes: jest.fn()
   };
   it('should render component', async () => {
     const wrapper = mount(<NetflowTableHeaderWrapper {...mocks} columns={AllSelectedColumns} />);

--- a/web/src/components/netflow-table/__tests__/netflow-table.spec.tsx
+++ b/web/src/components/netflow-table/__tests__/netflow-table.spec.tsx
@@ -22,7 +22,9 @@ describe('<NetflowTable />', () => {
     size: 'm' as Size,
     onSelect: jest.fn(),
     filterActionLinks: <></>,
-    setColumns: jest.fn()
+    setColumns: jest.fn(),
+    columnSizes: {},
+    setColumnSizes: jest.fn()
   };
 
   it('should render component', async () => {

--- a/web/src/components/netflow-table/netflow-table-header.css
+++ b/web/src/components/netflow-table/netflow-table-header.css
@@ -2,6 +2,16 @@ th.netobserv-header {
   cursor: pointer;
 }
 
+th.netobserv-header.column:hover:not(.dragged)::after {
+  position: absolute;
+  top: 0;
+  right: 0;
+  content: ' ';
+  cursor: col-resize;
+  height: 100%;
+  width: 15px;
+}
+
 th.netobserv-header.dragged:not(.dark) {
   opacity: 0.25;
   background: #fff;
@@ -10,6 +20,10 @@ th.netobserv-header.dragged:not(.dark) {
 th.netobserv-header.dragged.dark {
   opacity: 0.25;
   background: #1b1d21;
+}
+
+th.netobserv-header.resizing {
+  border-bottom: solid #0066CC;
 }
 
 th.netobserv-header.dropzone:not(.dragged) {

--- a/web/src/components/netflow-table/netflow-table.tsx
+++ b/web/src/components/netflow-table/netflow-table.tsx
@@ -16,7 +16,7 @@ import * as _ from 'lodash';
 import { Record } from '../../api/ipfix';
 import { NetflowTableHeader } from './netflow-table-header';
 import NetflowTableRow from './netflow-table-row';
-import { Column, ColumnsId, getCommonColumns } from '../../utils/columns';
+import { Column, ColumnsId, ColumnSizeMap, getCommonColumns } from '../../utils/columns';
 import { Size } from '../dropdowns/table-display-dropdown';
 import { usePrevious } from '../../utils/previous-hook';
 import './netflow-table.css';
@@ -32,13 +32,28 @@ const NetflowTable: React.FC<{
   selectedRecord?: Record;
   columns: Column[];
   setColumns: (v: Column[]) => void;
+  columnSizes: ColumnSizeMap;
+  setColumnSizes: (v: ColumnSizeMap) => void;
   size: Size;
   onSelect: (record?: Record) => void;
   loading?: boolean;
   error?: string;
   filterActionLinks: JSX.Element;
   isDark?: boolean;
-}> = ({ flows, selectedRecord, columns, setColumns, error, loading, size, onSelect, filterActionLinks, isDark }) => {
+}> = ({
+  flows,
+  selectedRecord,
+  columns,
+  setColumns,
+  columnSizes,
+  setColumnSizes,
+  error,
+  loading,
+  size,
+  onSelect,
+  filterActionLinks,
+  isDark
+}) => {
   const { t } = useTranslation('plugin__netobserv-plugin');
 
   //default to 300 to allow content to be rendered in tests
@@ -254,6 +269,8 @@ const NetflowTable: React.FC<{
           sortId={activeSortId}
           columns={columns}
           setColumns={setColumns}
+          columnSizes={columnSizes}
+          setColumnSizes={setColumnSizes}
           tableWidth={width}
           isDark={isDark}
         />

--- a/web/src/components/netflow-traffic.tsx
+++ b/web/src/components/netflow-traffic.tsx
@@ -62,7 +62,7 @@ import {
   TopologyGroupTypes,
   TopologyOptions
 } from '../model/topology';
-import { Column, getDefaultColumns } from '../utils/columns';
+import { Column, ColumnSizeMap, getDefaultColumns } from '../utils/columns';
 import { loadConfig } from '../utils/config';
 import { ContextSingleton } from '../utils/context';
 import { computeStepInterval, TimeRange } from '../utils/datetime';
@@ -70,6 +70,7 @@ import { getHTTPErrorDetails } from '../utils/errors';
 import { useK8sModelsWithColors } from '../utils/k8s-models-hook';
 import {
   LOCAL_STORAGE_COLS_KEY,
+  LOCAL_STORAGE_COLS_SIZES_KEY,
   LOCAL_STORAGE_DISABLED_FILTERS_KEY,
   LOCAL_STORAGE_LAST_LIMIT_KEY,
   LOCAL_STORAGE_LAST_TOP_KEY,
@@ -215,6 +216,7 @@ export const NetflowTraffic: React.FC<{
     id: 'id',
     criteria: 'isSelected'
   });
+  const [columnSizes, setColumnSizes] = useLocalStorage<ColumnSizeMap>(LOCAL_STORAGE_COLS_SIZES_KEY, {});
 
   React.useEffect(() => {
     loadConfig().then(setConfig);
@@ -829,6 +831,8 @@ export const NetflowTraffic: React.FC<{
             onSelect={onRecordSelect}
             columns={columns.filter(col => col.isSelected)}
             setColumns={(v: Column[]) => setColumns(v.concat(columns.filter(col => !col.isSelected)))}
+            columnSizes={columnSizes}
+            setColumnSizes={setColumnSizes}
             filterActionLinks={filterLinks()}
             isDark={isDarkTheme}
           />
@@ -1053,6 +1057,7 @@ export const NetflowTraffic: React.FC<{
         setModalOpen={setColModalOpen}
         columns={columns}
         setColumns={setColumns}
+        setColumnSizes={setColumnSizes}
       />
       <ExportModal
         id="export-modal"

--- a/web/src/utils/columns.ts
+++ b/web/src/utils/columns.ts
@@ -74,6 +74,10 @@ export interface Column {
   width: number;
 }
 
+export type ColumnSizeMap = {
+  [id in ColumnsId]?: string;
+};
+
 export type ColumnGroup = {
   title?: string;
   columns: Column[];

--- a/web/src/utils/local-storage-hook.ts
+++ b/web/src/utils/local-storage-hook.ts
@@ -3,6 +3,7 @@ import * as React from 'react';
 
 export const LOCAL_STORAGE_PLUGIN_KEY = 'netobserv-plugin-settings';
 export const LOCAL_STORAGE_COLS_KEY = 'netflow-traffic-columns';
+export const LOCAL_STORAGE_COLS_SIZES_KEY = 'netflow-traffic-column-sizes';
 export const LOCAL_STORAGE_EXPORT_COLS_KEY = 'netflow-traffic-export-columns';
 export const LOCAL_STORAGE_REFRESH_KEY = 'netflow-traffic-refresh';
 export const LOCAL_STORAGE_SIZE_KEY = 'netflow-traffic-size-size';


### PR DESCRIPTION
Add table resize capabilities
- Custom (min)sizes are stored in local storage
  - we only force css min size in `Px` on headers
  - the table behavior will not be affected if min size is lower than the default width in `%` 
- Table scroll adapts to new total width
- Reset default columns also reset sizes

[Screencast_22_11_2022_14:41:47.webm](https://user-images.githubusercontent.com/91894519/203328867-84b050fa-860e-4161-a718-259a9d663b78.webm)

Based on https://github.com/netobserv/network-observability-console-plugin/pull/236

