### PR TITLE
NETOBSERV-906 Document json format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,3 +168,7 @@ else
 	cd ${CONSOLE} && source contrib/oc-environment.sh && ./bin/bridge -plugins netobserv-plugin=http://localhost:9001/ --plugin-proxy='{"services":[{"consoleAPIPath":"/api/proxy/plugin/netobserv-plugin/backend/","endpoint":"http://localhost:9001"}]}'
 	cd -
 endif
+
+.PHONY: generate-doc
+generate-doc: ## Generate documentation of the flows JSON format
+	cd web && npm run generate-doc

--- a/web/docs/README.md
+++ b/web/docs/README.md
@@ -1,0 +1,11 @@
+# netobserv-plugin
+
+## Interfaces
+
+- [Record](interfaces/Record.md)
+- [Labels](interfaces/Labels.md)
+- [Fields](interfaces/Fields.md)
+
+## Enumerations
+
+- [FlowDirection](enums/FlowDirection.md)

--- a/web/docs/enums/FlowDirection.md
+++ b/web/docs/enums/FlowDirection.md
@@ -1,0 +1,17 @@
+# Enumeration: FlowDirection
+
+## Enumeration Members
+
+### Ingress
+
+• **Ingress** = ``"0"``
+
+Incoming traffic, from node observation point
+
+___
+
+### Egress
+
+• **Egress** = ``"1"``
+
+Outgoing traffic, from node observation point

--- a/web/docs/interfaces/Fields.md
+++ b/web/docs/interfaces/Fields.md
@@ -1,0 +1,177 @@
+# Interface: Fields
+
+## Properties
+
+### SrcAddr
+
+• **SrcAddr**: `string`
+
+Source IP address (ipv4 or ipv6)
+
+___
+
+### DstAddr
+
+• **DstAddr**: `string`
+
+Destination IP address (ipv4 or ipv6)
+
+___
+
+### SrcMac
+
+• **SrcMac**: `string`
+
+Source MAC address
+
+___
+
+### DstMac
+
+• **DstMac**: `string`
+
+Destination MAC address
+
+___
+
+### SrcK8S\_Name
+
+• `Optional` **SrcK8S\_Name**: `string`
+
+Name of the source matched Kubernetes object, such as Pod name, Service name, etc.
+
+___
+
+### DstK8S\_Name
+
+• `Optional` **DstK8S\_Name**: `string`
+
+Name of the destination matched Kubernetes object, such as Pod name, Service name, etc.
+
+___
+
+### SrcK8S\_Type
+
+• `Optional` **SrcK8S\_Type**: `string`
+
+Kind of the source matched Kubernetes object, such as Pod, Service, etc.
+
+___
+
+### DstK8S\_Type
+
+• `Optional` **DstK8S\_Type**: `string`
+
+Kind of the destination matched Kubernetes object, such as Pod name, Service name, etc.
+
+___
+
+### SrcPort
+
+• **SrcPort**: `number`
+
+Source port
+
+___
+
+### DstPort
+
+• **DstPort**: `number`
+
+Destination port
+
+___
+
+### SrcK8S\_OwnerType
+
+• `Optional` **SrcK8S\_OwnerType**: `string`
+
+Kind of the source Kubernetes owner, such as Deployment, StatefulSet, etc.
+
+___
+
+### DstK8S\_OwnerType
+
+• `Optional` **DstK8S\_OwnerType**: `string`
+
+Kind of the destination Kubernetes owner, such as Deployment, StatefulSet, etc.
+
+___
+
+### SrcK8S\_HostIP
+
+• `Optional` **SrcK8S\_HostIP**: `string`
+
+Source node IP
+
+___
+
+### DstK8S\_HostIP
+
+• `Optional` **DstK8S\_HostIP**: `string`
+
+Destination node IP
+
+___
+
+### SrcK8S\_HostName
+
+• `Optional` **SrcK8S\_HostName**: `string`
+
+Source node name
+
+___
+
+### DstK8S\_HostName
+
+• `Optional` **DstK8S\_HostName**: `string`
+
+Destination node name
+
+___
+
+### Proto
+
+• **Proto**: `number`
+
+L4 protocol
+
+___
+
+### Packets
+
+• **Packets**: `number`
+
+Number of packets in this flow
+
+___
+
+### Bytes
+
+• **Bytes**: `number`
+
+Number of bytes in this flow
+
+___
+
+### TimeFlowStartMs
+
+• **TimeFlowStartMs**: `number`
+
+Start timestamp of this flow, in milliseconds
+
+___
+
+### TimeFlowEndMs
+
+• **TimeFlowEndMs**: `number`
+
+End timestamp of this flow, in milliseconds
+
+___
+
+### TimeReceived
+
+• **TimeReceived**: `number`
+
+Timestamp when this flow was received and processed by the flow collector, in seconds

