### PR TITLE
NETOBSERV-903 banner style fix

### DIFF
--- a/web/src/components/alerts/banner.css
+++ b/web/src/components/alerts/banner.css
@@ -1,3 +1,9 @@
 .netobserv-alert {
-    margin: 1em;
+    margin: 1.5rem;
+}
+
+.netobserv-alerts-container {
+    position: absolute;
+    width: -webkit-fill-available;
+    z-index: 999;
 }

--- a/web/src/components/alerts/fetcher.tsx
+++ b/web/src/components/alerts/fetcher.tsx
@@ -44,12 +44,14 @@ export const AlertFetcher: React.FC<AlertFetcherProps> = ({ children }) => {
     return;
   }, []);
   return (
-    <div>
-      {alerts.map(a => (
-        <AlertBanner key={a.name} rule={a} onDelete={() => setAlerts(alerts.filter(alert => alert.name != a.name))} />
-      ))}
+    <>
+      <div className="netobserv-alerts-container">
+        {alerts.map(a => (
+          <AlertBanner key={a.name} rule={a} onDelete={() => setAlerts(alerts.filter(alert => alert.name != a.name))} />
+        ))}
+      </div>
       {!!children ? children : ''}
-    </div>
+    </>
   );
 };
 


### PR DESCRIPTION
It seems banner kills page div styling:
![Screenshot from 2023-02-20 11-37-19](https://user-images.githubusercontent.com/91894519/220083290-b6ae1e07-d351-42f6-a35a-079dbfc54fd4.png)

I would suggest putting these on `position: absolute`:
![image](https://user-images.githubusercontent.com/91894519/220085781-87dd6cb6-7f37-4af8-80c7-e1acdb2b9347.png)
