### PR TITLE
NETOBSERV-997 Cypress test console errors

### DIFF
--- a/web/src/components/netflow-traffic.tsx
+++ b/web/src/components/netflow-traffic.tsx
@@ -156,7 +156,10 @@ export const NetflowTraffic: React.FC<{
   const isDarkTheme = useTheme();
 
   const [queryParams, setQueryParams] = useLocalStorage<string>(LOCAL_STORAGE_QUERY_PARAMS_KEY);
-  const [disabledFilters, setDisabledFilters] = useLocalStorage<DisabledFilters>(LOCAL_STORAGE_DISABLED_FILTERS_KEY);
+  const [disabledFilters, setDisabledFilters] = useLocalStorage<DisabledFilters>(
+    LOCAL_STORAGE_DISABLED_FILTERS_KEY,
+    {}
+  );
   // set url params from local storage saved items at startup if empty
   if (hasEmptyParams() && queryParams) {
     setURLParams(queryParams);


### PR DESCRIPTION
Since `disabledFilters` are loaded from local storage, it can be undefined at first start.

This PR simply ensure the object is initialized and avoid the error.