### PR TITLE
NETOBSERV-915 add conversation direction

### DIFF
--- a/web/locales/en/plugin__netobserv-plugin.json
+++ b/web/locales/en/plugin__netobserv-plugin.json
@@ -44,7 +44,7 @@
   "Only available when FlowCollector.processor.logTypes option equals \"FLOWS\" or \"ALL\"": "Only available when FlowCollector.processor.logTypes option equals \"FLOWS\" or \"ALL\"",
   "Every flow can be reported from the source node and/or the destination node. For in-cluster traffic, usually both source and destination nodes report flows, resulting in duplicated data. Cluster ingress traffic is only reported by destination nodes, and cluster egress by source nodes.": "Every flow can be reported from the source node and/or the destination node. For in-cluster traffic, usually both source and destination nodes report flows, resulting in duplicated data. Cluster ingress traffic is only reported by destination nodes, and cluster egress by source nodes.",
   "Reporter node": "Reporter node",
-  "Only available using \"Flow\" log type. This option will be ignored for \"Conversation\".": "Only available using \"Flow\" log type. This option will be ignored for \"Conversation\".",
+  "Only available in Table view.": "Only available in Table view.",
   "Whether each query result has to match all the filters or just any of them": "Whether each query result has to match all the filters or just any of them",
   "Match filters": "Match filters",
   "Top items for internal backend queries.": "Top items for internal backend queries.",

--- a/web/src/components/dropdowns/query-options-dropdown.tsx
+++ b/web/src/components/dropdowns/query-options-dropdown.tsx
@@ -150,17 +150,13 @@ export const QueryOptionsPanel: React.FC<QueryOptionsDropdownProps> = ({
           </div>
         </Tooltip>
         {reporterOptions.map(opt => {
-          const disabled = recordType === 'allConnections' || (!allowReporterBoth && opt.value === 'both');
+          const disabled = !allowReporterBoth && opt.value === 'both';
           return (
             <div key={`reporter-${opt.value}`}>
               <label className="pf-c-select__menu-item">
                 <Tooltip
                   trigger={disabled ? 'mouseenter focus' : ''}
-                  content={
-                    disabled
-                      ? t('Only available using "Flow" log type. This option will be ignored for "Conversation".')
-                      : undefined
-                  }
+                  content={disabled ? t('Only available in Table view.') : undefined}
                 >
                   <Radio
                     isChecked={opt.value === reporter}

--- a/web/src/components/netflow-record/record-panel.tsx
+++ b/web/src/components/netflow-record/record-panel.tsx
@@ -226,9 +226,8 @@ export const RecordPanel: React.FC<RecordDrawerProps> = ({
   }, [record.labels._RecordType, t]);
 
   const getSortedJSON = React.useCallback(() => {
-    const allKeys = new Set<string>();
-    JSON.stringify(record, (key, value) => (allKeys.add(key), value));
-    return JSON.stringify(record, Array.from(allKeys).sort(), 2);
+    const flat = { ...record.fields, ...record.labels };
+    return JSON.stringify(flat, Object.keys(flat).sort(), 2);
   }, [record]);
 
   const groups = getColumnGroups(

--- a/web/src/components/netflow-record/record-panel.tsx
+++ b/web/src/components/netflow-record/record-panel.tsx
@@ -225,6 +225,12 @@ export const RecordPanel: React.FC<RecordDrawerProps> = ({
     }
   }, [record.labels._RecordType, t]);
 
+  const getSortedJSON = React.useCallback(() => {
+    const allKeys = new Set<string>();
+    JSON.stringify(record, (key, value) => (allKeys.add(key), value));
+    return JSON.stringify(record, Array.from(allKeys).sort(), 2);
+  }, [record]);
+
   const groups = getColumnGroups(
     columns.filter(
       c =>
@@ -331,7 +337,7 @@ export const RecordPanel: React.FC<RecordDrawerProps> = ({
                 clickTip={t('Copied')}
                 variant={ClipboardCopyVariant.expansion}
               >
-                {JSON.stringify(record, null, 2)}
+                {getSortedJSON()}
               </ClipboardCopy>
             </TextContent>
           </Tab>

--- a/web/src/components/netflow-traffic.tsx
+++ b/web/src/components/netflow-traffic.tsx
@@ -319,7 +319,7 @@ export const NetflowTraffic: React.FC<{
       filters: groupedFilters,
       limit: LIMIT_VALUES.includes(limit) ? limit : LIMIT_VALUES[0],
       recordType: recordType,
-      reporter: recordType === 'flowLog' ? reporter : 'both'
+      reporter: reporter
     };
     if (range) {
       if (typeof range === 'number') {

--- a/web/src/utils/columns.ts
+++ b/web/src/utils/columns.ts
@@ -780,7 +780,9 @@ export const getDefaultColumns = (t: TFunction, withCommonFields = true, withCon
       fieldName: 'TimeFlowStartMs',
       isSelected: false,
       value: f => f.fields.TimeFlowStartMs,
-      sort: (a, b, col) => compareNumbers(col.value(a) as number, col.value(b) as number),
+      sort: (a, b, col) =>
+        compareNumbers(col.value(a) as number, col.value(b) as number) ||
+        compareStrings(b.labels._RecordType!, a.labels._RecordType!),
       width: 15
     },
     {
@@ -793,7 +795,9 @@ export const getDefaultColumns = (t: TFunction, withCommonFields = true, withCon
       fieldName: 'TimeFlowEndMs',
       isSelected: true,
       value: f => f.fields.TimeFlowEndMs,
-      sort: (a, b, col) => compareNumbers(col.value(a) as number, col.value(b) as number),
+      sort: (a, b, col) =>
+        compareNumbers(col.value(a) as number, col.value(b) as number) ||
+        compareStrings(b.labels._RecordType!, a.labels._RecordType!),
       width: 15
     }
   ];


### PR DESCRIPTION
This PR adds direction fields to conversation tracking

Also, it adds JSON fields sorting to be able to easy compare 2 items

Related PRs:
- https://github.com/netobserv/network-observability-operator/pull/313
- https://github.com/netobserv/flowlogs-pipeline/pull/430