### PR TITLE
Bug NETOBSERV-743: update build image & CI tests to Go 1.18 (release-4.12)

### DIFF
--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: ['1.17']
+        go: ['1.18']
     steps:
       - name: install make
         run: sudo apt-get install make

--- a/.github/workflows/push_image_pr.yml
+++ b/.github/workflows/push_image_pr.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: ['1.17']
+        go: ['1.18']
     steps:
       - name: install make
         run: sudo apt-get install make

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: ['1.17']
+        go: ['1.18']
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,7 +21,7 @@ linters:
     - varcheck
 linters-settings:
   stylecheck:
-    go: "1.17"
+    go: "1.18"
   gocritic:
     enabled-checks:
       - hugeParam

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY --chown=default web web
 COPY mocks mocks
 RUN make fmt-frontend just-build-frontend
 
-FROM registry.access.redhat.com/ubi8/go-toolset:1.17 as go-builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.18 as go-builder
 
 WORKDIR /opt/app-root
 


### PR DESCRIPTION
Backport from `master`: https://github.com/netobserv/network-observability-console-plugin/pull/257
