### PR TITLE
NETOBSERV-1382 - Custom metrics from config

### DIFF
--- a/config/sample-config.yaml
+++ b/config/sample-config.yaml
@@ -65,6 +65,76 @@ frontend:
     merge: false
     # The following configuration is taken from Network Observability Operator
     # see https://github.com/netobserv/network-observability-operator/blob/main/controllers/consoleplugin/config/static-frontend-config.yaml
+    panels: 
+    # Protocol
+    - Proto_Bytes
+    - sum_Proto_Bytes
+    - avg_Proto_Bytes
+    - Proto_Packets
+    - sum_Proto_Packets
+    - avg_Proto_Packets
+    - Proto_Flows
+    # DSCP
+    - Dscp_Bytes
+    - Dscp_Packets
+    - min_Dscp_TimeFlowRttNs
+    - max_Dscp_TimeFlowRttNs
+    - avg_Dscp_TimeFlowRttNs
+    - p90_Dscp_TimeFlowRttNs
+    - p99_Dscp_TimeFlowRttNs
+    - min_Dscp_DnsLatencyMs
+    - max_Dscp_DnsLatencyMs
+    - avg_Dscp_DnsLatencyMs
+    - p90_Dscp_DnsLatencyMs
+    - p99_Dscp_DnsLatencyMs
+    - Dscp_Flows
+    # Port numbers
+    - SrcPort_Bytes
+    - sum_SrcPort_Bytes
+    - SrcPort_Packets
+    - sum_SrcPort_Packets
+    - SrcPort_TimeFlowRttNs
+    - min_SrcPort_TimeFlowRttNs
+    - max_SrcPort_TimeFlowRttNs
+    - avg_SrcPort_TimeFlowRttNs
+    - p90_SrcPort_TimeFlowRttNs
+    - p99_SrcPort_TimeFlowRttNs
+    - DstPort_Bytes
+    - sum_DstPort_Bytes
+    - DstPort_Packets
+    - sum_DstPort_Packets
+    - min_DstPort_TimeFlowRttNs
+    - max_DstPort_TimeFlowRttNs
+    - avg_DstPort_TimeFlowRttNs
+    - p90_DstPort_TimeFlowRttNs
+    - p99_DstPort_TimeFlowRttNs
+    # Node Directions
+    - FlowDirection_Bytes
+    - FlowDirection_Packets
+    - FlowDirection_Flows
+    # TODO: implement a way to manage plurals for interfaces
+    # Interfaces Directions
+    #- IfDirections_Bytes
+    #- IfDirections_Packets
+    #- IfDirections_Flows
+    # Interfaces names
+    #- Interfaces_Bytes
+    #- sum_Interfaces_Bytes
+    #- avg_Interfaces_Bytes
+    #- Interfaces_Packets
+    #- sum_Interfaces_Packets
+    #- avg_Interfaces_Packets
+    #- Interfaces_Flows
+    # DNS capture errors
+    - DnsErrno_Flows
+    # Connection tracking flow count
+    - numFlowLogs_Flows
+    # Bytes / Packets rates on current scope
+    - Bytes
+    - Packets
+    # flow on current scope
+    - Flows
+    - DnsFlows
   columns:
     - id: StartTime
       name: Start Time

