### PR TITLE
Update workflow, setup workflow-test

### DIFF
--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -35,10 +35,10 @@ jobs:
         run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       - name: build and push manifest with images
         run: |
-          MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" OCI_BIN=docker IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.WF_VERSION }} make images
-          MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" OCI_BIN=docker IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.short_sha }} OCI_BUILD_OPTS="--label quay.expires-after=2w" make images
+          MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.WF_VERSION }} make images
+          MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.short_sha }} OCI_BUILD_OPTS="--label quay.expires-after=2w" make images
           if [[ "main" == "$WF_VERSION" ]]; then
-            MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" OCI_BIN=docker IMAGE_ORG=${{ env.WF_ORG }} VERSION=latest make images
+            MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} VERSION=latest make images
           fi
 
   codecov-back:

--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -1,14 +1,13 @@
 name: Build and push to quay.io
 on:
   push:
-    branches: [ main ]
+    branches: [ main, workflow-test ]
 
 env:
-  REGISTRY_USER: netobserv+github_ci
-  REGISTRY: quay.io/netobserv
-  IMAGE: network-observability-console-plugin
-  ORG: netobserv
-  VERSION: main
+  WF_REGISTRY_USER: netobserv+github_ci
+  WF_ORG: netobserv
+  WF_MULTIARCH_TARGETS: amd64 arm64 ppc64le
+  WF_VERSION: ${{ github.ref_name }}
 
 jobs:
   push-image:
@@ -29,13 +28,18 @@ jobs:
       - name: docker login to quay.io
         uses: docker/login-action@v2
         with:
-          username: ${{ env.REGISTRY_USER }}
+          username: ${{ env.WF_REGISTRY_USER }}
           password: ${{ secrets.QUAY_SECRET }}
           registry: quay.io
+      - name: get short sha
+        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       - name: build and push manifest with images
-        run: IMAGE_ORG=${{ env.ORG }} VERSION=${{ env.VERSION }} make ci
-      - name: print image url
-        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+        run: |
+          MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" OCI_BIN=docker IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.WF_VERSION }} make images
+          MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" OCI_BIN=docker IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.short_sha }} OCI_BUILD_OPTS="--label quay.expires-after=2w" make images
+          if [[ "main" == "$WF_VERSION" ]]; then
+            MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" OCI_BIN=docker IMAGE_ORG=${{ env.WF_ORG }} VERSION=latest make images
+          fi
 
   codecov-back:
     name: Codecov backend upload

--- a/.github/workflows/push_image_pr.yml
+++ b/.github/workflows/push_image_pr.yml
@@ -4,10 +4,10 @@ on:
     types: [labeled]
 
 env:
-  REGISTRY_USER: netobserv+github_ci
-  REGISTRY: quay.io/netobserv
-  IMAGE: network-observability-console-plugin
-  ORG: netobserv
+  WF_REGISTRY_USER: netobserv+github_ci
+  WF_REGISTRY: quay.io/netobserv
+  WF_IMAGE: network-observability-console-plugin
+  WF_ORG: netobserv
 
 jobs:
   push-pr-image:
@@ -31,15 +31,13 @@ jobs:
       - name: docker login to quay.io
         uses: docker/login-action@v2
         with:
-          username: ${{ env.REGISTRY_USER }}
+          username: ${{ env.WF_REGISTRY_USER }}
           password: ${{ secrets.QUAY_SECRET }}
           registry: quay.io
       - name: get short sha
         run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-      - name: build and push images
-        run: IMAGE_ORG=${{ env.ORG }} IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.short_sha }} make images
-      - name: build and push manifest
-        run: IMAGE_ORG=${{ env.ORG }} IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.short_sha }} make ci-manifest
+      - name: build and push manifest with images
+        run: OCI_BUILD_OPTS="--label quay.expires-after=2w" OCI_BIN=docker IMAGE_ORG=${{ env.WF_ORG }} IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.short_sha }} make images
       - uses: actions/github-script@v6
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -48,5 +46,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'New image: ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ env.short_sha }}. It will expire after two weeks.'
+              body: 'New image: ${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.short_sha }}. It will expire after two weeks.'
             })

