### PR TITLE
pre-merge test labels

### DIFF
--- a/.github/workflows/pr_labels.yml
+++ b/.github/workflows/pr_labels.yml
@@ -1,0 +1,18 @@
+name: PR labels
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+    branches: ['*']
+
+jobs:
+  check-labels:
+    name: qe-approve|no-qe, doc-approve|no-doc
+    runs-on: ubuntu-latest
+    steps:
+      - name: QE approval
+        if: "!contains( github.event.pull_request.labels.*.name, 'qe-approved') && !contains( github.event.pull_request.labels.*.name, 'no-qe')"
+        run: exit 1
+      - name: Doc approval
+        if: "!contains( github.event.pull_request.labels.*.name, 'doc-approved') && !contains( github.event.pull_request.labels.*.name, 'no-doc')"
+        run: exit 1

--- a/.github/workflows/pr_labels.yml
+++ b/.github/workflows/pr_labels.yml
@@ -7,12 +7,12 @@ on:
 
 jobs:
   check-labels:
-    name: qe-approve|no-qe, doc-approve|no-doc
+    name: qe-approved|no-qe & docs-approved|no-docs
     runs-on: ubuntu-latest
     steps:
       - name: QE approval
         if: "!contains( github.event.pull_request.labels.*.name, 'qe-approved') && !contains( github.event.pull_request.labels.*.name, 'no-qe')"
         run: exit 1
-      - name: Doc approval
-        if: "!contains( github.event.pull_request.labels.*.name, 'doc-approved') && !contains( github.event.pull_request.labels.*.name, 'no-doc')"
+      - name: Docs approval
+        if: "!contains( github.event.pull_request.labels.*.name, 'docs-approved') && !contains( github.event.pull_request.labels.*.name, 'no-docs')"
         run: exit 1

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -26,7 +26,7 @@ jobs:
 
   build-test-frontend:
     name: Build, lint, test frontend
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         go: ['1.18']


### PR DESCRIPTION
Use direct workflow

Hey @netobserv/maintainers ,
This is my proposal for implementing the pre-merge acceptance labels

That's quite simple and more straightforward than if done with prow/tide
Currently it requires either no-doc or doc-approved, and either no-qe or qe-approved