### PR TITLE
NETOBSERV-1316 & NETOBSERV-1380 - Get dns noError codes to always show graphs

### DIFF
--- a/pkg/loki/flow_query.go
+++ b/pkg/loki/flow_query.go
@@ -274,12 +274,9 @@ func (q *FlowQueryBuilder) appendDNSFilter(sb *strings.Builder) {
 
 func (q *FlowQueryBuilder) appendDNSRCodeFilter(sb *strings.Builder) {
 	// ensure DnsFlagsResponseCode field is specified with valid error
-	// |~`"DnsFlagsResponseCode"`!~`"DnsFlagsResponseCode":"NoError"`
+	// |~`"DnsFlagsResponseCode"`
 	sb.WriteString("|~`")
 	sb.WriteString(`"DnsFlagsResponseCode"`)
-	sb.WriteString("`")
-	sb.WriteString("!~`")
-	sb.WriteString(`"DnsFlagsResponseCode":"NoError"`)
 	sb.WriteString("`")
 }
 

--- a/web/src/components/metrics/latency-donut.tsx
+++ b/web/src/components/metrics/latency-donut.tsx
@@ -41,6 +41,7 @@ export const LatencyDonut: React.FC<LatencyDonutProps> = ({
       name: (m as NamedMetric).fullName || (m as GenericMetric).name,
       value: getStat(m.stats, 'avg')
     }))
+    .filter(m => !othersName || m.name !== othersName)
     .sort((a, b) => b.value - a.value)
     .slice(0, limit);
 

--- a/web/src/components/metrics/single-metrics-total-content.tsx
+++ b/web/src/components/metrics/single-metrics-total-content.tsx
@@ -11,7 +11,6 @@ import {
   ChartThemeColor
 } from '@patternfly/react-charts';
 import { TextContent } from '@patternfly/react-core';
