### PR TITLE
NETOBSERV-1200: Show "< 1ms" for 0 latency instead of n/a

### DIFF
--- a/web/src/components/__tests-data__/flows.ts
+++ b/web/src/components/__tests-data__/flows.ts
@@ -85,7 +85,9 @@ export const FlowsSample: Record[] = [
       DstMac: '0a:58:0a:80:00:17',
       TimeFlowEndMs: 1639058288000,
       TimeFlowStartMs: 1639058286000,
-      TimeReceived: 1639058291
+      TimeReceived: 1639058291,
+      DnsId: 123,
+      DnsLatencyMs: 0
     }
   }
 ];

--- a/web/src/components/netflow-record/__tests__/record-field.spec.tsx
+++ b/web/src/components/netflow-record/__tests__/record-field.spec.tsx
@@ -5,6 +5,7 @@ import { DefaultColumns } from '../../__tests-data__/columns';
 import { FlowsSample } from '../../__tests-data__/flows';
 import RecordField, { RecordFieldFilter } from '../record-field';
 import { Size } from '../../dropdowns/table-display-dropdown';
+import { ColumnsId, getExtraColumns } from '../../../utils/columns';
 
 describe('<RecordField />', () => {
   const filterMock: RecordFieldFilter = {
@@ -33,5 +34,12 @@ describe('<RecordField />', () => {
     expect(button).toHaveLength(1);
     button.simulate('click');
     expect(filterMock.onClick).toHaveBeenCalledTimes(1);
+  });
+  it('should display <1ms DNS latency', async () => {
+    const dnsColumn = getExtraColumns((k: string) => k).find(c => c.id === ColumnsId.dnslatency)!;
+    const wrapper = shallow(<RecordField flow={FlowsSample[2]} column={dnsColumn} {...mocks} />);
+    expect(wrapper.find(RecordField)).toBeTruthy();
+    expect(wrapper.find('.record-field-content')).toHaveLength(1);
+    expect(wrapper.find('.record-field-content span').text()).toBe('< 1ms');
   });
 });

--- a/web/src/utils/columns.ts
+++ b/web/src/utils/columns.ts
@@ -790,7 +790,7 @@ export const getExtraColumns = (t: TFunction): Column[] => {
       fieldName: 'DnsId',
       quickFilter: 'dns_id',
       isSelected: false,
-      value: f => f.fields.DnsId || Number.NaN,
+      value: f => f.fields.DnsId === undefined ? Number.NaN : f.fields.DnsId,
       sort: (a, b, col) => compareNumbers(col.value(a) as number, col.value(b) as number),
       width: 5
     },
@@ -799,7 +799,7 @@ export const getExtraColumns = (t: TFunction): Column[] => {
       name: t('DNS Latency'),
       tooltip: t('Time elapsed between DNS request and response.'),
       isSelected: false,
-      value: f => f.fields.DnsLatencyMs || Number.NaN,
+      value: f => f.fields.DnsLatencyMs === undefined ? Number.NaN : f.fields.DnsLatencyMs,
       sort: (a, b, col) => compareNumbers(col.value(a) as number, col.value(b) as number),
       width: 5
     },

--- a/web/src/utils/columns.ts
+++ b/web/src/utils/columns.ts
@@ -790,7 +790,7 @@ export const getExtraColumns = (t: TFunction): Column[] => {
       fieldName: 'DnsId',
       quickFilter: 'dns_id',
       isSelected: false,
-      value: f => f.fields.DnsId === undefined ? Number.NaN : f.fields.DnsId,
+      value: f => (f.fields.DnsId === undefined ? Number.NaN : f.fields.DnsId),
       sort: (a, b, col) => compareNumbers(col.value(a) as number, col.value(b) as number),
       width: 5
     },
@@ -799,7 +799,7 @@ export const getExtraColumns = (t: TFunction): Column[] => {
       name: t('DNS Latency'),
       tooltip: t('Time elapsed between DNS request and response.'),
       isSelected: false,
-      value: f => f.fields.DnsLatencyMs === undefined ? Number.NaN : f.fields.DnsLatencyMs,
+      value: f => (f.fields.DnsLatencyMs === undefined ? Number.NaN : f.fields.DnsLatencyMs),
       sort: (a, b, col) => compareNumbers(col.value(a) as number, col.value(b) as number),
       width: 5
     },


### PR DESCRIPTION
![image](https://github.com/netobserv/network-observability-console-plugin/assets/2153442/773fba0d-f047-4133-bd42-bae52243ceb1)
