### PR TITLE
NETOBSERV-972 check if cluster admin via namespaces

### DIFF
--- a/cmd/plugin-backend.go
+++ b/cmd/plugin-backend.go
@@ -93,12 +93,9 @@ func main() {
 		if *lokiForwardUserToken {
 			// FORWARD lokiAuth mode
 			checkType = auth.CheckAuthenticated
-		} else if *lokiTokenPath != "" {
-			// HOST lokiAuth mode
-			checkType = auth.CheckAdmin
 		} else {
-			// DISABLED lokiAuth mode
-			checkType = auth.CheckAuthenticated
+			// HOST or DISABLED lokiAuth mode
+			checkType = auth.CheckAdmin
 		}
 		log.Info(fmt.Sprintf("auth-check 'auto' resolved to '%s'", checkType))
 	} else {


### PR DESCRIPTION
Follow-up on #320, which relaxed the permission checks performed when lokiAuth is DISABLED: after discussion, we roll back to a more strict approach; however to mitigate the limitation of TokenReview (it doesn't provide a reliable way to check for cluster admins right), we verify that the user can list namespaces, assuming this is a cluster admin capability.