### PR TITLE
NETOBSERV-794 Quick filters doesn't work in tabs

### DIFF
--- a/web/src/components/filters/filters-toolbar.tsx
+++ b/web/src/components/filters/filters-toolbar.tsx
@@ -258,7 +258,7 @@ export const FiltersToolbar: React.FC<FiltersToolbarProps> = ({
         <ToolbarItem className="flex-start">
           <QueryOptionsDropdown {...props.queryOptionsProps} />
         </ToolbarItem>
-        {quickFilters.length > 0 && (
+        {_.isEmpty(forcedFilters) && quickFilters.length > 0 && (
           <ToolbarItem className="flex-start">
             <QuickFilters quickFilters={quickFilters} activeFilters={filters || []} setFilters={setFilters} />
           </ToolbarItem>


### PR DESCRIPTION
Removed quick filters in tabs:
![image](https://user-images.githubusercontent.com/91894519/219017013-de832d8c-0575-4eed-8707-8e19d7c58fa6.png)
