### PR TITLE
NETOBSERV-678 Health dashboard link

### DIFF
--- a/web/locales/en/plugin__netobserv-plugin.json
+++ b/web/locales/en/plugin__netobserv-plugin.json
@@ -1,5 +1,6 @@
 {
   "View alert details": "View alert details",
+  "View health dashboard": "View health dashboard",
   "Namespaces + Owners": "Namespaces + Owners",
   "Nodes + Namespaces": "Nodes + Namespaces",
   "Nodes + Owners": "Nodes + Owners",
@@ -118,6 +119,7 @@
   "Show metrics": "Show metrics",
   "Show build info": "Show build info",
   "Show configuration limits": "Show configuration limits",
+  "Show health dashboard": "Show health dashboard",
   "Copy": "Copy",
   "Copied": "Copied",
   "Zoom in / out histogram. You can also use plus or minus buttons while histogram is focused.": "Zoom in / out histogram. You can also use plus or minus buttons while histogram is focused.",

--- a/web/src/components/alerts/banner.tsx
+++ b/web/src/components/alerts/banner.tsx
@@ -18,9 +18,13 @@ export const AlertBanner: React.FC<{
 }> = ({ rule, onDelete }) => {
   const history = useHistory();
   const { t } = useTranslation('plugin__netobserv-plugin');
-  const routeChange = () => {
+  const routeAlert = () => {
     let path = `/monitoring/alerts/${rule.id}`;
     path += `?alertname=${rule.name}&app=${rule.labels.app}&severity=${rule.labels.severity}`;
+    history.push(path);
+  };
+  const routeDashboard = () => {
+    const path = `/monitoring/dashboards/grafana-dashboard-netobserv-health`;
     history.push(path);
   };
   return (
@@ -32,7 +36,8 @@ export const AlertBanner: React.FC<{
         actionClose={<AlertActionCloseButton onClose={onDelete} />}
         actionLinks={
           <React.Fragment>
-            <AlertActionLink onClick={routeChange}>{t('View alert details')}</AlertActionLink>
+            <AlertActionLink onClick={routeAlert}>{t('View alert details')}</AlertActionLink>
+            <AlertActionLink onClick={routeDashboard}>{t('View health dashboard')}</AlertActionLink>
           </React.Fragment>
         }
       >

--- a/web/src/components/alerts/banner.tsx
+++ b/web/src/components/alerts/banner.tsx
@@ -20,7 +20,7 @@ export const AlertBanner: React.FC<{
   const { t } = useTranslation('plugin__netobserv-plugin');
   const routeChange = () => {
     let path = `/monitoring/alerts/${rule.id}`;
-    path += `?alertname=${rule.name}&namespace=${rule.labels.namespace}&severity=${rule.labels.severity}`;
+    path += `?alertname=${rule.name}&app=${rule.labels.app}&severity=${rule.labels.severity}`;
     history.push(path);
   };
   return (

--- a/web/src/components/alerts/fetcher.tsx
+++ b/web/src/components/alerts/fetcher.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import AlertBanner from './banner';
 import { getAlerts } from '../../api/routes';
 import { Rule } from '@openshift-console/dynamic-plugin-sdk';
-import { config } from '../../utils/config';
 
 import { murmur3 } from 'murmurhash-js';
 
@@ -16,24 +15,19 @@ export const AlertFetcher: React.FC<AlertFetcherProps> = ({ children }) => {
         setAlerts(
           result.data.groups.flatMap(group => {
             return group.rules
-              .filter(
-                  rule =>
-                      !!rule.labels.app &&
-			rule.labels.app == "netobserv" &&
-			rule.state == 'firing'
-              )
-			.map(rule => {
-                  const key = [
-                      group.file,
-                      group.name,
-                      rule.name,
-                      String(rule.duration),
-                      rule.query,
-                      `${rule.labels.app}=app`,
-                      `${rule.labels.prometheus}=prometheus`,
-                      `${rule.labels.severity}=severity`
-                  ].join(',');
-                  rule.id = String(murmur3(key, 0));
+              .filter(rule => !!rule.labels.app && rule.labels.app == 'netobserv' && rule.state == 'firing')
+              .map(rule => {
+                const key = [
+                  group.file,
+                  group.name,
+                  rule.name,
+                  String(rule.duration),
+                  rule.query,
+                  `${rule.labels.app}=app`,
+                  `${rule.labels.prometheus}=prometheus`,
+                  `${rule.labels.severity}=severity`
+                ].join(',');
+                rule.id = String(murmur3(key, 0));
                 return rule;
               });
           })

--- a/web/src/components/alerts/fetcher.tsx
+++ b/web/src/components/alerts/fetcher.tsx
@@ -17,22 +17,23 @@ export const AlertFetcher: React.FC<AlertFetcherProps> = ({ children }) => {
           result.data.groups.flatMap(group => {
             return group.rules
               .filter(
-                rule =>
-                  !!rule.labels.namespace &&
-                  config.alertNamespaces.findIndex(elem => elem == rule.labels.namespace) > -1 &&
-                  rule.state == 'firing'
+                  rule =>
+                      !!rule.labels.app &&
+			rule.labels.app == "netobserv" &&
+			rule.state == 'firing'
               )
-              .map(rule => {
-                const key = [
-                  group.file,
-                  group.name,
-                  rule.name,
-                  String(rule.duration),
-                  rule.query,
-                  `${rule.labels.namespace}=namespace`,
-                  `${rule.labels.severity}=severity`
-                ].join(',');
-                rule.id = String(murmur3(key, 0));
+			.map(rule => {
+                  const key = [
+                      group.file,
+                      group.name,
+                      rule.name,
+                      String(rule.duration),
+                      rule.query,
+                      `${rule.labels.app}=app`,
+                      `${rule.labels.prometheus}=prometheus`,
+                      `${rule.labels.severity}=severity`
+                  ].join(',');
+                  rule.id = String(murmur3(key, 0));
                 return rule;
               });
           })

--- a/web/src/components/messages/loki-error.tsx
+++ b/web/src/components/messages/loki-error.tsx
@@ -21,6 +21,7 @@ import { Link } from 'react-router-dom';
 import { getBuildInfo, getLimits, getMetrics, getLokiReady } from '../../api/routes';
 import { getHTTPErrorDetails } from '../../utils/errors';
 import './loki-error.css';
+import { useHistory } from 'react-router-dom';
 
 export type Size = 's' | 'm' | 'l';
 
@@ -42,6 +43,7 @@ export const LokiError: React.FC<Props> = ({ title, error }) => {
   const [ready, setReady] = React.useState<string | undefined>();
   const [infoName, setInfoName] = React.useState<string | undefined>();
   const [info, setInfo] = React.useState<string | undefined>();
+  const history = useHistory();
 
   const updateInfo = React.useCallback(
     (type: LokiInfo) => {
@@ -204,6 +206,12 @@ export const LokiError: React.FC<Props> = ({ title, error }) => {
           </Button>
           <Button onClick={() => updateInfo(LokiInfo.Limits)} variant="link">
             {t('Show configuration limits')}
+          </Button>
+          <Button
+            onClick={() => history.push('/monitoring/dashboards/grafana-dashboard-netobserv-health')}
+            variant="link"
+          >
+            {t('Show health dashboard')}
           </Button>
         </EmptyStateSecondaryActions>
       </EmptyState>


### PR DESCRIPTION
Fix alert id calculation after monitoring operator update and add health dashboard link:

![image](https://user-images.githubusercontent.com/20989309/225703440-d0058756-3a77-4c71-ab86-855508b4d05d.png)

and here (bottom right):

![image](https://user-images.githubusercontent.com/20989309/225703502-274a4961-ebbf-4e25-bd01-eb52fa4692c9.png)

Please note that this PR should be tested with the health [dashboard PR](https://github.com/netobserv/network-observability-operator/pull/299)
