### PR TITLE
NETOBSERV-741 "Clear all filters" setting is reset back to default when switching panels

### DIFF
--- a/web/src/components/netflow-traffic.tsx
+++ b/web/src/components/netflow-traffic.tsx
@@ -105,7 +105,7 @@ import {
   setURLRange,
   setURLReporter
 } from '../utils/router';
-import { getURLParams, hasEmptyParams, netflowTrafficPath, removeURLParam, setURLParams, URLParam } from '../utils/url';
+import { getURLParams, hasEmptyParams, netflowTrafficPath, setURLParams } from '../utils/url';
 import { OverviewDisplayDropdown } from './dropdowns/overview-display-dropdown';
 import { LIMIT_VALUES, TOP_VALUES } from './dropdowns/query-options-dropdown';
 import { RefreshDropdown } from './dropdowns/refresh-dropdown';
@@ -444,7 +444,13 @@ export const NetflowTraffic: React.FC<{
 
   // Rewrite URL params on state change
   React.useEffect(() => {
-    setURLFilters(forcedFilters || filters);
+    //writh forced filters in url if specified
+    if (forcedFilters) {
+      setURLFilters(forcedFilters!);
+    } else if (!_.isEmpty(filters)) {
+      //write filters in url if not empty
+      setURLFilters(filters);
+    }
   }, [filters, forcedFilters]);
   React.useEffect(() => {
     setURLRange(range);
@@ -497,7 +503,8 @@ export const NetflowTraffic: React.FC<{
     if (forcedFilters) {
       push(netflowTrafficPath);
     } else if (filters) {
-      removeURLParam(URLParam.Filters);
+      //set URL Param to empty value to be able to restore state coming from another page
+      setURLFilters([]);
       updateTableFilters([]);
     }
   }, [forcedFilters, push, filters, updateTableFilters]);

--- a/web/src/components/netflow-traffic.tsx
+++ b/web/src/components/netflow-traffic.tsx
@@ -444,7 +444,7 @@ export const NetflowTraffic: React.FC<{
 
   // Rewrite URL params on state change
   React.useEffect(() => {
-    //writh forced filters in url if specified
+    //with forced filters in url if specified
     if (forcedFilters) {
       setURLFilters(forcedFilters!);
     } else if (!_.isEmpty(filters)) {

--- a/web/src/utils/router.ts
+++ b/web/src/utils/router.ts
@@ -46,7 +46,8 @@ export const getMatchFromURL = (): Match => {
 
 export const getFiltersFromURL = (t: TFunction, disabledFilters: DisabledFilters): Promise<Filter[]> | undefined => {
   const urlParam = getURLParam(URLParam.Filters);
-  if (!urlParam) {
+  //skip filters only if url param is missing
+  if (urlParam === null) {
     return undefined;
   }
   const filterPromises: Promise<Filter>[] = [];
@@ -77,10 +78,7 @@ export const getFiltersFromURL = (t: TFunction, disabledFilters: DisabledFilters
       }
     }
   });
-  if (filterPromises.length > 0) {
-    return Promise.all(filterPromises);
-  }
-  return undefined;
+  return Promise.all(filterPromises);
 };
 
 export const setURLFilters = (filters: Filter[]) => {


### PR DESCRIPTION
When `&filters=` is specified without values, the empty filters state is restored.

The default filters are loaded when `filters` url param is missing from both url & local storage.