### PR TITLE
NETOBSERV-1216 pktDrop cause filter

### DIFF
--- a/web/src/components/netflow-record/__tests__/record-panel.spec.tsx
+++ b/web/src/components/netflow-record/__tests__/record-panel.spec.tsx
@@ -14,6 +14,7 @@ describe('<RecordPanel />', () => {
     range: 300,
     type: 'flowLog',
     canSwitchTypes: false,
+    allowPktDrops: false,
     setFilters: jest.fn(),
     setRange: jest.fn(),
     setType: jest.fn(),

--- a/web/src/components/netflow-record/record-panel.tsx
+++ b/web/src/components/netflow-record/record-panel.tsx
@@ -41,6 +41,7 @@ export type RecordDrawerProps = {
   range: number | TimeRange;
   type: RecordType;
   canSwitchTypes: boolean;
+  allowPktDrops: boolean;
   isDark?: boolean;
   setFilters: (v: Filter[]) => void;
   setRange: (r: number | TimeRange) => void;
@@ -57,6 +58,7 @@ export const RecordPanel: React.FC<RecordDrawerProps> = ({
   range,
   type,
   canSwitchTypes,
+  allowPktDrops,
   isDark,
   setFilters,
   setRange,
@@ -85,6 +87,8 @@ export const RecordPanel: React.FC<RecordDrawerProps> = ({
           return getTimeRangeFilter(col, value);
         case ColumnsId.recordtype:
           return getRecordTypeFilter();
+        case ColumnsId.packets:
+          return getPktDropFilter(col, record.fields.PktDropLatestDropCause);
         default:
           return getGenericFilter(col, value);
       }
@@ -158,6 +162,16 @@ export const RecordPanel: React.FC<RecordDrawerProps> = ({
       };
     },
     [t, filters, setFilters]
+  );
+
+  const getPktDropFilter = React.useCallback(
+    (col: Column, cause?: string): RecordFieldFilter | undefined => {
+      if (!allowPktDrops || !cause) {
+        return undefined;
+      }
+      return getGenericFilter(col, cause);
+    },
+    [allowPktDrops, getGenericFilter]
   );
 
   const getGroup = React.useCallback(

--- a/web/src/components/netflow-traffic.tsx
+++ b/web/src/components/netflow-traffic.tsx
@@ -996,6 +996,7 @@ export const NetflowTraffic: React.FC<{
           type={recordType}
           isDark={isDarkTheme}
           canSwitchTypes={isFlow() && isConnectionTracking()}
+          allowPktDrops={isPktDrop()}
           setFilters={setFiltersList}
           setRange={setRange}
           setType={setRecordType}

--- a/web/src/model/filters.ts
+++ b/web/src/model/filters.ts
@@ -160,7 +160,11 @@ export const removeFromFilters = (activeFilters: Filter[], search: FilterKey): F
 };
 
 export const filterKeyEqual = (f1: FilterKey, f2: FilterKey): boolean => {
-  return f1.def.id === f2.def.id && f1.not == f2.not && f1.moreThan == f2.moreThan;
+  return (
+    f1.def.id === f2.def.id &&
+    (f1.not === true) === (f2.not === true) &&
+    (f1.moreThan === true) === (f2.moreThan === true)
+  );
 };
 
 type ComparableFilter = { key: string; values: string[] };

--- a/web/src/utils/columns.ts
+++ b/web/src/utils/columns.ts
@@ -768,6 +768,7 @@ export const getExtraColumns = (t: TFunction): Column[] => {
       name: t('Packets'),
       tooltip: t('The total aggregated number of packets.'),
       fieldName: 'Packets',
+      quickFilter: 'pkt_drop_cause',
       isSelected: true,
       value: f => (f.fields.PktDropPackets ? [f.fields.Packets || 0, f.fields.PktDropPackets] : f.fields.Packets || 0),
       sort: (a, b, col) => compareNumbers(col.value(a) as number, col.value(b) as number),


### PR DESCRIPTION
Really simple implementation for pktDrop cause quick filter:

![image](https://github.com/netobserv/network-observability-console-plugin/assets/91894519/83290e14-a5e3-458e-98e4-e343f5f6ead4)
![image](https://github.com/netobserv/network-observability-console-plugin/assets/91894519/59ea0c2c-2d95-4765-93c2-9150ad68d0d7)

The button is hidden if pktDrop feature is disabled or if flow doesn't have drop cause:
![image](https://github.com/netobserv/network-observability-console-plugin/assets/91894519/d13ecd78-0cdc-4f90-8154-9c36c6e14e37)
