### PR TITLE
NETOBSERV-783 multiple page loads with quick filters

### DIFF
--- a/web/src/components/__tests-data__/config.ts
+++ b/web/src/components/__tests-data__/config.ts
@@ -1,0 +1,7 @@
+export const ConfigResultSample = {
+  portNaming: {
+    enable: true,
+    portNames: new Map([['3100', 'loki']])
+  },
+  quickFilters: []
+};

--- a/web/src/components/filters/filters-toolbar.tsx
+++ b/web/src/components/filters/filters-toolbar.tsx
@@ -46,7 +46,7 @@ import './filters-toolbar.css';
 export interface FiltersToolbarProps {
   id: string;
   filters?: Filter[];
-  forcedFilters?: Filter[];
+  forcedFilters?: Filter[] | null;
   skipTipsDelay?: boolean;
   setFilters: (v: Filter[]) => void;
   clearFilters: () => void;

--- a/web/src/components/netflow-traffic-parent.tsx
+++ b/web/src/components/netflow-traffic-parent.tsx
@@ -49,7 +49,7 @@ class NetflowTrafficParent extends React.Component<Props, State> {
       return this.props.children;
     }
     // else render default NetworkTraffic
-    return <NetflowTraffic />;
+    return <NetflowTraffic forcedFilters={null} />;
   }
 }
 

--- a/web/src/components/netflow-traffic.tsx
+++ b/web/src/components/netflow-traffic.tsx
@@ -208,7 +208,7 @@ export const NetflowTraffic: React.FC<{
   const searchRef = React.useRef<SearchHandle>(null);
   const [searchEvent, setSearchEvent] = React.useState<SearchEvent | undefined>(undefined);
   //use this ref to list any props / content loading state & events to skip tick function
-  const initState = React.useRef<string[]>([]);
+  const initState = React.useRef<Array<'initDone' | 'configLoading' | 'configLoaded' | 'forcedFiltersLoaded'>>([]);
   const [panels, setSelectedPanels] = useLocalStorage<OverviewPanel[]>(
     LOCAL_STORAGE_OVERVIEW_IDS_KEY,
     getDefaultOverviewPanels(),


### PR DESCRIPTION
This fix avoid tick being called multiple times at start.

Code changes:
- merged `config` / `forcedFilters` useEffect
- use null when `forcedFilters` are disabled to differenciate with undefined
- `initState` as string array to let developpers better understand what has been done, in which order and allow future states
- log error if tick is wrongly called