### PR TITLE
NETOBSERV-935 Disable notch to switch between FLOWS and CONNECTIONS when logType != ALL

### DIFF
--- a/web/src/components/netflow-record/__tests__/record-panel.spec.tsx
+++ b/web/src/components/netflow-record/__tests__/record-panel.spec.tsx
@@ -14,6 +14,7 @@ describe('<RecordPanel />', () => {
     range: 300,
     reporter: 'destination',
     type: 'flowLog',
+    canSwitchTypes: false,
     setFilters: jest.fn(),
     setRange: jest.fn(),
     setReporter: jest.fn(),

--- a/web/src/components/netflow-record/record-panel.tsx
+++ b/web/src/components/netflow-record/record-panel.tsx
@@ -41,6 +41,7 @@ export type RecordDrawerProps = {
   range: number | TimeRange;
   reporter: Reporter;
   type: RecordType;
+  canSwitchTypes: boolean;
   setFilters: (v: Filter[]) => void;
   setRange: (r: number | TimeRange) => void;
   setReporter: (r: Reporter) => void;
@@ -57,6 +58,7 @@ export const RecordPanel: React.FC<RecordDrawerProps> = ({
   range,
   reporter,
   type,
+  canSwitchTypes,
   setFilters,
   setRange,
   setReporter,
@@ -128,13 +130,16 @@ export const RecordPanel: React.FC<RecordDrawerProps> = ({
     [reporter, setReporter]
   );
 
-  const getRecordTypeFilter = React.useCallback((): RecordFieldFilter => {
+  const getRecordTypeFilter = React.useCallback((): RecordFieldFilter | undefined => {
+    if (!canSwitchTypes) {
+      return undefined;
+    }
     return {
       type: 'switch',
       onClick: () => setType(type === 'allConnections' ? 'flowLog' : 'allConnections'),
       isDelete: type !== 'allConnections'
     };
-  }, [setType, type]);
+  }, [canSwitchTypes, setType, type]);
 
   const getGenericFilter = React.useCallback(
     (col: Column, value: unknown): RecordFieldFilter | undefined => {

--- a/web/src/components/netflow-traffic.tsx
+++ b/web/src/components/netflow-traffic.tsx
@@ -107,6 +107,7 @@ import {
   setURLMetricFunction,
   setURLMetricType,
   setURLRange,
+  setURLRecortType,
   setURLReporter
 } from '../utils/router';
 import { getURLParams, hasEmptyParams, netflowTrafficPath, setURLParams } from '../utils/url';
@@ -552,6 +553,9 @@ export const NetflowTraffic: React.FC<{
     setURLMetricFunction(metricFunction);
     setURLMetricType(metricType);
   }, [metricFunction, metricType]);
+  React.useEffect(() => {
+    setURLRecortType(recordType);
+  }, [recordType]);
 
   // update local storage saved query params
   React.useEffect(() => {
@@ -870,6 +874,7 @@ export const NetflowTraffic: React.FC<{
           range={range}
           reporter={reporter}
           type={recordType}
+          canSwitchTypes={isFlow() && isConnectionTracking()}
           setFilters={setFilters}
           setRange={setRange}
           setReporter={setReporter}

--- a/web/src/utils/router.ts
+++ b/web/src/utils/router.ts
@@ -107,6 +107,10 @@ export const setURLRange = (range: number | TimeRange) => {
   }
 };
 
+export const setURLRecortType = (recordType: RecordType) => {
+  setURLParam(URLParam.RecordType, recordType);
+};
+
 export const setURLReporter = (reporter: Reporter) => {
   setURLParam(URLParam.Reporter, reporter);
 };


### PR DESCRIPTION
- remove switch button in side panel on `Event / Type` when both `Flow` and `Conversation` are not available
- fix `recordType` not saved in URL