### PR TITLE
remove tab trailing semicolon

### DIFF
--- a/web/src/components/netflow-tab.tsx
+++ b/web/src/components/netflow-tab.tsx
@@ -105,14 +105,13 @@ export const NetflowTab: React.FC<PageComponentProps> = ({ obj }) => {
             </Title>
             <EmptyStateBody>{obj?.kind}</EmptyStateBody>
           </EmptyState>
-          );
         </PageSection>
       );
   }
 
   return (
     <NetflowTrafficParent>
-      <NetflowTraffic forcedFilters={forcedFilters} isTab />;
+      <NetflowTraffic forcedFilters={forcedFilters} isTab />
     </NetflowTrafficParent>
   );
 };

--- a/web/src/components/netflow-traffic.css
+++ b/web/src/components/netflow-traffic.css
@@ -65,11 +65,6 @@ span.pf-c-button__icon.pf-m-start {
     padding: 0;
 }
 
-/* set max height to avoid huge table load if tab force scroll */
-#pageSection.tab {
-    max-height: 75vh;
-}
-
 #filter-toolbar {
     padding: 0 1.5rem 0 1.5rem;
 }


### PR DESCRIPTION
@andrew-ronaldson found a trailing semicolon in tab view (thanks for that !!)
![image](https://user-images.githubusercontent.com/91894519/229540674-e33884c2-2e44-46fa-ad50-c295db83fa72.png)

This PR removes it and fix tab height