### PR TITLE
NETOBSERV-267 Panels & columns popup filters

### DIFF
--- a/web/locales/en/plugin__netobserv-plugin.json
+++ b/web/locales/en/plugin__netobserv-plugin.json
@@ -188,6 +188,7 @@
   "Manage columns": "Manage columns",
   "Selected columns will appear in the table.": "Selected columns will appear in the table.",
   "Click and drag the items to reorder the columns in the table.": "Click and drag the items to reorder the columns in the table.",
+  "Clear filters": "Clear filters",
   "Unselect all": "Unselect all",
   "Select all": "Select all",
   "Restore default columns": "Restore default columns",

--- a/web/src/components/filters/filters-toolbar.css
+++ b/web/src/components/filters/filters-toolbar.css
@@ -189,3 +189,31 @@ div#filter-toolbar-search-filters {
 #clear-all-filters-button {
   padding: 0;
 }
+
+.custom-chip.buttonless>p {
+  margin-right: 1rem;
+}
+
+.custom-chip.selected,
+.custom-chip.selected>button,
+.custom-chip.selected>*,
+.pf-theme-dark .custom-chip.selected,
+.pf-theme-dark .custom-chip.selected>button,
+.pf-theme-dark .custom-chip.selected>* {
+  color: #fff;
+  background-color: #06c;
+}
+
+.custom-chip.unselected,
+.custom-chip.unselected>button,
+.custom-chip.unselected>* {
+  color: #000;
+  background-color: #fff;
+}
+
+.pf-theme-dark .custom-chip.unselected,
+.pf-theme-dark .custom-chip.unselected>button,
+.pf-theme-dark .custom-chip.unselected>* {
+  color: #000;
+  background-color: #D2D2D2;
+}

--- a/web/src/components/modals/columns-modal.css
+++ b/web/src/components/modals/columns-modal.css
@@ -25,3 +25,19 @@ label {
     margin-bottom: auto;
     padding: inherit;
 }
+
+.popup-header-margin {
+    margin-top: 1rem;
+}
+
+.flex-center {
+    align-self: center;
+}
+
+.flex-gap {
+    gap: 0.5rem;
+}
+
+.custom-chip.pointer {
+    cursor: pointer;
+}

--- a/web/src/components/modals/export-modal.tsx
+++ b/web/src/components/modals/export-modal.tsx
@@ -139,9 +139,11 @@ export const ExportModal: React.FC<ExportModalProps> = ({
             <ChipGroup isClosable={false} categoryName={t('Time Range')}>
               <Chip isReadOnly={true}>{rangeText()}</Chip>
             </ChipGroup>
-            <ChipGroup isClosable={false} categoryName={t('Deduplicate')}>
-              <Chip isReadOnly={true}>{flowQuery.dedup}</Chip>
-            </ChipGroup>
+            {flowQuery.dedup && (
+              <ChipGroup isClosable={false} categoryName={t('Deduplicate')}>
+                <Chip isReadOnly={true}>true</Chip>
+              </ChipGroup>
+            )}
             <ChipGroup isClosable={false} categoryName={t('Limit')}>
               <Chip isReadOnly={true}>{flowQuery.limit}</Chip>
             </ChipGroup>

--- a/web/src/components/modals/overview-panels-modal.css
+++ b/web/src/components/modals/overview-panels-modal.css
@@ -25,3 +25,15 @@ label {
     margin-bottom: auto;
     padding: inherit;
 }
+
+.popup-header-margin {
+    margin-top: 1rem;
+}
+
+.flex-center {
+    align-self: center;
+}
+
+.flex-gap {
+    gap: 0.5rem;
+}


### PR DESCRIPTION
## Description

Add view filters to quickly pick panels / columns:
![image](https://github.com/netobserv/network-observability-console-plugin/assets/91894519/1ebf3cf7-93aa-490f-aa58-a3d2529eb252)
![image](https://github.com/netobserv/network-observability-console-plugin/assets/91894519/47481f98-932e-4386-8621-54ddd2de240a)

## Dependencies

Panel ids are updated in https://github.com/netobserv/network-observability-console-plugin/pull/412

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