-import _ from 'lodash';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { GenericMetric, NamedMetric } from '../../api/loki';
@@ -56,22 +55,7 @@ export const SingleMetricsTotalContent: React.FC<SingleMetricsTotalContentProps>
 }) => {
   const { t } = useTranslation('plugin__netobserv-plugin');
 
-  let filtered = [...topKMetrics];
-  if (showOthers) {
-    const others = {
-      name: othersName || t('Others'),
-      values: _.cloneDeep(totalMetric.values),
-      aggregateBy: 'dnsRCode',
-      stats: totalMetric.stats
-    } as GenericMetric;
-    filtered.forEach(m => {
-      for (let i = 0; i < m.values.length; i++) {
-        others.values[i][1] -= m.values[i][1];
-      }
-    });
-    filtered.push(others);
-  }
-  filtered = filtered.slice(0, limit);
+  const filtered = topKMetrics.filter(m => showOthers || (othersName && m.name !== othersName)).slice(0, limit);
 
   const legendData: LegendDataItem[] = filtered.map((m, idx) => ({
     childName: `bar-${idx}`,

--- a/web/src/components/netflow-overview/netflow-overview.tsx
+++ b/web/src/components/netflow-overview/netflow-overview.tsx
@@ -553,7 +553,7 @@ export const NetflowOverview: React.FC<NetflowOverviewProps> = ({
       case 'top_dns_rcode_bar_total': {
         const options = kebabMap.get(id) || {
           showTotal: true,
-          showNoError: false
+          showNoError: true
         };
         return {
           element:

--- a/web/src/components/netflow-traffic.tsx
+++ b/web/src/components/netflow-traffic.tsx
@@ -365,9 +365,15 @@ export const NetflowTraffic: React.FC<{
     if (view === 'overview' && selectedViewId !== 'overview') {
       setLastLimit(limit);
       setLimit(lastTop);
+      if (!['bytes', 'packets'].includes(metricType)) {
+        setMetricType(defaultMetricType);
+      }
     } else if (view !== 'overview' && selectedViewId === 'overview') {
       setLastTop(limit);
       setLimit(lastLimit);
+      if (!['bytes', 'packets', 'dnsLatencies', 'flowRtt'].includes(metricType)) {
+        setMetricType(defaultMetricType);
+      }
     }
 
     if (view !== selectedViewId) {

--- a/web/src/components/query-summary/metrics-query-summary.tsx
+++ b/web/src/components/query-summary/metrics-query-summary.tsx
@@ -35,65 +35,75 @@ export const MetricsQuerySummaryContent: React.FC<{
     const avgSum = metrics.map(m => m.stats.avg).reduce((prev, cur) => prev + cur, 0);
     const absSum = metrics.map(m => m.stats.total).reduce((prev, cur) => prev + cur, 0);
 
-    if (metricType === 'bytes') {
-      const textAbs = appMetrics ? t('Filtered sum of top-k bytes / filtered total bytes') : t('Filtered sum of bytes');
-      const textRate = appMetrics ? t('Filtered top-k byte rate / filtered total byte rate') : t('Filtered byte rate');
-      const valAbs = appMetrics
-        ? valueFormat(absSum, 1, t('B')) + ' / ' + valueFormat(appMetrics.stats.total, 1, t('B'))
-        : valueFormat(absSum, 1, t('B'));
-      const valRate = appMetrics
-        ? valueFormat(avgSum, 2, t('Bps')) + ' / ' + valueFormat(appMetrics.stats.avg, 2, t('Bps'))
-        : valueFormat(avgSum, 2, t('Bps'));
-      return (
-        <>
+    switch (metricType) {
+      case 'bytes': {
+        const textAbs = appMetrics
+          ? t('Filtered sum of top-k bytes / filtered total bytes')
+          : t('Filtered sum of bytes');
+        const textRate = appMetrics
+          ? t('Filtered top-k byte rate / filtered total byte rate')
+          : t('Filtered byte rate');
+        const valAbs = appMetrics
+          ? valueFormat(absSum, 1, t('B')) + ' / ' + valueFormat(appMetrics.stats.total, 1, t('B'))
+          : valueFormat(absSum, 1, t('B'));
+        const valRate = appMetrics
+          ? valueFormat(avgSum, 2, t('Bps')) + ' / ' + valueFormat(appMetrics.stats.avg, 2, t('Bps'))
+          : valueFormat(avgSum, 2, t('Bps'));
+        return (
+          <>
+            <FlexItem>
+              <Tooltip content={<Text component={TextVariants.p}>{textAbs}</Text>}>
+                <Text id="bytesCount" component={TextVariants.p}>
+                  {valAbs}
+                </Text>
+              </Tooltip>
+            </FlexItem>
+            <FlexItem>
+              <Tooltip content={<Text component={TextVariants.p}>{textRate}</Text>}>
+                <Text id="bpsCount" component={TextVariants.p}>
+                  {valRate}
+                </Text>
+              </Tooltip>
+            </FlexItem>
+          </>
+        );
+      }
+      case 'packets': {
+        const textAbs = appMetrics
+          ? t('Filtered sum of top-k packets / filtered total packets')
+          : t('Filtered sum of packets');
+        const valAbs = (appMetrics ? `${absSum} / ${appMetrics.stats.total}` : String(absSum)) + ' ' + t('packets');
+        return (
           <FlexItem>
             <Tooltip content={<Text component={TextVariants.p}>{textAbs}</Text>}>
-              <Text id="bytesCount" component={TextVariants.p}>
+              <Text id="packetsCount" component={TextVariants.p}>
                 {valAbs}
               </Text>
             </Tooltip>
           </FlexItem>
+        );
+      }
+      case 'flowRtt': {
+        const textAvg = appMetrics ? t('Filtered avg RTT / filtered total avg RTT') : t('Filtered avg RTT');
+        const valAvg =
+          (appMetrics
+            ? `${valueFormat(avgSum / metrics.length, 1)} / ${valueFormat(appMetrics.stats.avg, 1)}`
+            : String(valueFormat(avgSum / metrics.length, 1))) +
+          ' ' +
+          t('ms');
+        return (
           <FlexItem>
-            <Tooltip content={<Text component={TextVariants.p}>{textRate}</Text>}>
-              <Text id="bpsCount" component={TextVariants.p}>
-                {valRate}
+            <Tooltip content={<Text component={TextVariants.p}>{textAvg}</Text>}>
+              <Text id="rttAvg" component={TextVariants.p}>
+                {valAvg}
               </Text>
             </Tooltip>
           </FlexItem>
-        </>
-      );
-    } else if (metricType === 'packets') {
-      const textAbs = appMetrics
-        ? t('Filtered sum of top-k packets / filtered total packets')
-        : t('Filtered sum of packets');
-      const valAbs = (appMetrics ? `${absSum} / ${appMetrics.stats.total}` : String(absSum)) + ' ' + t('packets');
-      return (
-        <FlexItem>
-          <Tooltip content={<Text component={TextVariants.p}>{textAbs}</Text>}>
-            <Text id="packetsCount" component={TextVariants.p}>
-              {valAbs}
-            </Text>
-          </Tooltip>
-        </FlexItem>
-      );
-    } else {
-      console.log('counters', avgSum, metrics);
-      const textAvg = appMetrics ? t('Filtered avg RTT / filtered total avg RTT') : t('Filtered avg RTT');
-      const valAvg =
-        (appMetrics
-          ? `${valueFormat(avgSum / metrics.length, 1)} / ${valueFormat(appMetrics.stats.avg, 1)}`
-          : String(valueFormat(avgSum / metrics.length, 1))) +
-        ' ' +
-        t('ms');
-      return (
-        <FlexItem>
-          <Tooltip content={<Text component={TextVariants.p}>{textAvg}</Text>}>
-            <Text id="rttAvg" component={TextVariants.p}>
-              {valAvg}
-            </Text>
-          </Tooltip>
-        </FlexItem>
-      );
+        );
+      }
+      default: {
+        return <></>;
+      }
     }
   }, [appMetrics, metricType, metrics, t]);
 

--- a/web/src/utils/columns.ts
+++ b/web/src/utils/columns.ts
@@ -832,7 +832,7 @@ export const getExtraColumns = (t: TFunction): Column[] => {
       group: t('DNS'),
       name: t('DNS Latency'),
       tooltip: t('Time elapsed between DNS request and response.'),
-      isSelected: false,
+      isSelected: true,
       value: f => (f.fields.DnsLatencyMs === undefined ? Number.NaN : f.fields.DnsLatencyMs),
       sort: (a, b, col) => compareNumbers(col.value(a) as number, col.value(b) as number),
       width: 5
@@ -844,7 +844,7 @@ export const getExtraColumns = (t: TFunction): Column[] => {
       tooltip: t('DNS RCODE name from response header.'),
       fieldName: 'DnsFlagsResponseCode',
       quickFilter: 'dns_flag_response_code',
-      isSelected: false,
+      isSelected: true,
       value: f => f.fields.DnsFlagsResponseCode || '',
       sort: (a, b, col) => compareNumbers(col.value(a) as number, col.value(b) as number),
       width: 5

--- a/web/src/utils/metrics.ts
+++ b/web/src/utils/metrics.ts
@@ -295,8 +295,10 @@ export const computeStats = (ts: [number, number][], skipZeros?: boolean): Metri
     return { latest: 0, avg: 0, max: 0, total: 0 };
   }
   const values = ts.map(dp => dp[1]);
-  const filteredValues = skipZeros ? values.filter(v => v !== 0) : values;
-
+  const filteredValues = skipZeros ? values.filter(v => v !== 0) : values.filter(v => !Number.isNaN(v));
+  if (!filteredValues.length) {
+    return { latest: 0, avg: 0, max: 0, total: 0 };
+  }
   // Compute stats
   const sum = filteredValues.reduce((prev, cur) => prev + cur, 0);
   const avg = sum / filteredValues.length;


### PR DESCRIPTION
## Description

This PR remove the filter on `NoError` DNS codes on backend side to always return metrics. The filter is done on display side according to the selected options.
It also enable `Show NoError` kebab options by default to avoid having empty graphs at first display.
Finally, `NaN` are skipped in stats generation.

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