--- a/.github/workflows/push_image_pr.yml
+++ b/.github/workflows/push_image_pr.yml
@@ -37,7 +37,7 @@ jobs:
       - name: get short sha
         run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       - name: build and push manifest with images
-        run: OCI_BUILD_OPTS="--label quay.expires-after=2w" OCI_BIN=docker IMAGE_ORG=${{ env.WF_ORG }} IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.short_sha }} make images
+        run: OCI_BUILD_OPTS="--label quay.expires-after=2w" IMAGE_ORG=${{ env.WF_ORG }} IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.short_sha }} make images
       - uses: actions/github-script@v6
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,4 +42,4 @@ jobs:
           password: ${{ secrets.QUAY_SECRET }}
           registry: quay.io
       - name: build and push manifest with images
-        run: MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" OCI_BIN=docker IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.tag }} make images
+        run: MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.tag }} make images

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,9 @@ on:
     tags: [v*]
 
 env:
-  REGISTRY_USER: netobserv+github_ci
-  REGISTRY_PASSWORD: ${{ secrets.QUAY_SECRET }}
-  REGISTRY: quay.io/netobserv
-  IMAGE: network-observability-console-plugin
+  WF_REGISTRY_USER: netobserv+github_ci
+  WF_ORG: netobserv
+  WF_MULTIARCH_TARGETS: amd64 arm64 ppc64le
 
 jobs:
   push-image:
@@ -39,10 +38,8 @@ jobs:
       - name: docker login to quay.io
         uses: docker/login-action@v2
         with:
-          username: ${{ env.REGISTRY_USER }}
-          password: ${{ env.REGISTRY_PASSWORD }}
+          username: ${{ env.WF_REGISTRY_USER }}
+          password: ${{ secrets.QUAY_SECRET }}
           registry: quay.io
-      - name: build and push images
-        run: OCI_BIN=docker IMAGE="quay.io/netobserv/${{ env.IMAGE }}:${{ env.tag }}" make images
-      - name: print image url
-        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+      - name: build and push manifest with images
+        run: MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" OCI_BIN=docker IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.tag }} make images

--- a/.mk/shortcuts.mk
+++ b/.mk/shortcuts.mk
@@ -42,15 +42,3 @@ push-manifest: manifest-push ## Push MULTIARCH_TARGETS manifest
 
 .PHONY: images
 images: image-build image-push manifest-build manifest-push ## Build and push MULTIARCH_TARGETS images and related manifest
-
-.PHONY: build-ci-manifest
-build-ci-manifest: ci-manifest-build ## Build CI manifest
-
-.PHONY: push-ci-manifest
-push-ci-manifest: ci-manifest-push ## Push CI manifest
-
-.PHONY: ci-manifest
-ci-manifest: ci-manifest-build ci-manifest-push ## Build and push CI manifest
-
-.PHONY: ci
-ci: images ci-manifest ## Build and push CI images and manifest

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ endif
 
 # Go architecture and targets images to build
 GOARCH ?= amd64
-MULTIARCH_TARGETS := amd64 arm64 ppc64le
+MULTIARCH_TARGETS ?= amd64
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 SHELL := /usr/bin/env bash
@@ -31,7 +31,7 @@ IMAGE_TAG_BASE ?= quay.io/${IMAGE_ORG}/network-observability-console-plugin
 
 # Image URL to use all building/pushing image targets
 IMAGE ?= ${IMAGE_TAG_BASE}:${VERSION}
-IMAGE_SHA = $(IMAGE_TAG_BASE):$(BUILD_SHA)
+OCI_BUILD_OPTS ?=
 
 # Image building tool (docker / podman)
 OCI_BIN_PATH = $(shell which podman  || which docker)
@@ -48,7 +48,7 @@ BUILD_FLAGS ?= -ldflags "-X 'main.buildVersion=${BUILD_VERSION}' -X 'main.buildD
 # build a single arch target provided as argument
 define build_target
 	echo 'building image for arch $(1)'; \