--- a/web/docs/interfaces/Labels.md
+++ b/web/docs/interfaces/Labels.md
@@ -1,0 +1,41 @@
+# Interface: Labels
+
+## Properties
+
+### SrcK8S\_Namespace
+
+• `Optional` **SrcK8S\_Namespace**: `string`
+
+Source namespace
+
+___
+
+### DstK8S\_Namespace
+
+• `Optional` **DstK8S\_Namespace**: `string`
+
+Destination namespace
+
+___
+
+### SrcK8S\_OwnerName
+
+• `Optional` **SrcK8S\_OwnerName**: `string`
+
+Source owner, such as Deployment, StatefulSet, etc.
+
+___
+
+### DstK8S\_OwnerName
+
+• `Optional` **DstK8S\_OwnerName**: `string`
+
+Destination owner, such as Deployment, StatefulSet, etc.
+
+___
+
+### FlowDirection
+
+• **FlowDirection**: [`FlowDirection`](../enums/FlowDirection.md)
+
+Flow direction from the node observation point

--- a/web/docs/interfaces/Record.md
+++ b/web/docs/interfaces/Record.md
@@ -1,0 +1,19 @@
+# Interface: Record
+
+## Properties
+
+### labels
+
+• **labels**: [`Labels`](Labels.md)
+
+___
+
+### key
+
+• **key**: `number`
+
+___
+
+### fields
+
+• **fields**: [`Fields`](Fields.md)

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -80,6 +80,8 @@
         "ts-jest-resolver": "2.0.0",
         "ts-loader": "9.3.1",
         "ts-node": "10.8.2",
+        "typedoc": "^0.23.25",
+        "typedoc-plugin-markdown": "^3.14.0",
         "typescript": "4.7.4",
         "webpack": "^5.73.0",
         "webpack-cli": "^4.10.0",
@@ -5045,6 +5047,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/ansi-sequence-parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.0.tgz",
+      "integrity": "sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ==",
+      "dev": true
+    },
     "node_modules/ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -9803,6 +9811,27 @@
       "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
       "dev": true
     },
+    "node_modules/handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -13041,6 +13070,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
+    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -13491,6 +13526,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
     "node_modules/lz-string": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
@@ -13537,6 +13578,18 @@
       "dev": true,
       "dependencies": {
         "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
+      "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw==",
+      "dev": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/matcher-collection": {
@@ -16620,6 +16673,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/shiki": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.1.tgz",
+      "integrity": "sha512-+Jz4nBkCBe0mEDqo1eKRcCdjRtrCjozmcbTUjbPTX7OOJfEbTZzlUWlZtGe3Gb5oV1/jnojhG//YZc3rs9zSEw==",
+      "dev": true,
+      "dependencies": {
+        "ansi-sequence-parser": "^1.1.0",
+        "jsonc-parser": "^3.2.0",
+        "vscode-oniguruma": "^1.7.0",
+        "vscode-textmate": "^8.0.0"
+      }
+    },
     "node_modules/showdown": {
       "version": "1.8.6",
       "resolved": "https://registry.npmjs.org/showdown/-/showdown-1.8.6.tgz",
@@ -18094,6 +18159,63 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/typedoc": {
+      "version": "0.23.25",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.25.tgz",
+      "integrity": "sha512-O1he153qVyoCgJYSvIyY3bPP1wAJTegZfa6tL3APinSZhJOf8CSd8F/21M6ex8pUY/fuY6n0jAsT4fIuMGA6sA==",
+      "dev": true,
+      "dependencies": {
+        "lunr": "^2.3.9",
+        "marked": "^4.2.12",
+        "minimatch": "^6.1.6",
+        "shiki": "^0.14.1"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 14.14"
+      },
+      "peerDependencies": {
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x"
+      }
+    },
+    "node_modules/typedoc-plugin-markdown": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.14.0.tgz",
+      "integrity": "sha512-UyQLkLRkfTFhLdhSf3RRpA3nNInGn+k6sll2vRXjflaMNwQAAiB61SYbisNZTg16t4K1dt1bPQMMGLrxS0GZ0Q==",
+      "dev": true,
+      "dependencies": {
+        "handlebars": "^4.7.7"
+      },
+      "peerDependencies": {
+        "typedoc": ">=0.23.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-6.2.0.tgz",
+      "integrity": "sha512-sauLxniAmvnhhRjFwPNnJKaPFYyddAgbYdeUpHULtCT/GhzdCx/MDNy+Y40lBxTQUrMzDE8e0S43Z5uqfO0REg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/typesafe-actions": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/typesafe-actions/-/typesafe-actions-4.4.2.tgz",
@@ -18114,6 +18236,19 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/unbox-primitive": {
@@ -18884,6 +19019,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+      "dev": true
+    },
+    "node_modules/vscode-textmate": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
+      "dev": true
+    },
     "node_modules/vue-template-compiler": {
       "version": "2.6.14",
       "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.14.tgz",
@@ -19455,6 +19602,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -23540,6 +23693,12 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
     },