--- a/pkg/handler/config.go
+++ b/pkg/handler/config.go
@@ -96,6 +96,7 @@ type Frontend struct {
 	BuildDate       string        `yaml:"buildDate" json:"buildDate"`
 	RecordTypes     []string      `yaml:"recordTypes" json:"recordTypes"`
 	PortNaming      PortNaming    `yaml:"portNaming" json:"portNaming"`
+	Panels          []string      `yaml:"panels" json:"panels"`
 	Columns         []Column      `yaml:"columns" json:"columns"`
 	Filters         []Filter      `yaml:"filters" json:"filters"`
 	QuickFilters    []QuickFilter `yaml:"quickFilters" json:"quickFilters"`
@@ -130,6 +131,7 @@ func ReadConfigFile(version, date, filename string) (*Config, error) {
 			BuildVersion: version,
 			BuildDate:    date,
 			RecordTypes:  []string{"flowLog"},
+			Panels:       []string{},
 			Columns: []Column{
 				{ID: "EndTime", Name: "End Time", Field: "TimeFlowEndMs", Default: true, Width: 15},
 				{ID: "SrcAddr", Name: "IP", Group: "Source", Field: "SrcAddr", Default: true, Width: 15},

--- a/pkg/handler/validation.go
+++ b/pkg/handler/validation.go
@@ -89,36 +89,36 @@ func getPacketLoss(params url.Values) (constants.PacketLoss, error) {
 	return "", fmt.Errorf("invalid packet loss: %s", pl)
 }
 
-func getMetricType(params url.Values) (constants.MetricType, error) {
+func getAggregate(params url.Values) (string, error) {
+	agg := params.Get(aggregateByKey)
+	if agg == "" {
+		return "", errors.New("aggregateBy parameter is required")
+	}
+	return agg, nil
+}
+
+func getMetricType(params url.Values) string {
 	mt := params.Get(metricTypeKey)
 	if mt == "" {
-		return constants.DefaultMetricType, nil
+		return constants.DefaultMetricType
 	}
-	metricType := constants.MetricType(mt)
-	if metricType == constants.MetricTypeBytes ||
-		metricType == constants.MetricTypeCount ||
-		metricType == constants.MetricTypeDroppedBytes ||
-		metricType == constants.MetricTypeDroppedPackets ||
-		metricType == constants.MetricTypePackets ||
-		metricType == constants.MetricTypeDNSLatencies ||
-		metricType == constants.MetricTypeCountDNS ||
-		metricType == constants.MetricTypeFlowRTT {
-		return metricType, nil
-	}
-	return "", fmt.Errorf("invalid metric type: %s", mt)
+	return mt
 }
 
 func getMetricFunction(params url.Values) (constants.MetricFunction, error) {
 	mf := params.Get(metricFunctionKey)
 	if mf == "" {
-		return "", nil
+		return constants.DefaultMetricFunction, nil
 	}
 	metricFunction := constants.MetricFunction(mf)
-	if metricFunction == constants.MetricFunctionAvg ||
+	if metricFunction == constants.MetricFunctionCount ||
+		metricFunction == constants.MetricFunctionSum ||
+		metricFunction == constants.MetricFunctionAvg ||
 		metricFunction == constants.MetricFunctionMin ||
 		metricFunction == constants.MetricFunctionMax ||
 		metricFunction == constants.MetricFunctionP90 ||
-		metricFunction == constants.MetricFunctionP99 {
+		metricFunction == constants.MetricFunctionP99 ||
+		metricFunction == constants.MetricFunctionRate {
 		return metricFunction, nil
 	}
 	return "", fmt.Errorf("invalid metric function: %s", mf)

--- a/pkg/handler/validation_test.go
+++ b/pkg/handler/validation_test.go
@@ -77,24 +77,14 @@ func TestGetRecordType(t *testing.T) {
 func TestGetMetricType(t *testing.T) {
 	// Valid
 	params := url.Values{
-		metricTypeKey: []string{"packets"},
+		metricTypeKey: []string{"Packets"},
 	}
-	m, err := getMetricType(params)
-	assert.NoError(t, err)
+	m := getMetricType(params)
 	assert.Equal(t, constants.MetricTypePackets, m)
-
-	// Invalid
-	params = url.Values{
-		metricTypeKey: []string{"invalid"},
-	}
-	_, err = getMetricType(params)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid metric type")
 
 	// Default
 	params = url.Values{}
-	m, err = getMetricType(params)
-	assert.NoError(t, err)
+	m = getMetricType(params)
 	assert.Equal(t, constants.DefaultMetricType, m)
 }
 

--- a/pkg/loki/flow_query.go
+++ b/pkg/loki/flow_query.go
@@ -254,20 +254,12 @@ func (q *FlowQueryBuilder) appendLineFilters(sb *strings.Builder) {
 	}
 }
 
-func (q *FlowQueryBuilder) appendPktDropStateFilter(sb *strings.Builder) {
-	// ensure PktDropLatestState is specified
-	// |~`"PktDropLatestState"`
-	sb.WriteString("|~`")
-	sb.WriteString(`"PktDropLatestState"`)
-	sb.WriteString("`")
-}
-
-func (q *FlowQueryBuilder) appendPktDropCauseFilter(sb *strings.Builder) {
-	// ensure PktDropLatestDropCause is specified
-	// |~`"PktDropLatestDropCause"`
-	sb.WriteString("|~`")
-	sb.WriteString(`"PktDropLatestDropCause"`)
-	sb.WriteString("`")
+func (q *FlowQueryBuilder) appendFilter(sb *strings.Builder, field string) {
+	// ensure field is specified
+	// |~`"{{field}}"`
+	sb.WriteString("|~`\"")
+	sb.WriteString(field)
+	sb.WriteString("\"`")
 }
 
 func (q *FlowQueryBuilder) appendDNSFilter(sb *strings.Builder) {
@@ -292,14 +284,6 @@ func (q *FlowQueryBuilder) appendDNSLatencyFilter(sb *strings.Builder) {
 	sb.WriteString("`")
 	sb.WriteString("!~`")
 	sb.WriteString(`"DnsLatencyMs":0[,}]`)
-	sb.WriteString("`")
-}
-
-func (q *FlowQueryBuilder) appendDNSRCodeFilter(sb *strings.Builder) {
-	// ensure DnsFlagsResponseCode field is specified with valid error
-	// |~`"DnsFlagsResponseCode"`
-	sb.WriteString("|~`")
-	sb.WriteString(`"DnsFlagsResponseCode"`)
 	sb.WriteString("`")
 }
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -365,7 +365,7 @@ func TestLokiConfigurationForTopology(t *testing.T) {
 	defer backendSvc.Close()
 
 	// WHEN the Loki flows endpoint is queried in the backend
-	resp, err := backendSvc.Client().Get(backendSvc.URL + "/api/loki/flow/metrics")
+	resp, err := backendSvc.Client().Get(backendSvc.URL + "/api/loki/flow/metrics?aggregateBy=resource")
 	require.NoError(t, err)
 
 	// THEN the query has been properly forwarded to Loki
@@ -424,12 +424,12 @@ func TestLokiConfigurationForTableHistogram(t *testing.T) {
 	backendSvc := httptest.NewServer(backendRoutes)
 	defer backendSvc.Close()
 
-	// WHEN the Loki flows endpoint is queried in the backend using count type
-	resp, err := backendSvc.Client().Get(backendSvc.URL + "/api/loki/flow/metrics?type=count")
+	// WHEN the Loki flows endpoint is queried in the backend using flow count type
+	resp, err := backendSvc.Client().Get(backendSvc.URL + "/api/loki/flow/metrics?type=Flows&function=count&aggregateBy=resource")
 	require.NoError(t, err)
 
 	// THEN the query has been properly forwarded to Loki
-	// Single query: no dedup for "count"
+	// Single query: no dedup for flow count
 	assert.Len(t, lokiMock.Calls, 1)
 	req1 := lokiMock.Calls[0].Arguments[1].(*http.Request)
 	query := req1.URL.Query().Get("query")

--- a/pkg/utils/constants/constants.go
+++ b/pkg/utils/constants/constants.go
@@ -1,10 +1,9 @@
 package constants
 
-type MetricType string
 type MetricFunction string
-
 type RecordType string
 type PacketLoss string
+type Discriminator string
 type Direction string
 
 const (
@@ -12,22 +11,25 @@ const (
 	AppLabelValue   = "netobserv-flowcollector"
 	RecordTypeLabel = "_RecordType"
 
-	MetricTypeBytes          MetricType = "bytes"
-	MetricTypePackets        MetricType = "packets"
-	MetricTypeCount          MetricType = "count"
-	MetricTypeCountDNS       MetricType = "countDns"
-	MetricTypeFlowRTT        MetricType = "flowRtt"
-	MetricTypeDNSLatencies   MetricType = "dnsLatencies"
-	MetricTypeDroppedBytes   MetricType = "droppedBytes"
-	MetricTypeDroppedPackets MetricType = "droppedPackets"
-	DefaultMetricType        MetricType = MetricTypeBytes
+	MetricTypeFlows          = "Flows"
+	MetricTypeBytes          = "Bytes"
+	MetricTypePackets        = "Packets"
+	MetricTypeDroppedBytes   = "PktDropBytes"
+	MetricTypeDroppedPackets = "PktDropPackets"
+	MetricTypeDNSLatency     = "DnsLatencyMs"
+	MetricTypeDNSFlows       = "DnsFlows"
+	MetricTypeFlowRTT        = "TimeFlowRttNs"
+	DefaultMetricType        = MetricTypeBytes
 
+	MetricFunctionCount   MetricFunction = "count"
+	MetricFunctionSum     MetricFunction = "sum"
 	MetricFunctionAvg     MetricFunction = "avg"
 	MetricFunctionMin     MetricFunction = "min"
 	MetricFunctionMax     MetricFunction = "max"
 	MetricFunctionP90     MetricFunction = "p90"
 	MetricFunctionP99     MetricFunction = "p99"
-	DefaultMetricFunction MetricFunction = MetricFunctionAvg
+	MetricFunctionRate    MetricFunction = "rate"
+	DefaultMetricFunction MetricFunction = MetricFunctionRate
 
 	RecordTypeAllConnections RecordType = "allConnections"
 	RecordTypeNewConnection  RecordType = "newConnection"

--- a/web/locales/en/plugin__netobserv-plugin.json
+++ b/web/locales/en/plugin__netobserv-plugin.json
@@ -33,10 +33,10 @@
   "Invalid": "Invalid",
   "rate": "rate",
   "Total": "Total",
+  "Average": "Average",
   "Latest": "Latest",
   "Min": "Min",
   "Max": "Max",
-  "Average": "Average",
   "P90": "P90",
   "P99": "P99",
   "Bytes": "Bytes",
@@ -346,7 +346,6 @@
   "Filtered total byte rate": "Filtered total byte rate",
   "Filtered sum of top-k packets": "Filtered sum of top-k packets",
   "Filtered total packets": "Filtered total packets",
-  "packets": "packets",
   "Filtered avg DNS Latency": "Filtered avg DNS Latency",
   "Filtered overall avg DNS Latency": "Filtered overall avg DNS Latency",
   "ms": "ms",
@@ -411,7 +410,6 @@
   "Unknown direction": "Unknown direction",
   "P": "P",
   "Pps": "Pps",
-  "total": "total",
   "minimum": "minimum",
   "maximum": "maximum",
   "90th percentile": "90th percentile",
@@ -455,5 +453,8 @@
   "Top {{limit}} DNS response code": "Top {{limit}} DNS response code",
   "Total DNS response code": "Total DNS response code",
   "Total DNS flow count": "Total DNS flow count",
-  "The top DNS response code extracted from DNS response headers compared to total over the selected interval": "The top DNS response code extracted from DNS response headers compared to total over the selected interval"
+  "The top DNS response code extracted from DNS response headers compared to total over the selected interval": "The top DNS response code extracted from DNS response headers compared to total over the selected interval",
+  "rates": "rates",
+  "with total": "with total",
+  "Invalid custom panel id": "Invalid custom panel id"
 }

--- a/web/src/api/ipfix.ts
+++ b/web/src/api/ipfix.ts
@@ -76,13 +76,13 @@ export enum IfDirection {
 
 export interface Fields {
   /** Source IP address (ipv4 or ipv6) */
-  SrcAddr: string;
+  SrcAddr?: string;
   /** Destination IP address (ipv4 or ipv6) */
-  DstAddr: string;
+  DstAddr?: string;
   /** Source MAC address */
-  SrcMac: string;
+  SrcMac?: string;
   /** Destination MAC address */
-  DstMac: string;
+  DstMac?: string;
   /** Name of the source matched Kubernetes object, such as Pod name, Service name, etc. */
   SrcK8S_Name?: string;
   /** Name of the destination matched Kubernetes object, such as Pod name, Service name, etc. */
@@ -110,7 +110,7 @@ export interface Fields {
   /** Cluster name */
   K8S_ClusterName?: string;
   /** L4 protocol */
-  Proto: number;
+  Proto?: number;
   /** Network interface array */
   Interfaces?: string[];
   /** Flow direction array from the network interface observation point */
@@ -164,11 +164,11 @@ export interface Fields {
   /** Error number returned from DNS tracker ebpf hook function */
   DnsErrno?: number;
   /** Start timestamp of this flow, in milliseconds */
-  TimeFlowStartMs: number;
+  TimeFlowStartMs?: number;
   /** End timestamp of this flow, in milliseconds */
-  TimeFlowEndMs: number;
+  TimeFlowEndMs?: number;
   /** Timestamp when this flow was received and processed by the flow collector, in seconds */
-  TimeReceived: number;
+  TimeReceived?: number;
   /** TCP handshake Round Trip Time (RTT) in nanoseconds */
   TimeFlowRttNs?: number;
   /** In conversation tracking, the conversation identifier */

--- a/web/src/api/routes.ts
+++ b/web/src/api/routes.ts
@@ -1,11 +1,12 @@
 import axios from 'axios';
 import { Config, defaultConfig } from '../model/config';
 import { buildExportQuery } from '../model/export-query';
-import { FlowQuery, FlowScope, GenericAggregation, isTimeMetric } from '../model/flow-query';
+import { FlowQuery, FlowScope, isTimeMetric } from '../model/flow-query';
 import { ContextSingleton } from '../utils/context';
 import { TimeRange } from '../utils/datetime';
 import { parseTopologyMetrics, parseGenericMetrics } from '../utils/metrics';
 import { AlertsResult, SilencedAlert } from './alert';
+import { Field } from './ipfix';
 import {
   AggregatedQueryResponse,
   GenericMetricsResult,
@@ -110,7 +111,7 @@ export const getFlowGenericMetrics = (params: FlowQuery, range: number | TimeRan
     return parseGenericMetrics(
       res.result as RawTopologyMetrics[],
       range,
-      params.aggregateBy as GenericAggregation,
+      params.aggregateBy as Field,
       res.unixTimestamp,
       !isTimeMetric(params.type),
       res.isMock
@@ -144,6 +145,7 @@ export const getConfig = (): Promise<Config> => {
       buildVersion: r.data.buildVersion,
       buildDate: r.data.buildDate,
       recordTypes: r.data.recordTypes,
+      panels: r.data.panels,
       columns: r.data.columns,
       portNaming: {
         enable: r.data.portNaming.enable ?? defaultConfig.portNaming.enable,

--- a/web/src/components/__tests-data__/config.ts
+++ b/web/src/components/__tests-data__/config.ts
@@ -1,6 +1,7 @@
 import { defaultConfig } from '../../model/config';
 import { ColumnConfigSampleDefs, FieldConfigSample } from './columns';
 import { FilterDefinitionSample } from './filters';
+import { CustomPanelsSample } from './panels';
 
 export const FullConfigResultSample = {
   ...defaultConfig,
@@ -9,6 +10,7 @@ export const FullConfigResultSample = {
     enable: true,
     portNames: new Map([['3100', 'loki']])
   },
+  panels: CustomPanelsSample,
   columns: ColumnConfigSampleDefs,
   filters: FilterDefinitionSample,
   sampling: 1,

--- a/web/src/components/__tests-data__/panels.ts
+++ b/web/src/components/__tests-data__/panels.ts
@@ -1,6 +1,7 @@
 import * as _ from 'lodash';
 import { getDefaultOverviewPanels, OverviewPanel } from '../../utils/overview-panels';
 
+export const CustomPanelsSample = ['Flows', 'DnsFlows'];
 export const SamplePanel = { id: 'top_avg_byte_rates', isSelected: true } as OverviewPanel;
 export const DefaultPanels = getDefaultOverviewPanels().filter(p => p.isSelected);
 export const ShuffledDefaultPanels: OverviewPanel[] = _.shuffle(DefaultPanels);

--- a/web/src/components/__tests__/netflow-traffic.spec.tsx
+++ b/web/src/components/__tests__/netflow-traffic.spec.tsx
@@ -75,34 +75,33 @@ describe('<NetflowTraffic />', () => {
     //should have called getMetricsMock & getGenericMetricsMock multiple times on render:
     const expectedMetricsQueries: FlowQuery[] = [
       // 4 queries for bytes & packets rate on current scope & app scope
-      { ...defaultQuery, type: 'bytes' },
-      { ...defaultQuery, type: 'packets' },
-      { ...defaultQuery, aggregateBy: 'app', type: 'bytes' },
-      { ...defaultQuery, aggregateBy: 'app', type: 'packets' },
+      { ...defaultQuery, function: 'rate', type: 'Bytes' },
+      { ...defaultQuery, function: 'rate', type: 'Packets' },
+      { ...defaultQuery, function: 'rate', aggregateBy: 'app', type: 'Bytes' },
+      { ...defaultQuery, function: 'rate', aggregateBy: 'app', type: 'Packets' },
       // 2 queries for dropped packets rate on current scope & app scope
-      { ...defaultQuery, type: 'droppedPackets' },
-      { ...defaultQuery, aggregateBy: 'app', type: 'droppedPackets' },
+      { ...defaultQuery, function: 'rate', type: 'PktDropPackets' },
+      { ...defaultQuery, function: 'rate', aggregateBy: 'app', type: 'PktDropPackets' },
       // 4 queries for dns latency avg & p90 on current scope & app scope
-      { ...defaultQuery, function: 'avg', type: 'dnsLatencies' },
-      { ...defaultQuery, function: 'p90', type: 'dnsLatencies' },
-      { ...defaultQuery, function: 'avg', aggregateBy: 'app', type: 'dnsLatencies' },
-      { ...defaultQuery, function: 'p90', aggregateBy: 'app', type: 'dnsLatencies' },
-      // 1 query for dns response codes count at app scope
-      { ...defaultQuery, type: 'countDns', aggregateBy: 'app' },
+      { ...defaultQuery, function: 'avg', type: 'DnsLatencyMs' },
+      { ...defaultQuery, function: 'p90', type: 'DnsLatencyMs' },
+      { ...defaultQuery, function: 'avg', aggregateBy: 'app', type: 'DnsLatencyMs' },
+      { ...defaultQuery, function: 'p90', aggregateBy: 'app', type: 'DnsLatencyMs' },
       // 6 queries for avg, min & p90 RTT on current scope & app scope
-      { ...defaultQuery, function: 'avg', type: 'flowRtt' },
-      { ...defaultQuery, function: 'min', type: 'flowRtt' },
-      { ...defaultQuery, function: 'p90', type: 'flowRtt' },
-      { ...defaultQuery, function: 'avg', aggregateBy: 'app', type: 'flowRtt' },
-      { ...defaultQuery, function: 'min', aggregateBy: 'app', type: 'flowRtt' },
-      { ...defaultQuery, function: 'p90', aggregateBy: 'app', type: 'flowRtt' }
+      { ...defaultQuery, function: 'avg', type: 'TimeFlowRttNs' },
+      { ...defaultQuery, function: 'min', type: 'TimeFlowRttNs' },
+      { ...defaultQuery, function: 'p90', type: 'TimeFlowRttNs' },
+      { ...defaultQuery, function: 'avg', aggregateBy: 'app', type: 'TimeFlowRttNs' },
+      { ...defaultQuery, function: 'min', aggregateBy: 'app', type: 'TimeFlowRttNs' },
+      { ...defaultQuery, function: 'p90', aggregateBy: 'app', type: 'TimeFlowRttNs' }
     ];
     const expectedGenericMetricsQueries: FlowQuery[] = [
       // 2 queries for packet dropped states & causes
-      { ...defaultQuery, type: 'droppedPackets', aggregateBy: 'droppedState' },
-      { ...defaultQuery, type: 'droppedPackets', aggregateBy: 'droppedCause' },
-      // 1 query for dns response codes
-      { ...defaultQuery, type: 'countDns', aggregateBy: 'dnsRCode' }
+      { ...defaultQuery, function: 'rate', type: 'PktDropPackets', aggregateBy: 'PktDropLatestState' },
+      { ...defaultQuery, function: 'rate', type: 'PktDropPackets', aggregateBy: 'PktDropLatestDropCause' },
+      // 2 queries for dns response codes count
+      { ...defaultQuery, function: 'count', type: 'DnsFlows', aggregateBy: 'DnsFlagsResponseCode' },
+      { ...defaultQuery, function: 'count', type: 'DnsFlows', aggregateBy: 'app' }
     ];
     await waitFor(() => {
       //config is get only once

--- a/web/src/components/dropdowns/__tests__/metric-type-dropdown.spec.tsx
+++ b/web/src/components/dropdowns/__tests__/metric-type-dropdown.spec.tsx
@@ -5,7 +5,7 @@ import MetricTypeDropdown from '../metric-type-dropdown';
 
 describe('<MetricDropdown />', () => {
   const props = {
-    selected: 'bytes',
+    selected: 'Bytes',
     setMetricType: jest.fn(),
     id: 'metric'
   };
@@ -35,14 +35,14 @@ describe('<MetricDropdown />', () => {
     const dropdown = wrapper.find('#metric-dropdown');
     //open dropdown and select PACKETS
     dropdown.at(0).simulate('click');
-    wrapper.find('[id="packets"]').at(0).simulate('click');
-    expect(props.setMetricType).toHaveBeenCalledWith('packets');
+    wrapper.find('[id="Packets"]').at(0).simulate('click');
+    expect(props.setMetricType).toHaveBeenCalledWith('Packets');
     expect(wrapper.find('li').length).toBe(0);
 
     //open dropdown and select BYTES
     dropdown.at(0).simulate('click');
-    wrapper.find('[id="bytes"]').at(0).simulate('click');
-    expect(props.setMetricType).toHaveBeenCalledWith('bytes');
+    wrapper.find('[id="Bytes"]').at(0).simulate('click');
+    expect(props.setMetricType).toHaveBeenCalledWith('Bytes');
     expect(wrapper.find('li').length).toBe(0);
 
     //setMetricType should be called twice

--- a/web/src/components/dropdowns/metric-function-dropdown.tsx
+++ b/web/src/components/dropdowns/metric-function-dropdown.tsx
@@ -1,24 +1,24 @@
 import { Dropdown, DropdownItem, DropdownPosition, DropdownToggle } from '@patternfly/react-core';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { MetricFunction, MetricType, isTimeMetric } from '../../model/flow-query';
+import { StatFunction, MetricType, isTimeMetric } from '../../model/flow-query';
 
-export const TIME_METRIC_FUNCTIONS: MetricFunction[] = ['avg', 'min', 'max', 'p90', 'p99'];
-export const RATE_METRIC_FUNCTIONS: MetricFunction[] = ['last', 'avg', 'min', 'max', 'sum'];
+export const TIME_METRIC_FUNCTIONS: StatFunction[] = ['avg', 'min', 'max', 'p90', 'p99'];
+export const RATE_METRIC_FUNCTIONS: StatFunction[] = ['last', 'avg', 'min', 'max', 'sum'];
 
 export const MetricFunctionDropdown: React.FC<{
   selected?: string;
-  setMetricFunction: (v: MetricFunction) => void;
+  setMetricFunction: (v: StatFunction) => void;
   metricType?: MetricType;
   id?: string;
 }> = ({ selected, setMetricFunction, metricType, id }) => {
   const { t } = useTranslation('plugin__netobserv-plugin');
   const [metricDropdownOpen, setMetricDropdownOpen] = React.useState(false);
 
-  const getAvailableFunctions = React.useCallback((): MetricFunction[] => {
+  const getAvailableFunctions = React.useCallback((): StatFunction[] => {
     switch (metricType) {
-      case 'dnsLatencies':
-      case 'flowRtt':
+      case 'DnsLatencyMs':
+      case 'TimeFlowRttNs':
         return TIME_METRIC_FUNCTIONS;
       default:
         return RATE_METRIC_FUNCTIONS;
@@ -26,19 +26,21 @@ export const MetricFunctionDropdown: React.FC<{
   }, [metricType]);
 
   const getMetricDisplay = React.useCallback(
-    (mf: MetricFunction): string => {
+    (mf: StatFunction): string => {
       const suffix = !isTimeMetric(metricType) ? ' ' + t('rate') : '';
       switch (mf) {
+        case 'count':
         case 'sum':
           return t('Total');
+        case 'rate':
+        case 'avg':
+          return `${t('Average')}${suffix}`;
         case 'last':
           return `${t('Latest')}${suffix}`;
         case 'min':
           return `${t('Min')}${suffix}`;
         case 'max':
           return `${t('Max')}${suffix}`;
-        case 'avg':
-          return `${t('Average')}${suffix}`;
         case 'p90':
           return `${t('P90')}${suffix}`;
         case 'p99':
@@ -59,7 +61,7 @@ export const MetricFunctionDropdown: React.FC<{
           id={`${id}-dropdown`}
           onToggle={() => setMetricDropdownOpen(!metricDropdownOpen)}
         >
-          {getMetricDisplay(selected as MetricFunction)}
+          {getMetricDisplay(selected as StatFunction)}
         </DropdownToggle>
       }
       isOpen={metricDropdownOpen}

--- a/web/src/components/dropdowns/metric-type-dropdown.tsx
+++ b/web/src/components/dropdowns/metric-type-dropdown.tsx
@@ -16,16 +16,16 @@ export const MetricTypeDropdown: React.FC<{
   const [metricDropdownOpen, setMetricDropdownOpen] = React.useState(false);
 
   const getMetricTypeOptions = React.useCallback(() => {
-    let options: MetricType[] = ['bytes', 'packets'];
+    let options: MetricType[] = ['Bytes', 'Packets'];
     if (isTopology) {
       if (allowPktDrop) {
-        options = options.concat('droppedBytes', 'droppedPackets');
+        options = options.concat('PktDropBytes', 'PktDropPackets');
       }
       if (allowDNSMetric) {
-        options.push('dnsLatencies');
+        options.push('DnsLatencyMs');
       }
       if (allowRTTMetric) {
-        options.push('flowRtt');
+        options.push('TimeFlowRttNs');
       }
     }
     return options;
@@ -34,17 +34,17 @@ export const MetricTypeDropdown: React.FC<{
   const getMetricDisplay = React.useCallback(
     (metricType: MetricType): string => {
       switch (metricType) {
-        case 'bytes':
+        case 'Bytes':
           return t('Bytes');
-        case 'droppedBytes':
+        case 'PktDropBytes':
           return t('Dropped bytes');
-        case 'packets':
+        case 'Packets':
           return t('Packets');
-        case 'droppedPackets':
+        case 'PktDropPackets':
           return t('Dropped packets');
-        case 'dnsLatencies':
+        case 'DnsLatencyMs':
           return t('DNS latencies');
-        case 'flowRtt':
+        case 'TimeFlowRttNs':
           return t('RTT');
         default:
           throw new Error('getMetricDisplay called with invalid metricType: ' + metricType);

--- a/web/src/components/dropdowns/topology-display-dropdown.tsx
+++ b/web/src/components/dropdowns/topology-display-dropdown.tsx
@@ -2,7 +2,7 @@ import { Checkbox, Flex, FlexItem, Select, Switch, Tooltip } from '@patternfly/r
 import { InfoAltIcon } from '@patternfly/react-icons';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { MetricFunction, FlowScope, MetricType } from '../../model/flow-query';
+import { StatFunction, FlowScope, MetricType } from '../../model/flow-query';
 import { MetricScopeOptions } from '../../model/metrics';
 import { LayoutName, TopologyGroupTypes, TopologyOptions } from '../../model/topology';
 import GroupDropdown from './group-dropdown';
@@ -17,8 +17,8 @@ import ScopeDropdown from './scope-dropdown';
 export type Size = 's' | 'm' | 'l';
 
 export const TopologyDisplayOptions: React.FC<{
-  metricFunction: MetricFunction;
-  setMetricFunction: (f: MetricFunction) => void;
+  metricFunction: StatFunction;
+  setMetricFunction: (f: StatFunction) => void;
   metricType: MetricType;
   setMetricType: (t: MetricType) => void;
   metricScope: FlowScope;
@@ -239,8 +239,8 @@ export const TopologyDisplayOptions: React.FC<{
 };
 
 export const TopologyDisplayDropdown: React.FC<{
-  metricFunction: MetricFunction;
-  setMetricFunction: (f: MetricFunction) => void;
+  metricFunction: StatFunction;
+  setMetricFunction: (f: StatFunction) => void;
   metricType: MetricType;
   setMetricType: (t: MetricType) => void;
   metricScope: FlowScope;

--- a/web/src/components/metrics/__tests__/metrics-donut.spec.tsx
+++ b/web/src/components/metrics/__tests__/metrics-donut.spec.tsx
@@ -10,8 +10,8 @@ describe('<StatDonut />', () => {
   const props: MetricsDonutProps = {
     id: 'donut-test',
     limit: 5,
-    metricType: 'bytes',
-    metricFunction: 'avg',
+    metricType: 'Bytes',
+    metricFunction: 'rate',
     topKMetrics: metrics.map(m => ({ ...m, fullName: 'whatever', shortName: 'whatever', isInternal: false })),
     totalMetric: { stats: { avg: 500 } } as NamedMetric,
     showInternal: true,

--- a/web/src/components/metrics/__tests__/metrics-graph.spec.tsx
+++ b/web/src/components/metrics/__tests__/metrics-graph.spec.tsx
@@ -8,7 +8,7 @@ import { MetricsGraph, MetricsGraphProps } from '../metrics-graph';
 describe('<MetricsContent />', () => {
   const props: MetricsGraphProps = {
     id: 'chart-test',
-    metricType: 'bytes',
+    metricType: 'Bytes',
     metricFunction: 'avg',
     metrics: metrics.map(m => ({ ...m, fullName: 'whatever', shortName: 'whatever', isInternal: false })),
     smallerTexts: false,

--- a/web/src/components/metrics/histogram.tsx
+++ b/web/src/components/metrics/histogram.tsx
@@ -28,7 +28,7 @@ import { NamedMetric, TopologyMetrics } from '../../api/loki';
 import { TimeRange } from '../../utils/datetime';
 import { getDateMsInSeconds } from '../../utils/duration';
 import { LOCAL_STORAGE_HISTOGRAM_GUIDED_TOUR_DONE_KEY, useLocalStorage } from '../../utils/local-storage-hook';
-import { getFormattedRateValue } from '../../utils/metrics';
+import { getFormattedValue } from '../../utils/metrics';
 import { TruncateLength } from '../dropdowns/truncate-dropdown';
 import { GuidedTourHandle } from '../guided-tour/guided-tour';
 import BrushHandleComponent from './brush-handle';
@@ -409,7 +409,7 @@ export const Histogram: React.FC<{
           dependentAxis
           showGrid
           fixLabelOverlap
-          tickFormat={y => getFormattedRateValue(y, 'count', t)}
+          tickFormat={y => getFormattedValue(y, 'Flows', 'sum', t)}
         />
         <ChartStack>
           <ChartBar

--- a/web/src/components/metrics/metrics-donut.tsx
+++ b/web/src/components/metrics/metrics-donut.tsx
@@ -2,7 +2,7 @@ import { ChartDonut, ChartLabel, ChartLegend, ChartThemeColor } from '@patternfl
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { GenericMetric, MetricStats, NamedMetric } from '../../api/loki';
-import { MetricFunction, MetricType } from '../../model/flow-query';
+import { MetricType, MetricFunction } from '../../model/flow-query';
 import { getStat } from '../../model/metrics';
 import { LOCAL_STORAGE_OVERVIEW_DONUT_DIMENSION_KEY, useLocalStorage } from '../../utils/local-storage-hook';
 import { getFormattedValue, isUnknownPeer } from '../../utils/metrics';
@@ -16,9 +16,10 @@ export type MetricsDonutProps = {
   metricType: MetricType;
   metricFunction: MetricFunction;
   topKMetrics: GenericMetric[] | NamedMetric[];
-  totalMetric: NamedMetric;
+  totalMetric: GenericMetric | NamedMetric;
   showOthers: boolean;
   othersName?: string;
+  showLast?: boolean;
   showInternal?: boolean;
   showOutOfScope?: boolean;
   smallerTexts?: boolean;
@@ -37,6 +38,7 @@ export const MetricsDonut: React.FC<MetricsDonutProps> = ({
   totalMetric,
   showOthers,
   othersName,
+  showLast,
   showInternal,
   showOutOfScope,
   smallerTexts,
@@ -47,10 +49,10 @@ export const MetricsDonut: React.FC<MetricsDonutProps> = ({
   const { t } = useTranslation('plugin__netobserv-plugin');
 
   const getStats = React.useCallback(
-    (s: MetricStats) => {
-      return metricType.startsWith('count') ? s.sum : getStat(s, metricFunction);
+    (stats: MetricStats) => {
+      return getStat(stats, showLast ? 'last' : metricFunction);
     },
-    [metricFunction, metricType]
+    [metricFunction, showLast]
   );
 
   let total = getStats(totalMetric.stats);

--- a/web/src/components/metrics/metrics-graph-total.tsx
+++ b/web/src/components/metrics/metrics-graph-total.tsx
@@ -15,7 +15,7 @@ import { TextContent } from '@patternfly/react-core';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { GenericMetric, NamedMetric } from '../../api/loki';
-import { MetricFunction, MetricType } from '../../model/flow-query';
+import { MetricType, MetricFunction } from '../../model/flow-query';
 import { LOCAL_STORAGE_OVERVIEW_METRICS_TOTAL_DIMENSION_KEY, useLocalStorage } from '../../utils/local-storage-hook';
 import { getFormattedValue, isUnknownPeer } from '../../utils/metrics';
 import './metrics-content.css';
@@ -34,7 +34,7 @@ export type MetricsGraphWithTotalProps = {
   metricType: MetricType;
   metricFunction: MetricFunction;
   topKMetrics: GenericMetric[] | NamedMetric[];
-  totalMetric?: NamedMetric;
+  totalMetric?: GenericMetric | NamedMetric;
   totalDropMetric?: NamedMetric;
   limit: number;
   showTop: boolean;

--- a/web/src/components/modals/__tests__/overview-panels-modal.spec.tsx
+++ b/web/src/components/modals/__tests__/overview-panels-modal.spec.tsx
@@ -12,6 +12,7 @@ describe('<OverviewPanelsModal />', () => {
     recordType: 'flowLog' as RecordType,
     panels: ShuffledDefaultPanels,
     setPanels: jest.fn(),
+    customIds: [],
     id: 'panels-modal'
   };
   it('should render component', async () => {

--- a/web/src/components/modals/overview-panels-modal.tsx
+++ b/web/src/components/modals/overview-panels-modal.tsx
@@ -34,8 +34,9 @@ export const OverviewPanelsModal: React.FC<{
   recordType: RecordType;
   panels: OverviewPanel[];
   setPanels: (v: OverviewPanel[]) => void;
+  customIds?: string[];
   id?: string;
-}> = ({ id, isModalOpen, setModalOpen, recordType, panels, setPanels }) => {
+}> = ({ id, isModalOpen, setModalOpen, recordType, panels, setPanels, customIds }) => {
   const [updatedPanels, setUpdatedPanels] = React.useState<OverviewPanel[]>([]);
   const [filterKeys, setFilterKeys] = React.useState<string[]>([]);
   const { t } = useTranslation('plugin__netobserv-plugin');
@@ -82,8 +83,8 @@ export const OverviewPanelsModal: React.FC<{
   );
 
   const onReset = React.useCallback(() => {
-    setUpdatedPanels(getDefaultOverviewPanels().filter(p => panels.some(existing => existing.id === p.id)));
-  }, [panels]);
+    setUpdatedPanels(getDefaultOverviewPanels(customIds).filter(p => panels.some(existing => existing.id === p.id)));
+  }, [customIds, panels]);
 
   const isSaveDisabled = React.useCallback(() => {
     return _.isEmpty(updatedPanels.filter(p => p.isSelected));

--- a/web/src/components/netflow-overview/__tests__/netflow-overview-panel.spec.tsx
+++ b/web/src/components/netflow-overview/__tests__/netflow-overview-panel.spec.tsx
@@ -18,7 +18,7 @@ describe('<NetflowOverviewPanel />', () => {
   };
   const contentProps: MetricsGraphProps = {
     id: SamplePanel.id,
-    metricType: 'bytes' as MetricType,
+    metricType: 'Bytes' as MetricType,
     metricFunction: 'avg',
     metrics: metrics.map(m => ({ ...m, shortName: 'whatever', fullName: 'whatever', isInternal: false })),
     limit: 5,

--- a/web/src/components/netflow-overview/__tests__/netflow-overview.spec.tsx
+++ b/web/src/components/netflow-overview/__tests__/netflow-overview.spec.tsx
@@ -18,7 +18,10 @@ describe('<NetflowOverview />', () => {
     error: undefined as string | undefined,
     loading: false,
     recordType: 'flowLog' as RecordType,
-    metrics: {},
+    metrics: {
+      customMetrics: new Map(),
+      totalCustomMetrics: new Map()
+    },
     filterActionLinks: <></>,
     truncateLength: TruncateLength.M
   };

--- a/web/src/components/netflow-overview/netflow-overview.tsx
+++ b/web/src/components/netflow-overview/netflow-overview.tsx
@@ -13,16 +13,18 @@ import _ from 'lodash';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { LOCAL_STORAGE_OVERVIEW_KEBAB_KEY, useLocalStorage } from '../../utils/local-storage-hook';
-import { NetflowMetrics } from '../../api/loki';
+import { GenericMetric, isValidTopologyMetrics, NamedMetric, NetflowMetrics, TopologyMetrics } from '../../api/loki';
 import { RecordType } from '../../model/flow-query';
 import { getStat } from '../../model/metrics';
 import {
+  CUSTOM_PANEL_MATCHER,
   getFunctionFromId,
   getOverviewPanelInfo,
   getRateFunctionFromId,
   OverviewPanel,
   OverviewPanelId,
-  OverviewPanelInfo
+  OverviewPanelInfo,
+  parseCustomMetricId
 } from '../../utils/overview-panels';
 import { TruncateLength } from '../dropdowns/truncate-dropdown';
 import LokiError from '../messages/loki-error';
@@ -35,6 +37,11 @@ import './netflow-overview.css';
 import { PanelKebab, PanelKebabOptions } from './panel-kebab';
 import { usePrevious } from '../../utils/previous-hook';
 import { convertRemToPixels } from '../../utils/panel';
+import { Field, FlowDirection, getDirectionDisplayString } from '../../api/ipfix';
+import { formatPort } from '../../utils/port';
+import { formatProtocol } from '../../utils/protocol';
+import { getDSCPServiceClassName } from '../../utils/dscp';
+import { getDNSRcodeDescription, getDNSErrorDescription } from '../../utils/dns';
 
 type PanelContent = {
   calculatedTitle?: string;
@@ -214,10 +221,9 @@ export const NetflowOverview: React.FC<NetflowOverviewProps> = ({
     return metrics.dnsRCodeMetrics?.sort((a, b) => getStat(b.stats, 'sum') - getStat(a.stats, 'sum')) || [];
   }, [metrics.dnsRCodeMetrics]);
 
-  const getNamedDnsCountTotalMetric = React.useCallback(() => {
-    const metric = metrics.totalDnsCountMetric;
-    return metric ? toNamedMetric(t, metric, truncateLength, false, false) : undefined;
-  }, [metrics.totalDnsCountMetric, t, truncateLength]);
+  const getDnsCountTotalMetric = React.useCallback(() => {
+    return metrics.totalDnsCountMetric;
+  }, [metrics.totalDnsCountMetric]);
 
   const getTopKMetrics = React.useCallback(
     (id: OverviewPanelId) => {
@@ -259,6 +265,70 @@ export const NetflowOverview: React.FC<NetflowOverviewProps> = ({
     [getTotalMetric, t, truncateLength]
   );
 
+  const getGenericMetricName = React.useCallback(
+    (field: Field, value: string) => {
+      switch (field) {
+        case 'SrcPort':
+        case 'DstPort':
+          return formatPort(Number(value));
+        case 'Proto':
+          return formatProtocol(Number(value), t);
+        case 'Dscp':
+          return getDSCPServiceClassName(Number(value)) || value;
+        case 'FlowDirection':
+          return getDirectionDisplayString(value as FlowDirection, t);
+        case 'DnsFlagsResponseCode':
+          return getDNSRcodeDescription(value);
+        case 'DnsErrno':
+          const err = getDNSErrorDescription(Number(value));
+          return err !== '' ? err : t('n/a');
+        default:
+          return value !== '' ? value : t('n/a');
+      }
+    },
+    [t]
+  );
+
+  const getTopKCustomMetrics = React.useCallback(
+    (id: string) => {
+      return metrics.customMetrics.get(id.replaceAll(CUSTOM_PANEL_MATCHER + '_', '')) || [];
+    },
+    [metrics.customMetrics]
+  );
+
+  const getNamedTopKCustomMetrics = React.useCallback(
+    (id: string) => {
+      const metrics = getTopKCustomMetrics(id);
+      return (metrics
+        .sort((a, b) => getStat(b.stats, 'sum') - getStat(a.stats, 'sum'))
+        .map(metric => {
+          if (isValidTopologyMetrics(metric)) {
+            return toNamedMetric(t, metric, truncateLength, true, true);
+          }
+          return { ...metric, name: getGenericMetricName(metric.aggregateBy, metric.name) };
+        }) || []) as NamedMetric[] | GenericMetric[];
+    },
+    [getGenericMetricName, getTopKCustomMetrics, t, truncateLength]
+  );
+
+  const getTotalCustomMetrics = React.useCallback(
+    (id: string) => {
+      return metrics.totalCustomMetrics.get(id.replaceAll(CUSTOM_PANEL_MATCHER + '_', ''));
+    },
+    [metrics.totalCustomMetrics]
+  );
+
+  const getNamedTotalCustomMetric = React.useCallback(
+    (id: OverviewPanelId) => {
+      const metric = getTotalCustomMetrics(id);
+      if (isValidTopologyMetrics(metric)) {
+        return metric ? toNamedMetric(t, metric as TopologyMetrics, truncateLength, false, false) : undefined;
+      }
+      return metric;
+    },
+    [getTotalCustomMetrics, t, truncateLength]
+  );
+
   const smallerTexts = truncateLength >= TruncateLength.M;
   const getPanelContent = React.useCallback(
     (id: OverviewPanelId, info: OverviewPanelInfo, isFocus: boolean, animate: boolean): PanelContent => {
@@ -286,7 +356,7 @@ export const NetflowOverview: React.FC<NetflowOverviewProps> = ({
               type: 'donut'
             }
           });
-          const metricType = id.endsWith('byte_rates') ? 'bytes' : 'packets';
+          const metricType = id.endsWith('byte_rates') ? 'Bytes' : 'Packets';
           const metrics = getTopKRateMetrics(id);
           const namedTotalMetric = getNamedTotalRateMetric(id);
           return {
@@ -297,10 +367,11 @@ export const NetflowOverview: React.FC<NetflowOverviewProps> = ({
                   subTitle={info.subtitle}
                   limit={limit}
                   metricType={metricType}
-                  metricFunction={options.showLast! ? 'last' : getFunctionFromId(id)}
+                  metricFunction={'rate'}
                   topKMetrics={metrics}
                   totalMetric={namedTotalMetric}
                   showOthers={options.showOthers!}
+                  showLast={options.showLast}
                   showInternal={options.showInternal!}
                   showOutOfScope={options.showOutOfScope!}
                   smallerTexts={smallerTexts}
@@ -332,7 +403,7 @@ export const NetflowOverview: React.FC<NetflowOverviewProps> = ({
           });
           const showTopOnly = options.showTop && !options.showApp?.value && !options.showAppDrop?.value;
           const showTotalOnly = !options.showTop && options.showApp!.value;
-          const metricType = id.endsWith('byte_rates') ? 'bytes' : 'packets';
+          const metricType = id.endsWith('byte_rates') ? 'Bytes' : 'Packets';
           const topKMetrics = getNoInternalTopKRateMetrics(id);
           const namedTotalMetric = getNamedTotalRateMetric(id.replace('dropped_', '') as OverviewPanelId);
           const namedTotalDroppedMetric = getNamedTotalRateMetric(id);
@@ -343,7 +414,7 @@ export const NetflowOverview: React.FC<NetflowOverviewProps> = ({
                 id={id}
                 metricType={metricType}
                 metrics={topKMetrics}
-                metricFunction="avg"
+                metricFunction="rate"
                 limit={limit}
                 showBar={false}
                 showArea={true}
@@ -360,7 +431,7 @@ export const NetflowOverview: React.FC<NetflowOverviewProps> = ({
               <MetricsGraphWithTotal
                 id={id}
                 metricType={metricType}
-                metricFunction="avg"
+                metricFunction="rate"
                 topKMetrics={topKMetrics}
                 totalMetric={namedTotalMetric}
                 totalDropMetric={namedTotalDroppedMetric}
@@ -387,7 +458,7 @@ export const NetflowOverview: React.FC<NetflowOverviewProps> = ({
         case 'state_dropped_packet_rates':
         case 'cause_dropped_packet_rates': {
           const isState = id === 'state_dropped_packet_rates';
-          const metricType = 'packets'; // TODO: consider adding bytes graphs here
+          const metricType = 'Packets'; // TODO: consider adding bytes graphs here
           const topKMetrics = isState ? getTopKDroppedStateMetrics() : getTopKDroppedCauseMetrics();
           const namedTotalMetric = getNamedTotalRateMetric(id);
           const options = getKebabOptions(id, {
@@ -408,7 +479,7 @@ export const NetflowOverview: React.FC<NetflowOverviewProps> = ({
                   subTitle={info.subtitle}
                   limit={limit}
                   metricType={metricType}
-                  metricFunction="avg"
+                  metricFunction="rate"
                   topKMetrics={topKMetrics}
                   totalMetric={namedTotalMetric}
                   showOthers={options.showOthers!}
@@ -421,7 +492,7 @@ export const NetflowOverview: React.FC<NetflowOverviewProps> = ({
                 <MetricsGraph
                   id={id}
                   metricType={metricType}
-                  metricFunction="avg"
+                  metricFunction="rate"
                   metrics={topKMetrics}
                   limit={limit}
                   showBar={false}
@@ -439,7 +510,7 @@ export const NetflowOverview: React.FC<NetflowOverviewProps> = ({
                 <MetricsGraphWithTotal
                   id={id}
                   metricType={metricType}
-                  metricFunction="avg"
+                  metricFunction="rate"
                   topKMetrics={topKMetrics}
                   totalMetric={namedTotalMetric}
                   limit={limit}
@@ -472,13 +543,13 @@ export const NetflowOverview: React.FC<NetflowOverviewProps> = ({
         case 'top_p99_rtt':
         case 'bottom_min_rtt': {
           const isAvg = id.includes('_avg_');
-          const metricType = id.endsWith('bytes')
-            ? 'bytes'
-            : id.endsWith('packets')
-            ? 'packets'
+          const metricType = id.endsWith('Bytes')
+            ? 'Bytes'
+            : id.endsWith('Packets')
+            ? 'Packets'
             : id.endsWith('dns_latency')
-            ? 'dnsLatencies'
-            : 'flowRtt';
+            ? 'DnsLatencyMs'
+            : 'TimeFlowRttNs';
           const metrics = getTopKMetrics(id);
           const namedTotalMetric = getNamedTotalMetric(id);
           const options = getKebabOptions(id, {
@@ -541,9 +612,9 @@ export const NetflowOverview: React.FC<NetflowOverviewProps> = ({
           };
         }
         case 'rcode_dns_latency_flows': {
-          const metricType = 'countDns'; // TODO: consider adding packets graphs here
+          const metricType = 'DnsFlows'; // TODO: consider adding packets graphs here
           const topKMetrics = getTopKDnsRCodeMetrics();
-          const namedTotalMetric = getNamedDnsCountTotalMetric();
+          const namedTotalMetric = getDnsCountTotalMetric();
           const options = getKebabOptions(id, {
             showNoError: true,
             showTop: true,
@@ -601,12 +672,76 @@ export const NetflowOverview: React.FC<NetflowOverviewProps> = ({
             doubleWidth: options.graph!.type !== 'donut'
           };
         }
+        default: {
+          const parsedId = parseCustomMetricId(id);
+          if (parsedId.isValid) {
+            const metricType = parsedId.type!;
+            const metricFunction = parsedId.fn || 'avg';
+            const topKMetrics = getNamedTopKCustomMetrics(id);
+            const namedTotalMetric = getNamedTotalCustomMetric(id);
+            const options = getKebabOptions(id, {
+              showTop: true,
+              showApp: { text: t('Show total'), value: true },
+              graph: { options: ['bar_line', 'donut'], type: 'donut' }
+            });
+            const isDonut = options!.graph!.type === 'donut';
+            const showTopOnly = isDonut || (options.showTop && !options.showApp!.value);
+            const showTotalOnly = !options.showTop && options.showApp!.value;
+            return {
+              calculatedTitle: showTopOnly ? info.topTitle : showTotalOnly ? info.totalTitle : undefined,
+              element:
+                !_.isEmpty(topKMetrics) && namedTotalMetric ? (
+                  isDonut ? (
+                    <MetricsDonut
+                      id={id}
+                      subTitle={info.subtitle}
+                      limit={limit}
+                      metricType={metricType}
+                      metricFunction={metricFunction}
+                      topKMetrics={topKMetrics}
+                      totalMetric={namedTotalMetric}
+                      showOthers={false}
+                      smallerTexts={smallerTexts}
+                      showLegend={!isFocus}
+                      animate={animate}
+                    />
+                  ) : (
+                    <MetricsGraphWithTotal
+                      id={id}
+                      metricType={metricType}
+                      metricFunction={metricFunction}
+                      topKMetrics={topKMetrics}
+                      totalMetric={namedTotalMetric}
+                      limit={limit}
+                      topAsBars={true}
+                      showTop={options.showTop!}
+                      showTotal={options.showApp!.value}
+                      showOthers={false}
+                      smallerTexts={smallerTexts}
+                      showTotalDrop={false}
+                      showLegend={!isFocus}
+                      animate={animate}
+                    />
+                  )
+                ) : (
+                  emptyGraph()
+                ),
+              kebab: <PanelKebab id={id} options={options} setOptions={opts => setKebabOptions(id, opts)} />,
+              bodyClassSmall: options.graph!.type === 'donut',
+              doubleWidth: options.graph!.type !== 'donut'
+            };
+          } else {
+            return {
+              element: <></>
+            };
+          }
+        }
       }
     },
     [
       emptyGraph,
       getKebabOptions,
-      getNamedDnsCountTotalMetric,
+      getDnsCountTotalMetric,
       getNamedTotalMetric,
       getNamedTotalRateMetric,
       getNoInternalTopKRateMetrics,
@@ -615,6 +750,8 @@ export const NetflowOverview: React.FC<NetflowOverviewProps> = ({
       getTopKDroppedStateMetrics,
       getTopKMetrics,
       getTopKRateMetrics,
+      getNamedTopKCustomMetrics,
+      getNamedTotalCustomMetric,
       isDark,
       limit,
       setKebabOptions,
@@ -672,7 +809,7 @@ export const NetflowOverview: React.FC<NetflowOverviewProps> = ({
       recordType,
       wasAllowFocus,
       previousSelectedPanel,
-      selectedPanel?.id,
+      selectedPanel,
       panels,
       allowFocus,
       getPanelContent,

--- a/web/src/components/netflow-overview/netflow-overview.tsx
+++ b/web/src/components/netflow-overview/netflow-overview.tsx
@@ -704,6 +704,7 @@ export const NetflowOverview: React.FC<NetflowOverviewProps> = ({
                       smallerTexts={smallerTexts}
                       showLegend={!isFocus}
                       animate={animate}
+                      isDark={isDark}
                     />
                   ) : (
                     <MetricsGraphWithTotal
@@ -721,6 +722,7 @@ export const NetflowOverview: React.FC<NetflowOverviewProps> = ({
                       showTotalDrop={false}
                       showLegend={!isFocus}
                       animate={animate}
+                      isDark={isDark}
                     />
                   )
                 ) : (

--- a/web/src/components/netflow-record/record-field.tsx
+++ b/web/src/components/netflow-record/record-field.tsx
@@ -306,24 +306,24 @@ export const RecordField: React.FC<{
         );
       case ColumnsId.addrport:
         return doubleContainer(
-          ipPortContent(flow.fields.SrcAddr, flow.fields.SrcPort || NaN),
-          ipPortContent(flow.fields.DstAddr, flow.fields.DstPort || NaN)
+          ipPortContent(flow.fields.SrcAddr || '', flow.fields.SrcPort || NaN),
+          ipPortContent(flow.fields.DstAddr || '', flow.fields.DstPort || NaN)
         );
       case ColumnsId.srcaddrport:
-        return singleContainer(ipPortContent(flow.fields.SrcAddr, flow.fields.SrcPort || NaN));
+        return singleContainer(ipPortContent(flow.fields.SrcAddr || '', flow.fields.SrcPort || NaN));
       case ColumnsId.dstaddrport:
-        return singleContainer(ipPortContent(flow.fields.DstAddr, flow.fields.DstPort || NaN));
+        return singleContainer(ipPortContent(flow.fields.DstAddr || '', flow.fields.DstPort || NaN));
       case ColumnsId.kubeobject:
         return doubleContainer(
           explicitKubeObjContent(
-            flow.fields.SrcAddr,
+            flow.fields.SrcAddr || '',
             flow.fields.SrcPort || NaN,
             flow.labels.SrcK8S_Type,
             flow.labels.SrcK8S_Namespace,
             flow.fields.SrcK8S_Name
           ),
           explicitKubeObjContent(
-            flow.fields.DstAddr,
+            flow.fields.DstAddr || '',
             flow.fields.DstPort || NaN,
             flow.labels.DstK8S_Type,
             flow.labels.DstK8S_Namespace,
@@ -333,7 +333,7 @@ export const RecordField: React.FC<{
       case ColumnsId.srckubeobject:
         return singleContainer(
           explicitKubeObjContent(
-            flow.fields.SrcAddr,
+            flow.fields.SrcAddr || '',
             flow.fields.SrcPort || NaN,
             flow.labels.SrcK8S_Type,
             flow.labels.SrcK8S_Namespace,
@@ -343,7 +343,7 @@ export const RecordField: React.FC<{
       case ColumnsId.dstkubeobject:
         return singleContainer(
           explicitKubeObjContent(
-            flow.fields.DstAddr,
+            flow.fields.DstAddr || '',
             flow.fields.DstPort || NaN,
             flow.labels.DstK8S_Type,
             flow.labels.DstK8S_Namespace,
@@ -353,14 +353,14 @@ export const RecordField: React.FC<{
       case ColumnsId.ownerkubeobject:
         return doubleContainer(
           explicitKubeObjContent(
-            flow.fields.SrcAddr,
+            flow.fields.SrcAddr || '',
             flow.fields.SrcPort || NaN,
             flow.fields.SrcK8S_OwnerType,
             flow.labels.SrcK8S_Namespace,
             flow.labels.SrcK8S_OwnerName
           ),
           explicitKubeObjContent(
-            flow.fields.DstAddr,
+            flow.fields.DstAddr || '',
             flow.fields.DstPort || NaN,
             flow.fields.DstK8S_OwnerType,
             flow.labels.DstK8S_Namespace,
@@ -370,7 +370,7 @@ export const RecordField: React.FC<{
       case ColumnsId.srcownerkubeobject:
         return singleContainer(
           explicitKubeObjContent(
-            flow.fields.SrcAddr,
+            flow.fields.SrcAddr || '',
             flow.fields.SrcPort || NaN,
             flow.fields.SrcK8S_OwnerType,
             flow.labels.SrcK8S_Namespace,
@@ -380,7 +380,7 @@ export const RecordField: React.FC<{
       case ColumnsId.dstownerkubeobject:
         return singleContainer(
           explicitKubeObjContent(
-            flow.fields.DstAddr,
+            flow.fields.DstAddr || '',
             flow.fields.DstPort || NaN,
             flow.fields.DstK8S_OwnerType,
             flow.labels.DstK8S_Namespace,
@@ -417,7 +417,7 @@ export const RecordField: React.FC<{
       case ColumnsId.proto: {
         if (typeof value === 'number' && !isNaN(value)) {
           const docUrl = getProtocolDocUrl();
-          const protocolName = formatProtocol(value as number);
+          const protocolName = formatProtocol(value as number, t);
           return singleContainer(
             detailed
               ? clickableContent(protocolName, `${t('Value')}: ${value}`, docUrl)
@@ -456,7 +456,7 @@ export const RecordField: React.FC<{
           } else {
             child = errorTextValue(
               String(value[1]),
-              t('ICMP type provided but protocol is {{proto}}', { proto: formatProtocol(value[0] as number) })
+              t('ICMP type provided but protocol is {{proto}}', { proto: formatProtocol(value[0] as number, t) })
             );
           }
         }
@@ -479,7 +479,7 @@ export const RecordField: React.FC<{
           } else {
             child = errorTextValue(
               String(value[1]),
-              t('ICMP code provided but protocol is {{proto}}', { proto: formatProtocol(value[0] as number) })
+              t('ICMP code provided but protocol is {{proto}}', { proto: formatProtocol(value[0] as number, t) })
             );
           }
         }

--- a/web/src/components/netflow-table/__tests__/netflow-table.spec.tsx
+++ b/web/src/components/netflow-table/__tests__/netflow-table.spec.tsx
@@ -68,7 +68,7 @@ describe('<NetflowTable />', () => {
     expect(wrapper.find(NetflowTable)).toBeTruthy();
 
     const timestampIdx = ShuffledColumnSample.findIndex(c => c.id === ColumnsId.endtime);
-    let expectedDate = new Date(FlowsSample[2].fields.TimeFlowEndMs);
+    let expectedDate = new Date(FlowsSample[2].fields.TimeFlowEndMs || '');
     // table should be sorted by date asc by default
     expect(wrapper.find(NetflowTableRow).find(Td).at(timestampIdx).find('.datetime').at(0).text()).toBe(
       getFormattedDate(expectedDate, dateTimeMSFormatter)
@@ -78,7 +78,7 @@ describe('<NetflowTable />', () => {
       return node.type() === 'button' && node.text() === 'End Time';
     });
     button.simulate('click');
-    expectedDate = new Date(FlowsSample[1].fields.TimeFlowEndMs);
+    expectedDate = new Date(FlowsSample[1].fields.TimeFlowEndMs || '');
     // then should sort date desc on click
     expect(wrapper.find(NetflowTableRow).find(Td).at(timestampIdx).find('.datetime').at(0).text()).toBe(
       getFormattedDate(expectedDate, dateTimeMSFormatter)

--- a/web/src/components/netflow-topology/2d/topology-content.tsx
+++ b/web/src/components/netflow-topology/2d/topology-content.tsx
@@ -20,7 +20,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { TopologyMetrics } from '../../../api/loki';
 import { Filter, FilterDefinition, Filters } from '../../../model/filters';
-import { MetricFunction, FlowScope, MetricType } from '../../../model/flow-query';
+import { StatFunction, FlowScope, MetricType } from '../../../model/flow-query';
 import { MetricScopeOptions, getStat } from '../../../model/metrics';
 import {
   Decorated,
@@ -51,7 +51,7 @@ const FIT_PADDING = 80;
 
 export const TopologyContent: React.FC<{
   k8sModels: { [key: string]: K8sModel };
-  metricFunction: MetricFunction;
+  metricFunction: StatFunction;
   metricType: MetricType;
   metricScope: FlowScope;
   setMetricScope: (ms: FlowScope) => void;

--- a/web/src/components/netflow-topology/3d/three-d-topology-content.tsx
+++ b/web/src/components/netflow-topology/3d/three-d-topology-content.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { TopologyMetrics } from '../../../api/loki';
 import { SearchHandle, SearchEvent } from '../../../components/search/search';
 import { Filter } from '../../../model/filters';
-import { MetricFunction, MetricType, FlowScope } from '../../../model/flow-query';
+import { StatFunction, MetricType, FlowScope } from '../../../model/flow-query';
 import { TopologyOptions, GraphElementPeer, NodeData } from '../../../model/topology';
 import * as RTTopology from '@jpinsonneau/react-three-topology';
 import _ from 'lodash';
@@ -14,7 +14,7 @@ import { createPeer } from '../../../utils/metrics';
 
 export const ThreeDTopologyContent: React.FC<{
   k8sModels: { [key: string]: K8sModel };
-  metricFunction: MetricFunction;
+  metricFunction: StatFunction;
   metricType: MetricType;
   metricScope: FlowScope;
   setMetricScope: (ms: FlowScope) => void;

--- a/web/src/components/netflow-topology/__tests__/element-panel.spec.tsx
+++ b/web/src/components/netflow-topology/__tests__/element-panel.spec.tsx
@@ -37,7 +37,7 @@ describe('<ElementPanel />', () => {
     element: getNode('Pod', 'loki-distributor-loki-76598c8449-csmh2', '10.129.0.15'),
     metrics: dataSample as TopologyMetrics[],
     droppedMetrics: [],
-    metricType: 'bytes' as MetricType,
+    metricType: 'Bytes' as MetricType,
     metricScope: 'resource' as FlowScope,
     filters: [] as Filter[],
     filterDefinitions: FilterDefinitionSample,

--- a/web/src/components/netflow-topology/__tests__/netflow-topology.spec.tsx
+++ b/web/src/components/netflow-topology/__tests__/netflow-topology.spec.tsx
@@ -3,7 +3,7 @@ import { TopologyView, VisualizationSurface } from '@patternfly/react-topology';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { TopologyMetrics } from '../../../api/loki';
-import { MetricFunction, FlowScope, MetricType } from '../../../model/flow-query';
+import { StatFunction, FlowScope, MetricType } from '../../../model/flow-query';
 import { DefaultOptions, LayoutName } from '../../../model/topology';
 import { defaultTimeRange } from '../../../utils/router';
 import { NetflowTopology } from '../netflow-topology';
@@ -18,8 +18,8 @@ describe('<NetflowTopology />', () => {
     loading: false,
     k8sModels: {},
     range: defaultTimeRange,
-    metricFunction: 'sum' as MetricFunction,
-    metricType: 'bytes' as MetricType,
+    metricFunction: 'sum' as StatFunction,
+    metricType: 'Bytes' as MetricType,
     metricScope: 'host' as FlowScope,
     setMetricScope: jest.fn(),
     metrics: [] as TopologyMetrics[],

--- a/web/src/components/netflow-topology/element-panel-metrics.tsx
+++ b/web/src/components/netflow-topology/element-panel-metrics.tsx
@@ -57,9 +57,9 @@ export const ElementPanelMetrics: React.FC<{
 
   const getChartTitle = React.useCallback(() => {
     switch (metricType) {
-      case 'dnsLatencies':
+      case 'DnsLatencyMs':
         return t('Top 5 DNS latency');
-      case 'flowRtt':
+      case 'TimeFlowRttNs':
         return t('Top 5 flow RTT');
       default:
         return t('Top 5 rates');

--- a/web/src/components/netflow-topology/element-panel-stats.tsx
+++ b/web/src/components/netflow-topology/element-panel-stats.tsx
@@ -68,10 +68,12 @@ export const ElementPanelStats: React.FC<{
           <Text id="metrics-stats-in">{isEdge ? t('A -> B') : t('In')}</Text>
         </FlexItem>
         <FlexItem>
-          <Text id="metrics-stats-avg-in">{getFormattedValue(averageIn, metricType, 'avg', t)}</Text>
+          <Text id="metrics-stats-avg-in">{getFormattedValue(averageIn, metricType, isTime ? 'avg' : 'rate', t)}</Text>
         </FlexItem>
         <FlexItem>
-          <Text id="metrics-stats-latest-in">{getFormattedValue(latestIn, metricType, 'last', t)}</Text>
+          <Text id="metrics-stats-latest-in">
+            {getFormattedValue(latestIn, metricType, isTime ? 'avg' : 'rate', t)}
+          </Text>
         </FlexItem>
         {!isTime ? (
           <FlexItem>
@@ -86,10 +88,14 @@ export const ElementPanelStats: React.FC<{
           <Text id="metrics-stats-out">{isEdge ? t('B -> A') : t('Out')}</Text>
         </FlexItem>
         <FlexItem>
-          <Text id="metrics-stats-avg-out">{getFormattedValue(averageOut, metricType, 'avg', t)}</Text>
+          <Text id="metrics-stats-avg-out">
+            {getFormattedValue(averageOut, metricType, isTime ? 'avg' : 'rate', t)}
+          </Text>
         </FlexItem>
         <FlexItem>
-          <Text id="metrics-stats-latest-out">{getFormattedValue(latestOut, metricType, 'last', t)}</Text>
+          <Text id="metrics-stats-latest-out">
+            {getFormattedValue(latestOut, metricType, isTime ? 'avg' : 'rate', t)}
+          </Text>
         </FlexItem>
         {!isTime ? (
           <FlexItem>
@@ -105,10 +111,14 @@ export const ElementPanelStats: React.FC<{
         </FlexItem>
 
         <FlexItem>
-          <Text id="metrics-stats-avg-both">{getFormattedValue(averageBoth, metricType, 'avg', t)}</Text>
+          <Text id="metrics-stats-avg-both">
+            {getFormattedValue(averageBoth, metricType, isTime ? 'avg' : 'rate', t)}
+          </Text>
         </FlexItem>
         <FlexItem>
-          <Text id="metrics-stats-latest-both">{getFormattedValue(latestBoth, metricType, 'last', t)}</Text>
+          <Text id="metrics-stats-latest-both">
+            {getFormattedValue(latestBoth, metricType, isTime ? 'avg' : 'rate', t)}
+          </Text>
         </FlexItem>
         {!isTime ? (
           <FlexItem>

--- a/web/src/components/netflow-topology/netflow-topology.tsx
+++ b/web/src/components/netflow-topology/netflow-topology.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { TopologyMetrics } from '../../api/loki';
 import { Filter, FilterDefinition, Filters } from '../../model/filters';
-import { MetricFunction, FlowScope, MetricType } from '../../model/flow-query';
+import { StatFunction, FlowScope, MetricType } from '../../model/flow-query';
 import { GraphElementPeer, LayoutName, TopologyOptions } from '../../model/topology';
 import LokiError from '../messages/loki-error';
 import { SearchEvent, SearchHandle } from '../search/search';
@@ -22,7 +22,7 @@ export const NetflowTopology: React.FC<{
   loading?: boolean;
   k8sModels: { [key: string]: K8sModel };
   error?: string;
-  metricFunction: MetricFunction;
+  metricFunction: StatFunction;
   metricType: MetricType;
   metricScope: FlowScope;
   setMetricScope: (ms: FlowScope) => void;

--- a/web/src/components/query-summary/__tests__/flows-query-summary.spec.tsx
+++ b/web/src/components/query-summary/__tests__/flows-query-summary.spec.tsx
@@ -12,7 +12,7 @@ describe('<FlowsQuerySummary />', () => {
     toggleQuerySummary: jest.fn(),
     flows: FlowsSample,
     type: 'flowLog' as RecordType,
-    metricType: 'bytes' as MetricType,
+    metricType: 'Bytes' as MetricType,
     stats: {
       limitReached: false,
       numQueries: 1

--- a/web/src/components/query-summary/metrics-query-summary.tsx
+++ b/web/src/components/query-summary/metrics-query-summary.tsx
@@ -9,7 +9,14 @@ import { valueFormat } from '../../utils/format';
 import './query-summary.css';
 import StatsQuerySummary from './stats-query-summary';
 
-const EXPOSED_METRICS: MetricType[] = ['bytes', 'packets', 'droppedBytes', 'droppedPackets', 'dnsLatencies', 'flowRtt'];
+const EXPOSED_METRICS: MetricType[] = [
+  'Bytes',
+  'Packets',
+  'PktDropBytes',
+  'PktDropPackets',
+  'DnsLatencyMs',
+  'TimeFlowRttNs'
+];
 
 export const MetricsQuerySummaryContent: React.FC<{
   metrics: NetflowMetrics;
@@ -43,15 +50,15 @@ export const MetricsQuerySummaryContent: React.FC<{
   const getMetrics = React.useCallback(
     (metricType: MetricType) => {
       switch (metricType) {
-        case 'bytes':
-        case 'packets':
+        case 'Bytes':
+        case 'Packets':
           return metrics.rateMetrics?.[getRateMetricKey(metricType)];
-        case 'droppedBytes':
-        case 'droppedPackets':
+        case 'PktDropBytes':
+        case 'PktDropPackets':
           return metrics.droppedRateMetrics?.[getRateMetricKey(metricType)];
-        case 'dnsLatencies':
+        case 'DnsLatencyMs':
           return metrics.dnsLatencyMetrics?.avg;
-        case 'flowRtt':
+        case 'TimeFlowRttNs':
           return metrics.rttMetrics?.avg;
         default:
           return undefined;
@@ -63,15 +70,15 @@ export const MetricsQuerySummaryContent: React.FC<{
   const getAppMetrics = React.useCallback(
     (metricType: MetricType) => {
       switch (metricType) {
-        case 'bytes':
-        case 'packets':
+        case 'Bytes':
+        case 'Packets':
           return metrics.totalRateMetric?.[getRateMetricKey(metricType)];
-        case 'droppedBytes':
-        case 'droppedPackets':
+        case 'PktDropBytes':
+        case 'PktDropPackets':
           return metrics.totalDroppedRateMetric?.[getRateMetricKey(metricType)];
-        case 'dnsLatencies':
+        case 'DnsLatencyMs':
           return metrics.totalDnsLatencyMetric?.avg;
-        case 'flowRtt':
+        case 'TimeFlowRttNs':
           return metrics.totalRttMetric?.avg;
         default:
           return undefined;
@@ -91,10 +98,10 @@ export const MetricsQuerySummaryContent: React.FC<{
       const absTotal = metrics.map(m => m.stats.total).reduce((prev, cur) => prev + cur, 0);
 
       switch (metricType) {
-        case 'bytes':
-        case 'droppedBytes': {
-          const textColor = metricType === 'droppedBytes' ? (isDark ? '#C9190B' : '#A30000') : undefined;
-          const droppedText = metricType === 'droppedBytes' ? ' ' + t('dropped') : '';
+        case 'Bytes':
+        case 'PktDropBytes': {
+          const textColor = metricType === 'PktDropBytes' ? (isDark ? '#C9190B' : '#A30000') : undefined;
+          const droppedText = metricType === 'PktDropBytes' ? ' ' + t('dropped') : '';
           const textAbs = appMetrics
             ? `${t('Filtered sum of top-k bytes')}${droppedText} / ${t('Filtered total bytes')}${droppedText}`
             : `${t('Filtered sum of top-k bytes')}${droppedText}`;
@@ -111,7 +118,7 @@ export const MetricsQuerySummaryContent: React.FC<{
             <FlexItem key={`${metricType}Count`}>
               <Tooltip content={<Text component={TextVariants.p}>{textAbs}</Text>}>
                 <div className="stats-query-summary-container">
-                  <Text id={`${metricType}Count`} component={TextVariants.p} style={{ color: textColor }}>
+                  <Text id={`${_.lowerFirst(metricType)}Count`} component={TextVariants.p} style={{ color: textColor }}>
                     {valAbs}
                   </Text>
                 </div>
@@ -121,7 +128,11 @@ export const MetricsQuerySummaryContent: React.FC<{
               <Tooltip content={<Text component={TextVariants.p}>{textRate}</Text>}>
                 <div className="stats-query-summary-container-with-icon">
                   <TachometerAltIcon />
-                  <Text id={`${metricType}PerSecondsCount`} component={TextVariants.p} style={{ color: textColor }}>
+                  <Text
+                    id={`${_.lowerFirst(metricType)}PerSecondsCount`}
+                    component={TextVariants.p}
+                    style={{ color: textColor }}
+                  >
                     {valRate}
                   </Text>
                 </div>
@@ -129,20 +140,20 @@ export const MetricsQuerySummaryContent: React.FC<{
             </FlexItem>
           ];
         }
-        case 'packets':
-        case 'droppedPackets': {
-          const textColor = metricType === 'droppedPackets' ? (isDark ? '#C9190B' : '#A30000') : undefined;
-          const droppedText = metricType === 'droppedPackets' ? ' ' + t('dropped') : '';
+        case 'Packets':
+        case 'PktDropPackets': {
+          const textColor = metricType === 'PktDropPackets' ? (isDark ? '#C9190B' : '#A30000') : undefined;
+          const droppedText = metricType === 'PktDropPackets' ? ' ' + t('dropped') : '';
           const textAbs = appMetrics
             ? `${t('Filtered sum of top-k packets')}${droppedText} / ${t('Filtered total packets')}${droppedText}`
             : `${t('Filtered sum of top-k packets')}${droppedText}`;
           const valAbs =
-            (appMetrics ? `${absTotal} / ${appMetrics.stats.total}` : String(absTotal)) + ' ' + t('packets');
+            (appMetrics ? `${absTotal} / ${appMetrics.stats.total}` : String(absTotal)) + ' ' + t('Packets');
           return [
             <FlexItem key={`${metricType}Count`}>
               <Tooltip content={<Text component={TextVariants.p}>{textAbs}</Text>}>
                 <div className="stats-query-summary-container">
-                  <Text id={`${metricType}Count`} component={TextVariants.p} style={{ color: textColor }}>
+                  <Text id={`${_.lowerFirst(metricType)}Count`} component={TextVariants.p} style={{ color: textColor }}>
                     {valAbs}
                   </Text>
                 </div>
@@ -150,7 +161,7 @@ export const MetricsQuerySummaryContent: React.FC<{
             </FlexItem>
           ];
         }
-        case 'dnsLatencies': {
+        case 'DnsLatencyMs': {
           const textAvg = appMetrics
             ? `${t('Filtered avg DNS Latency')} | ${t('Filtered overall avg DNS Latency')}`
             : t('Filtered avg DNS Latency');
@@ -170,7 +181,7 @@ export const MetricsQuerySummaryContent: React.FC<{
             </FlexItem>
           ];
         }
-        case 'flowRtt': {
+        case 'TimeFlowRttNs': {
           const textAvg = appMetrics ? `${t('Filtered avg RTT')} | ${t('Overall avg RTT')}` : t('Filtered avg RTT');
           const valAvg = appMetrics
             ? `${valueFormat(avgSum / metrics.length, 2, t('ms'))} | ${valueFormat(appMetrics.stats.avg, 2, t('ms'))}`

--- a/web/src/components/query-summary/summary-panel.tsx
+++ b/web/src/components/query-summary/summary-panel.tsx
@@ -228,7 +228,9 @@ export const SummaryPanelContent: React.FC<{
           typesCardinality.push(tc);
         });
 
-      addresses = Array.from(new Set(flows.map(f => f.fields.SrcAddr).concat(flows.map(f => f.fields.DstAddr))));
+      addresses = Array.from(
+        new Set(flows.map(f => f.fields.SrcAddr || '').concat(flows.map(f => f.fields.DstAddr || '')))
+      );
       ports = Array.from(
         new Set(
           flows
@@ -237,7 +239,7 @@ export const SummaryPanelContent: React.FC<{
             .concat(flows.filter(f => f.fields.DstPort).map(f => f.fields.DstPort)) as number[]
         )
       );
-      protocols = Array.from(new Set(flows.map(f => f.fields.Proto)));
+      protocols = Array.from(new Set(flows.map(f => f.fields.Proto || NaN)));
     } else if (rateMetrics) {
       function manageTypeCardinality(hostName?: string, namespace?: string, type?: string, name?: string) {
         if (namespace && !namespaces.includes(namespace)) {
@@ -326,7 +328,7 @@ export const SummaryPanelContent: React.FC<{
                 'protocols',
                 t('{{count}} Protocol(s)', { count: protocols.length }),
                 listCardinalityContent(
-                  protocols.map(p => formatProtocol(p)),
+                  protocols.map(p => formatProtocol(p, t)),
                   compareStrings
                 )
               )
@@ -367,12 +369,14 @@ export const SummaryPanelContent: React.FC<{
   const timeContent = () => {
     const filteredFlows = flows || [];
     const duration = filteredFlows.length
-      ? filteredFlows.map(f => f.fields.TimeFlowEndMs - f.fields.TimeFlowStartMs).reduce((a, b) => a + b, 0) /
-        filteredFlows.length
+      ? filteredFlows
+          .map(f => (f.fields.TimeFlowEndMs || 0) - (f.fields.TimeFlowStartMs || 0))
+          .reduce((a, b) => a + b, 0) / filteredFlows.length
       : 0;
     const collectionLatency = filteredFlows.length
-      ? filteredFlows.map(f => f.fields.TimeReceived * 1000 - f.fields.TimeFlowEndMs).reduce((a, b) => a + b, 0) /
-        filteredFlows.length
+      ? filteredFlows
+          .map(f => (f.fields.TimeReceived || 0) * 1000 - (f.fields.TimeFlowEndMs || 0))
+          .reduce((a, b) => a + b, 0) / filteredFlows.length
       : 0;
 
     return flows && flows.length ? (

--- a/web/src/model/config.ts
+++ b/web/src/model/config.ts
@@ -19,6 +19,7 @@ export type Config = {
     enable: boolean;
     portNames: Map<string, string>;
   };
+  panels: string[];
   columns: ColumnConfigDef[];
   quickFilters: RawQuickFilter[];
   filters: FilterConfigDef[];
@@ -37,6 +38,7 @@ export const defaultConfig: Config = {
     enable: true,
     portNames: new Map()
   },
+  panels: [],
   columns: [],
   quickFilters: [],
   filters: [],

--- a/web/src/model/flow-query.ts
+++ b/web/src/model/flow-query.ts
@@ -1,21 +1,14 @@
+import { Field } from '../api/ipfix';
 import { Filter } from './filters';
 
 export type RecordType = 'allConnections' | 'newConnection' | 'heartbeat' | 'endConnection' | 'flowLog';
 export type Match = 'all' | 'any';
 export type PacketLoss = 'dropped' | 'hasDrops' | 'sent' | 'all';
-export type MetricFunction = 'sum' | 'avg' | 'min' | 'max' | 'last' | 'p90' | 'p99';
-export type MetricType =
-  | 'count'
-  | 'countDns'
-  | 'bytes'
-  | 'packets'
-  | 'droppedBytes'
-  | 'droppedPackets'
-  | 'dnsLatencies'
-  | 'flowRtt';
+export type MetricFunction = 'count' | 'sum' | 'avg' | 'min' | 'max' | 'p90' | 'p99' | 'rate';
+export type StatFunction = MetricFunction | 'last';
+export type MetricType = 'Flows' | 'DnsFlows' | Field;
 export type FlowScope = 'app' | 'cluster' | 'zone' | 'host' | 'namespace' | 'owner' | 'resource';
-export type GenericAggregation = 'droppedCause' | 'droppedState' | 'dnsRCode';
-export type AggregateBy = FlowScope | GenericAggregation;
+export type AggregateBy = FlowScope | Field;
 export type NodeType = FlowScope | 'unknown';
 export type Groups =
   | 'clusters'

--- a/web/src/model/metrics.ts
+++ b/web/src/model/metrics.ts
@@ -1,5 +1,5 @@
 import { MetricStats } from '../api/loki';
-import { MetricFunction } from './flow-query';
+import { StatFunction } from './flow-query';
 import { PERCENTILE_VALUES } from '../utils/metrics';
 
 export enum MetricScopeOptions {
@@ -11,8 +11,12 @@ export enum MetricScopeOptions {
   RESOURCE = 'resource'
 }
 
-export const getStat = (stats: MetricStats, mf: MetricFunction): number => {
+export const getStat = (stats: MetricStats, mf: StatFunction): number => {
   switch (mf) {
+    case 'count':
+    case 'sum':
+      return stats.total;
+    case 'rate':
     case 'avg':
       return stats.avg;
     case 'min':
@@ -21,8 +25,6 @@ export const getStat = (stats: MetricStats, mf: MetricFunction): number => {
       return stats.max;
     case 'last':
       return stats.latest;
-    case 'sum':
-      return stats.total;
     case 'p90':
       return stats.percentiles[PERCENTILE_VALUES.indexOf(90)];
     case 'p99':

--- a/web/src/model/topology.ts
+++ b/web/src/model/topology.ts
@@ -21,7 +21,7 @@ import { TFunction } from 'i18next';
 import { K8sModel } from '@openshift-console/dynamic-plugin-sdk';
 import { getTopologyEdgeId } from '../utils/ids';
 import { getStat, MetricScopeOptions } from './metrics';
-import { MetricFunction, FlowScope, MetricType, NodeType } from './flow-query';
+import { StatFunction, FlowScope, MetricType, NodeType, MetricFunction } from './flow-query';
 import { createPeer, getFormattedValue } from '../utils/metrics';
 import { TruncateLength } from '../components/dropdowns/truncate-dropdown';
 
@@ -103,7 +103,7 @@ export interface TopologyOptions {
   groupTypes: TopologyGroupTypes;
   lowScale: number;
   medScale: number;
-  metricFunction: MetricFunction;
+  metricFunction: StatFunction;
   metricType: MetricType;
 }
 
@@ -389,7 +389,14 @@ const getEdgeStyle = (count: number) => {
 
 const getEdgeTag = (value: number, options: TopologyOptions, t: TFunction) => {
   if (options.edgeTags && value) {
-    return getFormattedValue(value, options.metricType, options.metricFunction, t);
+    let metricFunction = options.metricFunction as MetricFunction;
+    if (
+      options.metricFunction !== 'sum' &&
+      ['Bytes', 'Packets', 'PktDropBytes', 'PktDropPackets'].includes(options.metricType)
+    ) {
+      metricFunction = 'rate';
+    }
+    return getFormattedValue(value, options.metricType, metricFunction, t);
   }
   return undefined;
 };

--- a/web/src/utils/__tests__/metrics.spec.ts
+++ b/web/src/utils/__tests__/metrics.spec.ts
@@ -399,26 +399,26 @@ describe('parseTopologyMetrics', () => {
 
 describe('getFormattedValue', () => {
   it('should format BPS', () => {
-    expect(getFormattedValue(500, 'bytes', 'last', t)).toBe('500 Bps');
-    expect(getFormattedValue(1300, 'bytes', 'avg', t)).toBe('1.3 kBps');
-    expect(getFormattedValue(10500, 'bytes', 'max', t)).toBe('10.5 kBps');
-    expect(getFormattedValue(1500000, 'bytes', 'avg', t)).toBe('1.5 MBps');
+    expect(getFormattedValue(500, 'Bytes', 'rate', t)).toBe('500 Bps');
+    expect(getFormattedValue(1300, 'Bytes', 'rate', t)).toBe('1.3 kBps');
+    expect(getFormattedValue(10500, 'Bytes', 'rate', t)).toBe('10.5 kBps');
+    expect(getFormattedValue(1500000, 'Bytes', 'rate', t)).toBe('1.5 MBps');
   });
 
   it('should format absolute bytes', () => {
-    expect(getFormattedValue(500, 'bytes', 'sum', t)).toBe('500 B');
-    expect(getFormattedValue(10500, 'bytes', 'sum', t)).toBe('10.5 kB');
+    expect(getFormattedValue(500, 'Bytes', 'sum', t)).toBe('500 B');
+    expect(getFormattedValue(10500, 'Bytes', 'sum', t)).toBe('10.5 kB');
   });
 
   it('should format packets rate', () => {
-    expect(getFormattedValue(500, 'packets', 'last', t)).toBe('500 Pps');
-    expect(getFormattedValue(1300, 'packets', 'avg', t)).toBe('1.3 kPps');
-    expect(getFormattedValue(10500, 'packets', 'max', t)).toBe('10.5 kPps');
-    expect(getFormattedValue(1500000, 'packets', 'avg', t)).toBe('1.5 MPps');
+    expect(getFormattedValue(500, 'Packets', 'rate', t)).toBe('500 Pps');
+    expect(getFormattedValue(1300, 'Packets', 'rate', t)).toBe('1.3 kPps');
+    expect(getFormattedValue(10500, 'Packets', 'rate', t)).toBe('10.5 kPps');
+    expect(getFormattedValue(1500000, 'Packets', 'rate', t)).toBe('1.5 MPps');
   });
 
   it('should format absolute packets', () => {
-    expect(getFormattedValue(500, 'packets', 'sum', t)).toBe('500 P');
-    expect(getFormattedValue(10500, 'packets', 'sum', t)).toBe('10.5 kP');
+    expect(getFormattedValue(500, 'Packets', 'sum', t)).toBe('500 P');
+    expect(getFormattedValue(10500, 'Packets', 'sum', t)).toBe('10.5 kP');
   });
 });

--- a/web/src/utils/__tests__/protocol.spec.ts
+++ b/web/src/utils/__tests__/protocol.spec.ts
@@ -3,9 +3,9 @@ import { FilterDefinitionSample } from '../../components/__tests-data__/filters'
 
 describe('formatProtocol', () => {
   it('should format protocol', () => {
-    expect(formatProtocol(6)).toEqual('TCP');
-    expect(formatProtocol(17)).toEqual('UDP');
-    expect(formatProtocol(0)).toEqual('HOPOPT');
+    expect(formatProtocol(6, v => v)).toEqual('TCP');
+    expect(formatProtocol(17, v => v)).toEqual('UDP');
+    expect(formatProtocol(0, v => v)).toEqual('HOPOPT');
   });
 });
 

--- a/web/src/utils/local-storage-hook.ts
+++ b/web/src/utils/local-storage-hook.ts
@@ -35,6 +35,11 @@ export interface ArraySelectionOptions {
   criteria: string;
 }
 
+export const DEFAULT_ARRAY_SELECTION_OPTIONS = {
+  id: 'id',
+  criteria: 'isSelected'
+};
+
 export function useLocalStorage<T>(
   key: string,
   initialValue?: T,

--- a/web/src/utils/protocol.ts
+++ b/web/src/utils/protocol.ts
@@ -1,3 +1,4 @@
+import { TFunction } from 'i18next';
 import protocols from 'protocol-numbers';
 import { compareStrings } from './base-compare';
 
@@ -5,11 +6,11 @@ export const getProtocolDocUrl = () => {
   return 'https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml';
 };
 
-export const formatProtocol = (p: number) => {
+export const formatProtocol = (p: number, t: TFunction) => {
   if (p !== undefined && protocols[p]) {
     return protocols[p].name;
   } else {
-    return 'N/A';
+    return t('n/a');
   }
 };
 

--- a/web/src/utils/router.ts
+++ b/web/src/utils/router.ts
@@ -1,6 +1,6 @@
 import { findFilter } from './filter-definitions';
 import { TimeRange } from './datetime';
-import { Match, MetricFunction, MetricType, PacketLoss, RecordType } from '../model/flow-query';
+import { Match, StatFunction, MetricType, PacketLoss, RecordType } from '../model/flow-query';
 import {
   getURLParam,
   getURLParamAsBool,
@@ -27,8 +27,8 @@ export const defaultTimeRange = 300;
 export const defaultRecordType: RecordType = 'flowLog';
 export const defaultMatch: Match = 'all';
 export const defaultPacketLoss: PacketLoss = 'all';
-export const defaultMetricFunction: MetricFunction = 'last';
-export const defaultMetricType: MetricType = 'bytes';
+export const defaultMetricFunction: StatFunction = 'last';
+export const defaultMetricType: MetricType = 'Bytes';
 const defaultShowDuplicates = false;
 
 export const getRangeFromURL = (): number | TimeRange => {
@@ -165,7 +165,7 @@ export const setURLPacketLoss = (pl: PacketLoss, replace?: boolean) => {
   setURLParam(URLParam.PacketLoss, pl), replace;
 };
 
-export const setURLMetricFunction = (metricFunction?: MetricFunction, replace?: boolean) => {
+export const setURLMetricFunction = (metricFunction?: StatFunction, replace?: boolean) => {
   if (metricFunction) {
     setURLParam(URLParam.MetricFunction, metricFunction, replace);
   } else {


### PR DESCRIPTION
## Description

I took the opportunity of [NETOBSERV-1382](https://issues.redhat.com/browse/NETOBSERV-1382) to allow custom metrics definition in console plugin config from a simple list of ids such as:
```
 panels: 
    # Protocol
    - Proto_Bytes
    - sum_Proto_Bytes
    - avg_Proto_Bytes
    - Proto_Packets
    - sum_Proto_Packets
    - avg_Proto_Packets
    - Proto_Flows
    # DSCP
    - Dscp_Bytes
    - Dscp_Packets
    - min_Dscp_TimeFlowRttNs
    - max_Dscp_TimeFlowRttNs
    - avg_Dscp_TimeFlowRttNs
    - p90_Dscp_TimeFlowRttNs
    - p99_Dscp_TimeFlowRttNs
    - min_Dscp_DnsLatencyMs
    - max_Dscp_DnsLatencyMs
    - avg_Dscp_DnsLatencyMs
    - p90_Dscp_DnsLatencyMs
    - p99_Dscp_DnsLatencyMs
    - Dscp_Flows
    # Port numbers
    - SrcPort_Bytes
    - sum_SrcPort_Bytes
    - SrcPort_Packets
    - sum_SrcPort_Packets
    - SrcPort_TimeFlowRttNs
    - min_SrcPort_TimeFlowRttNs
    - max_SrcPort_TimeFlowRttNs
    - avg_SrcPort_TimeFlowRttNs
    - p90_SrcPort_TimeFlowRttNs
    - p99_SrcPort_TimeFlowRttNs
    - DstPort_Bytes
    - sum_DstPort_Bytes
    - DstPort_Packets
    - sum_DstPort_Packets
    - min_DstPort_TimeFlowRttNs
    - max_DstPort_TimeFlowRttNs
    - avg_DstPort_TimeFlowRttNs
    - p90_DstPort_TimeFlowRttNs
    - p99_DstPort_TimeFlowRttNs
    # Directions
    - FlowDirection_Bytes
    - FlowDirection_Packets
    - FlowDirection_Flows
    - IfDirection_Bytes
    - IfDirection_Packets
    - IfDirection_Flows
    # Interface names
    - Interface_Bytes
    - sum_Interface_Bytes
    - avg_Interface_Bytes
    - Interface_Packets
    - sum_Interface_Packets
    - avg_Interface_Packets
    - Interface_Flows
    # DNS capture errors
    - DnsErrno_Flows
    # Connection tracking flow count
    - numFlowLogs_Flows
    # Bytes / Packets rates on current scope
    - Bytes
    - Packets
    # flow on current scope
    - Flows
    - DnsFlows
```

The ids are parsed as:
- MetricFunction (optionnal)
- AggregateBy (optionnal)
- MetricType

Custom metrics results are saved in a `Map<string, TopologyMetrics[] | GenericMetric[]>` 
Their total are in a similar `Map<string, TopologyMetrics | GenericMetric>`
Overview panel allow a donut or graph for each of these.

![image](https://github.com/netobserv/network-observability-console-plugin/assets/91894519/b294d895-97b0-43e3-a1b5-914898758cd1)
![image](https://github.com/netobserv/network-observability-console-plugin/assets/91894519/c92fc625-27ea-4ef4-805c-2285086e9ad1)
![image](https://github.com/netobserv/network-observability-console-plugin/assets/91894519/8026a3c7-5127-4cf2-87d7-49b46263f38d)
![image](https://github.com/netobserv/network-observability-console-plugin/assets/91894519/5c72b742-b207-41af-96bc-684744b89cc8)
![image](https://github.com/netobserv/network-observability-console-plugin/assets/91894519/6d00b28e-4469-4c08-be9e-8936e82d9942)

~See https://github.com/netobserv/network-observability-console-plugin/pull/431/commits/25faa3506973b0ef1efc824f5ad5ebcbe8abec96 for change list~

## Dependencies

Based on https://github.com/netobserv/network-observability-console-plugin/pull/412

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
