### PR TITLE
NETOBSERV-1313 enable feature gated panels by default

### DIFF
--- a/web/src/utils/overview-panels.ts
+++ b/web/src/utils/overview-panels.ts
@@ -48,11 +48,11 @@ export const getDefaultOverviewPanels = (): OverviewPanel[] => {
     { id: 'top_dropped_state_donut', isSelected: true },
     { id: 'top_dropped_cause_donut', isSelected: true },
     { id: 'top_dropped_bar_total', isSelected: true },
-    { id: 'top_avg_dns_latency_donut', isSelected: false },
-    { id: 'top_dns_rcode_donut', isSelected: false },
-    { id: 'top_dns_rcode_bar_total', isSelected: false },
-    { id: 'top_avg_rtt_donut', isSelected: false },
-    { id: 'top_avg_rtt_line', isSelected: false }
+    { id: 'top_avg_dns_latency_donut', isSelected: true },
+    { id: 'top_dns_rcode_donut', isSelected: true },
+    { id: 'top_dns_rcode_bar_total', isSelected: true },
+    { id: 'top_avg_rtt_donut', isSelected: true },
+    { id: 'top_avg_rtt_line', isSelected: true }
   ]);
   if (isAllowed(Feature.Overview)) {
     panels.unshift({ id: 'overview', isSelected: true });


### PR DESCRIPTION
## Description

Show DNS & RTT panels by default (when feature enabled)
Backport: https://github.com/netobserv/network-observability-console-plugin/pull/403

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