+    "ansi-sequence-parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-sequence-parser/-/ansi-sequence-parser-1.1.0.tgz",
+      "integrity": "sha512-lEm8mt52to2fT8GhciPCGeCXACSz2UwIN4X2e2LJSnZ5uAbn2/dsYdOmUXq0AtWS5cpAupysIneExOgH0Vd2TQ==",
+      "dev": true
+    },
     "ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -27305,6 +27464,19 @@
       "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
       "dev": true
     },
+    "handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      }
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -29718,6 +29890,12 @@
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
     },
+    "jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
+    },
     "jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -30065,6 +30243,12 @@
         "yallist": "^4.0.0"
       }
     },
+    "lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
     "lz-string": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
@@ -30102,6 +30286,12 @@
       "requires": {
         "tmpl": "1.0.5"
       }
+    },
+    "marked": {
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
+      "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw==",
+      "dev": true
     },
     "matcher-collection": {
       "version": "2.0.1",
@@ -32492,6 +32682,18 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
+    "shiki": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.14.1.tgz",
+      "integrity": "sha512-+Jz4nBkCBe0mEDqo1eKRcCdjRtrCjozmcbTUjbPTX7OOJfEbTZzlUWlZtGe3Gb5oV1/jnojhG//YZc3rs9zSEw==",
+      "dev": true,
+      "requires": {
+        "ansi-sequence-parser": "^1.1.0",
+        "jsonc-parser": "^3.2.0",
+        "vscode-oniguruma": "^1.7.0",
+        "vscode-textmate": "^8.0.0"
+      }
+    },
     "showdown": {
       "version": "1.8.6",
       "resolved": "https://registry.npmjs.org/showdown/-/showdown-1.8.6.tgz",
@@ -33635,6 +33837,47 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typedoc": {
+      "version": "0.23.25",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.25.tgz",
+      "integrity": "sha512-O1he153qVyoCgJYSvIyY3bPP1wAJTegZfa6tL3APinSZhJOf8CSd8F/21M6ex8pUY/fuY6n0jAsT4fIuMGA6sA==",
+      "dev": true,
+      "requires": {
+        "lunr": "^2.3.9",
+        "marked": "^4.2.12",
+        "minimatch": "^6.1.6",
+        "shiki": "^0.14.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-6.2.0.tgz",
+          "integrity": "sha512-sauLxniAmvnhhRjFwPNnJKaPFYyddAgbYdeUpHULtCT/GhzdCx/MDNy+Y40lBxTQUrMzDE8e0S43Z5uqfO0REg==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
+      }
+    },
+    "typedoc-plugin-markdown": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.14.0.tgz",
+      "integrity": "sha512-UyQLkLRkfTFhLdhSf3RRpA3nNInGn+k6sll2vRXjflaMNwQAAiB61SYbisNZTg16t4K1dt1bPQMMGLrxS0GZ0Q==",
+      "dev": true,
+      "requires": {
+        "handlebars": "^4.7.7"
+      }
+    },
     "typesafe-actions": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/typesafe-actions/-/typesafe-actions-4.4.2.tgz",
@@ -33646,6 +33889,13 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
       "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true
+    },
+    "uglify-js": {
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+      "dev": true,
+      "optional": true
     },
     "unbox-primitive": {
       "version": "1.0.1",
@@ -34296,6 +34546,18 @@
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
       "integrity": "sha1-YU9/v42AHwu18GYfWy9XhXUOTwk="
     },
