### PR TITLE
NETOBSERV-1265 Overview / Topology fully drop metrics doesn't show

### DIFF
--- a/web/src/components/netflow-overview/netflow-overview.tsx
+++ b/web/src/components/netflow-overview/netflow-overview.tsx
@@ -101,7 +101,12 @@ export const NetflowOverview: React.FC<NetflowOverviewProps> = ({
 
   if (error) {
     return <LokiError title={t('Unable to get overview')} error={error} />;
-  } else if (_.isEmpty(metrics) || !totalMetric) {
+  } else if (
+    _.isEmpty(metrics) &&
+    _.isEmpty(droppedMetrics) &&
+    _.isEmpty(dnsLatencyMetrics) &&
+    _.isEmpty(dnsRCodeMetrics)
+  ) {
     //TODO: manage each metrics loading state separately
     if (loading) {
       return (
@@ -151,7 +156,7 @@ export const NetflowOverview: React.FC<NetflowOverviewProps> = ({
       ?.sort((a, b) => getStat(b.stats, 'sum') - getStat(a.stats, 'sum'))
       .map(m => toNamedMetric(t, m, truncateLength, true, true)) || [];
 
-  const namedTotalMetric = toNamedMetric(t, totalMetric, truncateLength, false, false);
+  const namedTotalMetric = totalMetric ? toNamedMetric(t, totalMetric, truncateLength, false, false) : undefined;
   const namedTotalDroppedMetric = totalDroppedMetric
     ? toNamedMetric(t, totalDroppedMetric, truncateLength, false, false)
     : undefined;
@@ -193,7 +198,7 @@ export const NetflowOverview: React.FC<NetflowOverviewProps> = ({
         };
       case 'total_line':
         return {
-          element: (
+          element: namedTotalMetric ? (
             <MetricsContent
               id={id}
               title={title}
@@ -206,6 +211,8 @@ export const NetflowOverview: React.FC<NetflowOverviewProps> = ({
               smallerTexts={smallerTexts}
               tooltipsTruncate={false}
             />
+          ) : (
+            emptyGraph()
           ),
           kebab: <PanelKebab id={id} />,
           doubleWidth: false
@@ -217,7 +224,7 @@ export const NetflowOverview: React.FC<NetflowOverviewProps> = ({
           showOutOfScope: false
         };
         return {
-          element: (
+          element: namedTotalMetric ? (
             <MetricsTotalContent
               id={id}
               title={title}
@@ -230,6 +237,8 @@ export const NetflowOverview: React.FC<NetflowOverviewProps> = ({
               showOutOfScope={options.showOutOfScope!}
               smallerTexts={smallerTexts}
             />
+          ) : (
+            emptyGraph()
           ),
           kebab: (
             <PanelKebab id={id} options={options} setOptions={opts => setKebabOptions(id, opts)} isDark={isDark} />
@@ -263,7 +272,7 @@ export const NetflowOverview: React.FC<NetflowOverviewProps> = ({
           showOutOfScope: false
         };
         return {
-          element: (
+          element: namedTotalMetric ? (
             <StatDonut
               id={id}
               limit={limit}
@@ -276,6 +285,8 @@ export const NetflowOverview: React.FC<NetflowOverviewProps> = ({
               showOutOfScope={options.showOutOfScope!}
               smallerTexts={smallerTexts}
             />
+          ) : (
+            emptyGraph()
           ),
           kebab: (
             <PanelKebab id={id} options={options} setOptions={opts => setKebabOptions(id, opts)} isDark={isDark} />
@@ -290,7 +301,7 @@ export const NetflowOverview: React.FC<NetflowOverviewProps> = ({
           showOutOfScope: false
         };
         return {
-          element: (
+          element: namedTotalMetric ? (
             <StatDonut
               id={id}
               limit={limit}
@@ -303,6 +314,8 @@ export const NetflowOverview: React.FC<NetflowOverviewProps> = ({
               showOutOfScope={options.showOutOfScope!}
               smallerTexts={smallerTexts}
             />
+          ) : (
+            emptyGraph()
           ),
           kebab: (
             <PanelKebab id={id} options={options} setOptions={opts => setKebabOptions(id, opts)} isDark={isDark} />
@@ -405,25 +418,26 @@ export const NetflowOverview: React.FC<NetflowOverviewProps> = ({
           showOutOfScope: false,
           compareToDropped: namedTotalDroppedMetric ? false : undefined
         };
+        const totalMetric =
+          options.compareToDropped && namedTotalDroppedMetric ? namedTotalDroppedMetric : namedTotalMetric;
         return {
-          element: !_.isEmpty(topKDroppedMetrics) ? (
-            <MetricsTotalContent
-              id={id}
-              title={title}
-              metricType={metricType}
-              topKMetrics={topKDroppedMetrics}
-              totalMetric={
-                options.compareToDropped && namedTotalDroppedMetric ? namedTotalDroppedMetric : namedTotalMetric
-              }
-              limit={limit}
-              showTotal={options.showTotal!}
-              showInternal={options.showInternal!}
-              showOutOfScope={options.showOutOfScope!}
-              smallerTexts={smallerTexts}
-            />
-          ) : (
-            emptyGraph()
-          ),
+          element:
+            !_.isEmpty(topKDroppedMetrics) && totalMetric ? (
+              <MetricsTotalContent
+                id={id}
+                title={title}
+                metricType={metricType}
+                topKMetrics={topKDroppedMetrics}
+                totalMetric={totalMetric}
+                limit={limit}
+                showTotal={options.showTotal!}
+                showInternal={options.showInternal!}
+                showOutOfScope={options.showOutOfScope!}
+                smallerTexts={smallerTexts}
+              />
+            ) : (
+              emptyGraph()
+            ),
           kebab: <PanelKebab id={id} options={options} setOptions={opts => setKebabOptions(id, opts)} />,
           doubleWidth: true
         };

--- a/web/src/components/netflow-topology/netflow-topology.tsx
+++ b/web/src/components/netflow-topology/netflow-topology.tsx
@@ -59,6 +59,9 @@ export const NetflowTopology: React.FC<{
   const { t } = useTranslation('plugin__netobserv-plugin');
   const [controller, setController] = React.useState<Visualization>();
 
+  //show fully dropped metrics if no metrics available
+  const displayedMetrics = _.isEmpty(metrics) ? droppedMetrics : metrics;
+
   //create controller on startup and register factories
   React.useEffect(() => {
     const c = new Visualization();
@@ -85,7 +88,7 @@ export const NetflowTopology: React.FC<{
         metricType={metricType}
         metricScope={metricScope}
         setMetricScope={setMetricScope}
-        metrics={metrics}
+        metrics={displayedMetrics}
         options={options}
         setOptions={setOptions}
         filters={filters.list}
@@ -107,7 +110,7 @@ export const NetflowTopology: React.FC<{
           metricType={metricType}
           metricScope={metricScope}
           setMetricScope={setMetricScope}
-          metrics={metrics}
+          metrics={displayedMetrics}
           droppedMetrics={droppedMetrics}
           options={options}
           setOptions={setOptions}


### PR DESCRIPTION
- Overview will show "No results found" on the entire page only if every metrics buckets are empty, else it will show per graph results.
- Topology will fallback on dropped metrics if metrics are empty, only for that particular case. Everything then appears red.

![image](https://github.com/netobserv/network-observability-console-plugin/assets/91894519/96ba8d25-4789-4daf-bf1c-6a6317f6dff8)
![image](https://github.com/netobserv/network-observability-console-plugin/assets/91894519/591c7566-54fb-4024-9ffe-7454989198ee)
![image](https://github.com/netobserv/network-observability-console-plugin/assets/91894519/722094ed-5c13-4c8b-8ad8-a5bd449a473f)
![image](https://github.com/netobserv/network-observability-console-plugin/assets/91894519/9877e2a9-4d2b-42ed-b6b4-5d7606f93c16)
![image](https://github.com/netobserv/network-observability-console-plugin/assets/91894519/bcbe4dc9-e2dc-4e1d-94f6-9c07c4149230)
