### PR TITLE
NETOBSERV-688 UI: Overview labels options

### DIFF
--- a/web/src/components/dropdowns/__tests__/truncate-dropdown.spec.tsx
+++ b/web/src/components/dropdowns/__tests__/truncate-dropdown.spec.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
 import { mount, shallow } from 'enzyme';
 
-import TruncateDropdown from '../truncate-dropdown';
-import { TopologyTruncateLength } from '../../../model/topology';
+import { TruncateDropdown, TruncateLength } from '../truncate-dropdown';
 
 describe('<TruncateDropdown />', () => {
   const props = {
-    selected: TopologyTruncateLength.M,
+    selected: TruncateLength.M,
     setTruncateLength: jest.fn(),
     id: 'truncate'
   };
@@ -37,13 +36,13 @@ describe('<TruncateDropdown />', () => {
     //open dropdown and select NONE
     dropdown.at(0).simulate('click');
     wrapper.find('[id="0"]').at(0).simulate('click');
-    expect(props.setTruncateLength).toHaveBeenCalledWith(TopologyTruncateLength.OFF);
+    expect(props.setTruncateLength).toHaveBeenCalledWith(TruncateLength.OFF);
     expect(wrapper.find('li').length).toBe(0);
 
     //open dropdown and select OWNERS
     dropdown.at(0).simulate('click');
     wrapper.find('[id="40"]').at(0).simulate('click');
-    expect(props.setTruncateLength).toHaveBeenCalledWith(TopologyTruncateLength.XL);
+    expect(props.setTruncateLength).toHaveBeenCalledWith(TruncateLength.XL);
     expect(wrapper.find('li').length).toBe(0);
 
     //setTruncateLength should be called twice

--- a/web/src/components/dropdowns/overview-display-dropdown.tsx
+++ b/web/src/components/dropdowns/overview-display-dropdown.tsx
@@ -7,6 +7,7 @@ import { MetricScope, MetricType } from '../../model/flow-query';
 import MetricTypeDropdown from './metric-type-dropdown';
 import './overview-display-dropdown.css';
 import ScopeDropdown from './scope-dropdown';
+import TruncateDropdown, { TruncateLength } from './truncate-dropdown';
 
 export type Size = 's' | 'm' | 'l';
 
@@ -15,7 +16,9 @@ export const OverviewDisplayOptions: React.FC<{
   setMetricType: (t: MetricType) => void;
   metricScope: MetricScope;
   setMetricScope: (s: MetricScope) => void;
-}> = ({ metricType, setMetricType, metricScope, setMetricScope }) => {
+  truncateLength: TruncateLength;
+  setTruncateLength: (v: TruncateLength) => void;
+}> = ({ metricType, setMetricType, metricScope, setMetricScope, truncateLength, setTruncateLength }) => {
   const { t } = useTranslation('plugin__netobserv-plugin');
 
   return (
@@ -46,6 +49,18 @@ export const OverviewDisplayOptions: React.FC<{
           <ScopeDropdown data-test="scope" id="scope" selected={metricScope} setScopeType={setMetricScope} />
         </div>
       </div>
+      <div className="pf-c-select__menu-group">
+        <Tooltip content={t('Long labels can reduce visibility.')}>
+          <div className="pf-c-select__menu-group-title">
+            <>
+              {t('Truncate labels')} <InfoAltIcon />
+            </>
+          </div>
+        </Tooltip>
+        <div className="display-dropdown-padding">
+          <TruncateDropdown id="truncate" selected={truncateLength} setTruncateLength={setTruncateLength} />
+        </div>
+      </div>
     </>
   );
 };
@@ -55,7 +70,9 @@ export const OverviewDisplayDropdown: React.FC<{
   setMetricType: (t: MetricType) => void;
   metricScope: MetricScope;
   setMetricScope: (s: MetricScope) => void;
-}> = ({ metricType, setMetricType, metricScope, setMetricScope }) => {
+  truncateLength: TruncateLength;
+  setTruncateLength: (v: TruncateLength) => void;
+}> = ({ metricType, setMetricType, metricScope, setMetricScope, truncateLength, setTruncateLength }) => {
   const { t } = useTranslation('plugin__netobserv-plugin');
   const [isOpen, setOpen] = React.useState<boolean>(false);
 
@@ -72,6 +89,8 @@ export const OverviewDisplayDropdown: React.FC<{
             setMetricType={setMetricType}
             metricScope={metricScope}
             setMetricScope={setMetricScope}
+            truncateLength={truncateLength}
+            setTruncateLength={setTruncateLength}
           />
         }
       />

--- a/web/src/components/dropdowns/topology-display-dropdown.tsx
+++ b/web/src/components/dropdowns/topology-display-dropdown.tsx
@@ -4,10 +4,10 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { MetricFunction, MetricScope, MetricType } from '../../model/flow-query';
 import { MetricScopeOptions } from '../../model/metrics';
-import { LayoutName, TopologyGroupTypes, TopologyOptions, TopologyTruncateLength } from '../../model/topology';
+import { LayoutName, TopologyGroupTypes, TopologyOptions } from '../../model/topology';
 import GroupDropdown from './group-dropdown';
 import LayoutDropdown from './layout-dropdown';
-import TruncateDropdown from './truncate-dropdown';
+import TruncateDropdown, { TruncateLength } from './truncate-dropdown';
 
 import './topology-display-dropdown.css';
 import MetricFunctionDropdown from './metric-function-dropdown';
@@ -51,7 +51,7 @@ export const TopologyDisplayOptions: React.FC<{
     });
   };
 
-  const setTruncateLength = (truncateLength: TopologyTruncateLength) => {
+  const setTruncateLength = (truncateLength: TruncateLength) => {
     setTopologyOptions({
       ...topologyOptions,
       truncateLength

--- a/web/src/components/dropdowns/truncate-dropdown.tsx
+++ b/web/src/components/dropdowns/truncate-dropdown.tsx
@@ -1,27 +1,35 @@
 import { Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { TopologyTruncateLength } from '../../model/topology';
+
+export enum TruncateLength {
+  OFF = 0,
+  XS = 10,
+  S = 20,
+  M = 25,
+  L = 30,
+  XL = 40
+}
 
 export const TruncateDropdown: React.FC<{
-  selected: TopologyTruncateLength;
-  setTruncateLength: (v: TopologyTruncateLength) => void;
+  selected: TruncateLength;
+  setTruncateLength: (v: TruncateLength) => void;
   id?: string;
 }> = ({ selected, setTruncateLength, id }) => {
   const { t } = useTranslation('plugin__netobserv-plugin');
   const [truncateDropdownOpen, setTruncateDropdownOpen] = React.useState(false);
 
-  const getTruncateDisplay = (v: TopologyTruncateLength) => {
+  const getTruncateDisplay = (v: TruncateLength) => {
     switch (v) {
-      case TopologyTruncateLength.XL:
+      case TruncateLength.XL:
         return t('XL');
-      case TopologyTruncateLength.L:
+      case TruncateLength.L:
         return t('L');
-      case TopologyTruncateLength.M:
+      case TruncateLength.M:
         return t('M');
-      case TopologyTruncateLength.S:
+      case TruncateLength.S:
         return t('S');
-      case TopologyTruncateLength.XS:
+      case TruncateLength.XS:
         return t('XS');
       default:
         return t('None');
@@ -43,13 +51,13 @@ export const TruncateDropdown: React.FC<{
       }
       isOpen={truncateDropdownOpen}
       dropdownItems={[
-        TopologyTruncateLength.OFF,
-        TopologyTruncateLength.XS,
-        TopologyTruncateLength.S,
-        TopologyTruncateLength.M,
-        TopologyTruncateLength.L,
-        TopologyTruncateLength.XL
-      ].map((v: TopologyTruncateLength) => (
+        TruncateLength.OFF,
+        TruncateLength.XS,
+        TruncateLength.S,
+        TruncateLength.M,
+        TruncateLength.L,
+        TruncateLength.XL
+      ].map((v: TruncateLength) => (
         <DropdownItem
           data-test={String(v)}
           id={String(v)}

--- a/web/src/components/metrics/metrics-content.css
+++ b/web/src/components/metrics/metrics-content.css
@@ -4,5 +4,5 @@
 }
 
 .small-chart-label>tspan {
-  font-size: 10px !important;
+  font-size: 11px !important;
 }

--- a/web/src/components/metrics/metrics-content.tsx
+++ b/web/src/components/metrics/metrics-content.tsx
@@ -30,6 +30,7 @@ export type MetricsContentProps = {
   showArea?: boolean;
   showScatter?: boolean;
   smallerTexts?: boolean;
+  itemsPerRow?: number;
 };
 
 export const MetricsContent: React.FC<MetricsContentProps> = ({
@@ -43,7 +44,8 @@ export const MetricsContent: React.FC<MetricsContentProps> = ({
   showBar,
   showArea,
   showScatter,
-  smallerTexts
+  smallerTexts,
+  itemsPerRow
 }) => {
   const filteredMetrics = metrics.slice(0, limit);
 
@@ -56,6 +58,7 @@ export const MetricsContent: React.FC<MetricsContentProps> = ({
 
   const legentComponent = (
     <ChartLegend
+      itemsPerRow={itemsPerRow ? itemsPerRow : 1}
       labelComponent={<ChartLabel className={smallerTexts ? 'small-chart-label' : ''} />}
       data={legendData}
     />
@@ -81,7 +84,7 @@ export const MetricsContent: React.FC<MetricsContentProps> = ({
           ariaTitle={title}
           containerComponent={chartVoronoi(legendData, metricType)}
           legendData={legendData}
-          legendOrientation="vertical"
+          legendOrientation={'horizontal'}
           legendPosition="bottom-left"
           legendAllowWrap={true}
           legendComponent={legentComponent}
@@ -92,7 +95,7 @@ export const MetricsContent: React.FC<MetricsContentProps> = ({
           height={dimensions.height}
           domainPadding={{ x: 0, y: 0 }}
           padding={{
-            bottom: legendData.length * 25 + 75,
+            bottom: (itemsPerRow && itemsPerRow > 1 ? legendData.length / 2 + 1 : legendData.length) * 25 + 75,
             left: 90,
             right: 50,
             top: 50

--- a/web/src/components/metrics/metrics-total-content.tsx
+++ b/web/src/components/metrics/metrics-total-content.tsx
@@ -36,6 +36,7 @@ export type MetricsTotalContentProps = {
   showTotal: boolean;
   showInternal: boolean;
   showOutOfScope: boolean;
+  smallerTexts?: boolean;
 };
 
 export const MetricsTotalContent: React.FC<MetricsTotalContentProps> = ({
@@ -47,7 +48,8 @@ export const MetricsTotalContent: React.FC<MetricsTotalContentProps> = ({
   limit,
   showTotal,
   showInternal,
-  showOutOfScope
+  showOutOfScope,
+  smallerTexts
 }) => {
   let filtered = topKMetrics;
   if (!showInternal) {
@@ -71,7 +73,13 @@ export const MetricsTotalContent: React.FC<MetricsTotalContentProps> = ({
   const topKDatapoints: ChartDataPoint[][] = filtered.map(toDatapoints);
   const totalDatapoints: ChartDataPoint[] = toDatapoints(totalMetric);
 
-  const legentComponent = <ChartLegend labelComponent={<ChartLabel />} data={legendData} />;
+  const legentComponent = (
+    <ChartLegend
+      itemsPerRow={2}
+      labelComponent={<ChartLabel className={smallerTexts ? 'small-chart-label' : ''} />}
+      data={legendData}
+    />
+  );
 
   const containerRef = React.createRef<HTMLDivElement>();
   const [dimensions, setDimensions] = React.useState<Dimensions>(defaultDimensions);
@@ -88,7 +96,7 @@ export const MetricsTotalContent: React.FC<MetricsTotalContentProps> = ({
             ariaTitle={title}
             containerComponent={chartVoronoi(legendData, metricType)}
             legendData={legendData}
-            legendOrientation="vertical"
+            legendOrientation="horizontal"
             legendPosition="bottom-left"
             legendAllowWrap={true}
             legendComponent={legentComponent}
@@ -99,7 +107,7 @@ export const MetricsTotalContent: React.FC<MetricsTotalContentProps> = ({
             height={dimensions.height}
             domainPadding={{ x: 0, y: 0 }}
             padding={{
-              bottom: legendData.length * 25 + 75,
+              bottom: (legendData.length / 2) * 25 + 100,
               left: 90,
               right: 50,
               top: 50

--- a/web/src/components/metrics/stat-donut.tsx
+++ b/web/src/components/metrics/stat-donut.tsx
@@ -113,7 +113,7 @@ export const StatDonut: React.FC<StatDonutProps> = ({
         padding={{
           bottom: 20,
           left: 20,
-          right: 300,
+          right: 400,
           top: 20
         }}
         title={`${getFormattedRateValue(total, metricType)}`}

--- a/web/src/components/netflow-overview/__tests__/netflow-overview.spec.tsx
+++ b/web/src/components/netflow-overview/__tests__/netflow-overview.spec.tsx
@@ -8,6 +8,7 @@ import { MetricType } from '../../../model/flow-query';
 import { SamplePanel, ShuffledDefaultPanels } from '../../__tests-data__/panels';
 import { NetflowOverview, NetflowOverviewProps } from '../netflow-overview';
 import { NetflowOverviewPanel } from '../netflow-overview-panel';
+import { TruncateLength } from '../../../components/dropdowns/truncate-dropdown';
 
 describe('<NetflowOverview />', () => {
   const props: NetflowOverviewProps = {
@@ -18,7 +19,8 @@ describe('<NetflowOverview />', () => {
     metricType: 'bytes' as MetricType,
     metrics: [],
     totalMetric: undefined,
-    filterActionLinks: <></>
+    filterActionLinks: <></>,
+    truncateLength: TruncateLength.M
   };
   it('should render component', async () => {
     const wrapper = shallow(<NetflowOverview {...props} />);

--- a/web/src/components/netflow-overview/netflow-overview.tsx
+++ b/web/src/components/netflow-overview/netflow-overview.tsx
@@ -17,6 +17,7 @@ import { MetricType } from '../../model/flow-query';
 import { getStat } from '../../model/topology';
 import { peersEqual } from '../../utils/metrics';
 import { getOverviewPanelInfo, OverviewPanel, OverviewPanelId } from '../../utils/overview-panels';
+import { TruncateLength } from '../dropdowns/truncate-dropdown';
 import LokiError from '../messages/loki-error';
 import { MetricsContent } from '../metrics/metrics-content';
 import { toNamedMetric } from '../metrics/metrics-helper';
@@ -44,6 +45,7 @@ export type NetflowOverviewProps = {
   error?: string;
   isDark?: boolean;
   filterActionLinks: JSX.Element;
+  truncateLength: TruncateLength;
 };
 
 export const NetflowOverview: React.FC<NetflowOverviewProps> = ({
@@ -55,7 +57,8 @@ export const NetflowOverview: React.FC<NetflowOverviewProps> = ({
   loading,
   error,
   isDark,
-  filterActionLinks
+  filterActionLinks,
+  truncateLength
 }) => {
   const { t } = useTranslation('plugin__netobserv-plugin');
   const [kebabMap, setKebabMap] = React.useState(new Map<OverviewPanelId, PanelKebabOptions>());
@@ -98,9 +101,11 @@ export const NetflowOverview: React.FC<NetflowOverviewProps> = ({
   //limit to top X since multiple queries can run in parallel
   const topKMetrics = metrics
     .sort((a, b) => getStat(b.stats, 'sum') - getStat(a.stats, 'sum'))
-    .map(m => toNamedMetric(t, m));
-  const namedTotalMetric = toNamedMetric(t, totalMetric);
+    .map(m => toNamedMetric(t, m, undefined, truncateLength));
+  const namedTotalMetric = toNamedMetric(t, totalMetric, undefined, truncateLength);
   const noInternalTopK = topKMetrics.filter(m => !peersEqual(m.source, m.destination));
+
+  const smallerTexts = truncateLength >= TruncateLength.M;
 
   const getPanelContent = (id: OverviewPanelId, title: string): PanelContent => {
     switch (id) {
@@ -122,8 +127,7 @@ export const NetflowOverview: React.FC<NetflowOverviewProps> = ({
               showBar={true}
               showArea={false}
               showScatter={false}
-              //TODO: NETOBSERV-688 make options for truncate / text size
-              smallerTexts={false}
+              smallerTexts={smallerTexts}
             />
           ),
           doubleWidth: false
@@ -140,8 +144,7 @@ export const NetflowOverview: React.FC<NetflowOverviewProps> = ({
               showBar={false}
               showArea={true}
               showScatter={true}
-              //TODO: NETOBSERV-688 make options for truncate / text size
-              smallerTexts={false}
+              smallerTexts={smallerTexts}
             />
           ),
           doubleWidth: false
@@ -164,6 +167,7 @@ export const NetflowOverview: React.FC<NetflowOverviewProps> = ({
               showTotal={options.showTotal!}
               showInternal={options.showInternal!}
               showOutOfScope={options.showOutOfScope!}
+              smallerTexts={smallerTexts}
             />
           ),
           kebab: <PanelKebab id={id} options={options} setOptions={opts => setKebabOptions(id, opts)} />,
@@ -182,8 +186,8 @@ export const NetflowOverview: React.FC<NetflowOverviewProps> = ({
               showBar={false}
               showArea={true}
               showScatter={true}
-              //TODO: NETOBSERV-688 make options for truncate / text size
-              smallerTexts={false}
+              itemsPerRow={2}
+              smallerTexts={smallerTexts}
             />
           ),
           doubleWidth: true
@@ -206,8 +210,7 @@ export const NetflowOverview: React.FC<NetflowOverviewProps> = ({
               showOthers={options.showOthers!}
               showInternal={options.showInternal!}
               showOutOfScope={options.showOutOfScope!}
-              //TODO: NETOBSERV-688 make options for truncate / text size
-              smallerTexts={true}
+              smallerTexts={smallerTexts}
             />
           ),
           kebab: <PanelKebab id={id} options={options} setOptions={opts => setKebabOptions(id, opts)} />,
@@ -232,8 +235,7 @@ export const NetflowOverview: React.FC<NetflowOverviewProps> = ({
               showOthers={options.showOthers!}
               showInternal={options.showInternal!}
               showOutOfScope={options.showOutOfScope!}
-              //TODO: NETOBSERV-688 make options for truncate / text size
-              smallerTexts={true}
+              smallerTexts={smallerTexts}
             />
           ),
           kebab: <PanelKebab id={id} options={options} setOptions={opts => setKebabOptions(id, opts)} />,

--- a/web/src/components/netflow-topology/__tests__/element-panel.spec.tsx
+++ b/web/src/components/netflow-topology/__tests__/element-panel.spec.tsx
@@ -8,6 +8,7 @@ import { MetricFunction, MetricScope, MetricType } from '../../../model/flow-que
 import { ElementPanel, ElementPanelDetailsContent, ElementPanelMetricsContent } from '../element-panel';
 import { dataSample } from '../__tests-data__/metrics';
 import { NodeData } from '../../../model/topology';
+import { TruncateLength } from '../../../components/dropdowns/truncate-dropdown';
 
 describe('<ElementPanel />', () => {
   const getNode = (kind: string, name: string, addr: string) => {
@@ -37,6 +38,7 @@ describe('<ElementPanel />', () => {
     filters: [] as Filter[],
     setFilters: jest.fn(),
     onClose: jest.fn(),
+    truncateLength: TruncateLength.M,
     id: 'element-panel-test'
   };
 

--- a/web/src/components/netflow-topology/element-panel.tsx
+++ b/web/src/components/netflow-topology/element-panel.tsx
@@ -41,6 +41,7 @@ import './element-panel.css';
 import { MetricsContent } from '../metrics/metrics-content';
 import { getFormattedValue, matchPeer, peersEqual } from '../../utils/metrics';
 import { toNamedMetric } from '../metrics/metrics-helper';
+import { TruncateLength } from '../dropdowns/truncate-dropdown';
 
 export const ElementPanelDetailsContent: React.FC<{
   element: GraphElementPeer;
@@ -214,7 +215,8 @@ export const ElementPanelMetricsContent: React.FC<{
   metrics: TopologyMetrics[];
   metricFunction: MetricFunction;
   metricType: MetricType;
-}> = ({ element, metrics, metricFunction, metricType }) => {
+  truncateLength: TruncateLength;
+}> = ({ element, metrics, metricFunction, metricType, truncateLength }) => {
   const { t } = useTranslation('plugin__netobserv-plugin');
   const data = element.getData();
 
@@ -262,8 +264,12 @@ export const ElementPanelMetricsContent: React.FC<{
 
   if (element instanceof BaseNode && data) {
     const filteredMetrics = metrics.filter(m => !peersEqual(m.source, m.destination));
-    const outMetrics = filteredMetrics.filter(m => matchPeer(data, m.source)).map(m => toNamedMetric(t, m, data));
-    const inMetrics = filteredMetrics.filter(m => matchPeer(data, m.destination)).map(m => toNamedMetric(t, m, data));
+    const outMetrics = filteredMetrics
+      .filter(m => matchPeer(data, m.source))
+      .map(m => toNamedMetric(t, m, data, truncateLength));
+    const inMetrics = filteredMetrics
+      .filter(m => matchPeer(data, m.destination))
+      .map(m => toNamedMetric(t, m, data, truncateLength));
     const outCount = outMetrics.reduce((prev, cur) => prev + getStat(cur.stats, metricFunction), 0);
     const inCount = inMetrics.reduce((prev, cur) => prev + getStat(cur.stats, metricFunction), 0);
     return (
@@ -287,10 +293,10 @@ export const ElementPanelMetricsContent: React.FC<{
     const bData = element.getTarget().getData();
     const aToBMetrics = metrics
       .filter(m => matchPeer(aData, m.source) && matchPeer(bData, m.destination))
-      .map(m => toNamedMetric(t, m, data));
+      .map(m => toNamedMetric(t, m, data, truncateLength));
     const bToAMetrics = metrics
       .filter(m => matchPeer(bData, m.source) && matchPeer(aData, m.destination))
-      .map(m => toNamedMetric(t, m, data));
+      .map(m => toNamedMetric(t, m, data, truncateLength));
     const aToBCount = aToBMetrics.reduce((prev, cur) => prev + getStat(cur.stats, metricFunction), 0);
     const bToACount = bToAMetrics.reduce((prev, cur) => prev + getStat(cur.stats, metricFunction), 0);
     return (
@@ -320,8 +326,9 @@ export const ElementPanel: React.FC<{
   metricType: MetricType;
   filters: Filter[];
   setFilters: (filters: Filter[]) => void;
+  truncateLength: TruncateLength;
   id?: string;
-}> = ({ id, element, metrics, metricFunction, metricType, filters, setFilters, onClose }) => {
+}> = ({ id, element, metrics, metricFunction, metricType, filters, setFilters, onClose, truncateLength }) => {
   const { t } = useTranslation('plugin__netobserv-plugin');
   const [activeTab, setActiveTab] = React.useState<string>('details');
 
@@ -373,6 +380,7 @@ export const ElementPanel: React.FC<{
               metrics={metrics}
               metricFunction={metricFunction}
               metricType={metricType}
+              truncateLength={truncateLength}
             />
           </Tab>
         </Tabs>

--- a/web/src/components/netflow-traffic.tsx
+++ b/web/src/components/netflow-traffic.tsx
@@ -77,6 +77,7 @@ import {
   LOCAL_STORAGE_METRIC_SCOPE_KEY,
   LOCAL_STORAGE_METRIC_TYPE_KEY,
   LOCAL_STORAGE_OVERVIEW_IDS_KEY,
+  LOCAL_STORAGE_OVERVIEW_TRUNCATE_KEY,
   LOCAL_STORAGE_QUERY_PARAMS_KEY,
   LOCAL_STORAGE_REFRESH_KEY,
   LOCAL_STORAGE_SHOW_OPTIONS_KEY,
@@ -127,6 +128,7 @@ import MetricsQuerySummary from './query-summary/metrics-query-summary';
 import FlowsQuerySummary from './query-summary/flows-query-summary';
 import { SearchComponent, SearchEvent, SearchHandle } from './search/search';
 import './netflow-traffic.css';
+import { TruncateLength } from './dropdowns/truncate-dropdown';
 
 export type ViewId = 'overview' | 'table' | 'topology';
 
@@ -161,6 +163,10 @@ export const NetflowTraffic: React.FC<{
   const [flows, setFlows] = React.useState<Record[]>([]);
   const [stats, setStats] = React.useState<Stats | undefined>(undefined);
   const [appStats, setAppStats] = React.useState<Stats | undefined>(undefined);
+  const [overviewTruncateLength, setOverviewTruncateLength] = useLocalStorage<TruncateLength>(
+    LOCAL_STORAGE_OVERVIEW_TRUNCATE_KEY,
+    TruncateLength.M
+  );
   const [topologyOptions, setTopologyOptions] = useLocalStorage<TopologyOptions>(
     LOCAL_STORAGE_TOPOLOGY_OPTIONS_KEY,
     DefaultOptions
@@ -770,6 +776,7 @@ export const NetflowTraffic: React.FC<{
           metrics={metrics}
           metricFunction={metricFunction}
           metricType={metricType}
+          truncateLength={topologyOptions.truncateLength}
           filters={filters}
           setFilters={setFilters}
           onClose={() => onElementSelect(undefined)}
@@ -807,6 +814,7 @@ export const NetflowTraffic: React.FC<{
             error={error}
             isDark={isDarkTheme}
             filterActionLinks={filterLinks()}
+            truncateLength={overviewTruncateLength}
           />
         );
         break;
@@ -979,6 +987,8 @@ export const NetflowTraffic: React.FC<{
                   setMetricType={setMetricType}
                   metricScope={metricScope}
                   setMetricScope={setMetricScope}
+                  truncateLength={overviewTruncateLength}
+                  setTruncateLength={setOverviewTruncateLength}
                 />
               )}
               {selectedViewId === 'table' && <TableDisplayDropdown size={size} setSize={setSize} />}

--- a/web/src/model/topology.ts
+++ b/web/src/model/topology.ts
@@ -23,6 +23,7 @@ import { getTopologyEdgeId, getTopologyGroupId, getTopologyNodeId } from '../uti
 import { MetricScopeOptions } from './metrics';
 import { MetricFunction, MetricScope, MetricType, NodeType } from './flow-query';
 import { getFormattedValue } from '../utils/metrics';
+import { TruncateLength } from '../components/dropdowns/truncate-dropdown';
 
 export enum LayoutName {
   BreadthFirst = 'BreadthFirst',
@@ -64,22 +65,13 @@ export const getAvailableGroups = (scope: MetricScopeOptions) => {
   }
 };
 
-export enum TopologyTruncateLength {
-  OFF = 0,
-  XS = 10,
-  S = 20,
-  M = 25,
-  L = 30,
-  XL = 40
-}
-
 export interface TopologyOptions {
   maxEdgeStat: number;
   nodeBadges?: boolean;
   edges?: boolean;
   edgeTags?: boolean;
   startCollapsed?: boolean;
-  truncateLength: TopologyTruncateLength;
+  truncateLength: TruncateLength;
   layout: LayoutName;
   groupTypes: TopologyGroupTypes;
   lowScale: number;
@@ -94,7 +86,7 @@ export const DefaultOptions: TopologyOptions = {
   edgeTags: true,
   maxEdgeStat: 0,
   startCollapsed: false,
-  truncateLength: TopologyTruncateLength.M,
+  truncateLength: TruncateLength.M,
   layout: LayoutName.ColaNoForce,
   groupTypes: TopologyGroupTypes.NONE,
   lowScale: 0.3,
@@ -256,7 +248,7 @@ export const generateNode = (
       badgeClassName: 'topology-icon',
       showDecorators: true,
       secondaryLabel,
-      truncateLength: options.truncateLength !== TopologyTruncateLength.OFF ? options.truncateLength : undefined
+      truncateLength: options.truncateLength !== TruncateLength.OFF ? options.truncateLength : undefined
     }
   };
 };
@@ -395,7 +387,7 @@ export const generateDataModel = (
           collapsedWidth: 75,
           collapsedHeight: 75,
           truncateLength:
-            options.truncateLength !== TopologyTruncateLength.OFF
+            options.truncateLength !== TruncateLength.OFF
               ? //match node label length according to badge
                 options.nodeBadges
                 ? options.truncateLength + 2

--- a/web/src/utils/local-storage-hook.ts
+++ b/web/src/utils/local-storage-hook.ts
@@ -7,6 +7,7 @@ export const LOCAL_STORAGE_EXPORT_COLS_KEY = 'netflow-traffic-export-columns';
 export const LOCAL_STORAGE_REFRESH_KEY = 'netflow-traffic-refresh';
 export const LOCAL_STORAGE_SIZE_KEY = 'netflow-traffic-size-size';
 export const LOCAL_STORAGE_VIEW_ID_KEY = 'netflow-traffic-view-id';
+export const LOCAL_STORAGE_OVERVIEW_TRUNCATE_KEY = 'netflow-traffic-overview-truncate';
 export const LOCAL_STORAGE_TOPOLOGY_OPTIONS_KEY = 'netflow-traffic-topology-options';
 export const LOCAL_STORAGE_QUERY_PARAMS_KEY = 'netflow-traffic-query-params';
 export const LOCAL_STORAGE_DISABLED_FILTERS_KEY = 'netflow-traffic-disabled-filters';


### PR DESCRIPTION
- Added truncate label option in Overview `Display options`
- Uses existing topology truncate option for side panel graphs
- Adapt text size according to selected truncate length (XS / S are bigger)
- 2 items per row in legend when possible

![image](https://user-images.githubusercontent.com/91894519/203553881-4c91ac9e-ab46-4cd0-a2aa-f2e2da702664.png)
![image](https://user-images.githubusercontent.com/91894519/203553976-ef62885a-578c-4a4b-8571-6a057089a08c.png)