-	DOCKER_BUILDKIT=1 $(OCI_BIN) buildx build --load --build-arg TARGETPLATFORM=linux/$(1) --build-arg TARGETARCH=$(1) --build-arg BUILDPLATFORM=linux/amd64 -t ${IMAGE}-$(1) -f Dockerfile .;
+	DOCKER_BUILDKIT=1 $(OCI_BIN) buildx build --load --build-arg TARGETPLATFORM=linux/$(1) --build-arg TARGETARCH=$(1) --build-arg BUILDPLATFORM=linux/amd64 ${OCI_BUILD_OPTS} -t ${IMAGE}-$(1) -f Dockerfile .;
 endef
 
 # push a single arch target image
@@ -58,8 +58,8 @@ define push_target
 endef
 
 # manifest create a single arch target provided as argument
-define manifest_create_target
-	echo 'manifest create for arch $(1)'; \
+define manifest_add_target
+	echo 'manifest add target $(1)'; \
 	DOCKER_BUILDKIT=1 $(OCI_BIN) manifest add ${IMAGE} ${IMAGE}-$(target);
 endef
 
@@ -210,7 +210,7 @@ ifeq (${OCI_BIN}, docker)
 else
 	trap 'exit' INT; \
 	DOCKER_BUILDKIT=1 $(OCI_BIN) manifest create ${IMAGE} ||:
-	$(foreach target,$(MULTIARCH_TARGETS),$(call manifest_create_target,$(target)))
+	$(foreach target,$(MULTIARCH_TARGETS),$(call manifest_add_target,$(target)))
 endif
 
 .PHONY: manifest-push
@@ -220,23 +220,6 @@ ifeq (${OCI_BIN}, docker)
 	DOCKER_BUILDKIT=1 $(OCI_BIN) manifest push ${IMAGE};
 else
 	DOCKER_BUILDKIT=1 $(OCI_BIN) manifest push ${IMAGE} docker://${IMAGE};
-endif
-
-.PHONY: ci-manifest-build
-ci-manifest-build: manifest-build ## Build CI manifest
-	$(OCI_BIN) build --build-arg BASE_IMAGE=$(IMAGE) -t $(IMAGE_SHA) -f shortlived.Dockerfile .
-ifeq ($(VERSION), main)
-# Also tag "latest" only for branch "main"
-	$(OCI_BIN) build -t $(IMAGE) -t $(IMAGE_TAG_BASE):latest .
-endif
-
-.PHONY: ci-manifest-push
-ci-manifest-push: ## Push CI manifest
-	$(OCI_BIN) push $(IMAGE_SHA)
-ifeq ($(VERSION), main)
-# Also tag "latest" only for branch "main"
-	$(OCI_BIN) push $(IMAGE)
-	$(OCI_BIN) push $(IMAGE_TAG_BASE):latest
 endif
 
 include .mk/shortcuts.mk

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,8 @@ IMAGE_TAG_BASE ?= quay.io/${IMAGE_ORG}/network-observability-console-plugin
 IMAGE ?= ${IMAGE_TAG_BASE}:${VERSION}
 OCI_BUILD_OPTS ?=
 
-# Image building tool (docker / podman)
-OCI_BIN_PATH = $(shell which podman  || which docker)
+# Image building tool (docker / podman) - docker is preferred in CI
+OCI_BIN_PATH = $(shell which docker || which podman)
 OCI_BIN ?= $(shell basename ${OCI_BIN_PATH})
 
 GOLANGCI_LINT_VERSION = v1.50.1

--- a/shortlived.Dockerfile
+++ b/shortlived.Dockerfile
@@ -1,3 +1,0 @@
-ARG BASE_IMAGE=quay.io/netobserv/network-observability-console-plugin:main
-FROM $BASE_IMAGE
-LABEL quay.expires-after=2w


### PR DESCRIPTION
- Can trigger workflow from branch workflow-test
- Make default multi-arch to single amd64
- Remove specific ci targets; make shortlive builds more straightforward
- Disambiguate makefile env vs workflow env
- Remove unused targets
- Remove now unused shortlived dockerfile
- Use docker