+    "vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+      "dev": true
+    },
+    "vscode-textmate": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==",
+      "dev": true
+    },
     "vue-template-compiler": {
       "version": "2.6.14",
       "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.14.tgz",
@@ -34715,6 +34977,12 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
       "dev": true
     },
     "wrap-ansi": {

--- a/web/package.json
+++ b/web/package.json
@@ -22,7 +22,8 @@
     "lint": "./node_modules/.bin/eslint \"./src/**/*.{ts,tsx}\"",
     "format": "pretty-quick --branch main",
     "format-all": "prettier --write \"./src/**/*.{ts,tsx}\" && npm run fix-imports",
-    "fix-imports": "eslint --no-eslintrc --no-inline-config --parser '@typescript-eslint/parser' --plugin 'unused-imports' --plugin 'react-hooks' --rule 'unused-imports/no-unused-imports:error' --fix \"./src/**/*.{ts,tsx}\""
+    "fix-imports": "eslint --no-eslintrc --no-inline-config --parser '@typescript-eslint/parser' --plugin 'unused-imports' --plugin 'react-hooks' --rule 'unused-imports/no-unused-imports:error' --fix \"./src/**/*.{ts,tsx}\"",
+    "generate-doc": "typedoc --sort source-order --categorizeByGroup false --githubPages false --readme none --disableSources --out docs src/api/ipfix.ts --hideBreadcrumbs true --hideInPageTOC true"
   },
   "devDependencies": {
     "@babel/core": "^7.17.12",
@@ -75,6 +76,8 @@
     "ts-jest-resolver": "2.0.0",
     "ts-loader": "9.3.1",
     "ts-node": "10.8.2",
+    "typedoc": "^0.23.25",
+    "typedoc-plugin-markdown": "^3.14.0",
     "typescript": "4.7.4",
     "webpack": "^5.73.0",
     "webpack-cli": "^4.10.0",

--- a/web/src/api/ipfix.ts
+++ b/web/src/api/ipfix.ts
@@ -5,39 +5,68 @@ export interface Record {
 }
 
 export interface Labels {
+  /** Source namespace */
   SrcK8S_Namespace?: string;
+  /** Destination namespace */
   DstK8S_Namespace?: string;
+  /** Source owner, such as Deployment, StatefulSet, etc. */
   SrcK8S_OwnerName?: string;
+  /** Destination owner, such as Deployment, StatefulSet, etc. */
   DstK8S_OwnerName?: string;
+  /** Flow direction from the node observation point */
   FlowDirection: FlowDirection;
 }
 
 export enum FlowDirection {
+  /** Incoming traffic, from node observation point */
   Ingress = '0',
+  /** Outgoing traffic, from node observation point */
   Egress = '1'
 }
 
 export interface Fields {
+  /** Source IP address (ipv4 or ipv6) */
   SrcAddr: string;
+  /** Destination IP address (ipv4 or ipv6) */
   DstAddr: string;
+  /** Source MAC address */
   SrcMac: string;
+  /** Destination MAC address */
   DstMac: string;
+  /** Name of the source matched Kubernetes object, such as Pod name, Service name, etc. */
   SrcK8S_Name?: string;
+  /** Name of the destination matched Kubernetes object, such as Pod name, Service name, etc. */
   DstK8S_Name?: string;
+  /** Kind of the source matched Kubernetes object, such as Pod, Service, etc. */
   SrcK8S_Type?: string;
+  /** Kind of the destination matched Kubernetes object, such as Pod name, Service name, etc. */
   DstK8S_Type?: string;
+  /** Source port */
   SrcPort: number;
+  /** Destination port */
   DstPort: number;
+  /** Kind of the source Kubernetes owner, such as Deployment, StatefulSet, etc. */
   SrcK8S_OwnerType?: string;
+  /** Kind of the destination Kubernetes owner, such as Deployment, StatefulSet, etc. */
   DstK8S_OwnerType?: string;
+  /** Source node IP */
   SrcK8S_HostIP?: string;
+  /** Destination node IP */
   DstK8S_HostIP?: string;
+  /** Source node name */
   SrcK8S_HostName?: string;
+  /** Destination node name */
   DstK8S_HostName?: string;
-  Packets: number;
+  /** L4 protocol */
   Proto: number;
+  /** Number of packets in this flow */
+  Packets: number;
+  /** Number of bytes in this flow */
   Bytes: number;
+  /** Start timestamp of this flow, in milliseconds */
   TimeFlowStartMs: number;
+  /** End timestamp of this flow, in milliseconds */
   TimeFlowEndMs: number;
+  /** Timestamp when this flow was received and processed by the flow collector, in seconds */
   TimeReceived: number;
 }


### PR DESCRIPTION
Hey @jpinsonneau @OlivierCazade  @skrthomas ,

This PR is a first step to automate generating doc for our custom the json format, which now become mandatory to have since it is exposed for kafka export (and it is anyway good to have for people willing to query Loki directly).

I didn't find a satisfying Typescript-API-doc-to-asciidoc tool so what I plan to do is doing this in two steps:
- First, as shown in this PR, generate Typescipt-API-to-markdown here, without much post-edition of the generated files
- Next, open a PR on the operator side that pulls markdown from there, do some post-edition (e.g. merge all in a single file, do some `sed` here and there), and convert to asciidoc. This will allow having our asciidoc consumable for downstream all in one place.