### PR TITLE
NETOBSERV-1432 Missing drops information in table view

### DIFF
--- a/config/sample-config.yaml
+++ b/config/sample-config.yaml
@@ -393,13 +393,17 @@ frontend:
     - id: Bytes
       name: Bytes
       tooltip: The total aggregated number of bytes.
-      field: Bytes
+      fields: 
+        - Bytes
+        - PktDropBytes
       default: true
       width: 5
     - id: Packets
       name: Packets
       tooltip: The total aggregated number of packets.
-      field: Packets
+      fields: 
+        - Packets
+        - PktDropPackets
       filter: pkt_drop_cause
       default: true
       width: 5

--- a/pkg/handler/config.go
+++ b/pkg/handler/config.go
@@ -46,14 +46,15 @@ type Column struct {
 	ID   string `yaml:"id" json:"id"`
 	Name string `yaml:"name" json:"name"`
 
-	Group      string `yaml:"group,omitempty" json:"group,omitempty"`
-	Field      string `yaml:"field,omitempty" json:"field,omitempty"`
-	Calculated string `yaml:"calculated,omitempty" json:"calculated,omitempty"`
-	Tooltip    string `yaml:"tooltip,omitempty" json:"tooltip,omitempty"`
-	DocURL     string `yaml:"docURL,omitempty" json:"docURL,omitempty"`
-	Filter     string `yaml:"filter,omitempty" json:"filter,omitempty"`
-	Default    bool   `yaml:"default,omitempty" json:"default,omitempty"`
-	Width      int    `yaml:"width,omitempty" json:"width,omitempty"`
+	Group      string   `yaml:"group,omitempty" json:"group,omitempty"`
+	Field      string   `yaml:"field,omitempty" json:"field,omitempty"`
+	Fields     []string `yaml:"fields,omitempty" json:"fields,omitempty"`
+	Calculated string   `yaml:"calculated,omitempty" json:"calculated,omitempty"`
+	Tooltip    string   `yaml:"tooltip,omitempty" json:"tooltip,omitempty"`
+	DocURL     string   `yaml:"docURL,omitempty" json:"docURL,omitempty"`
+	Filter     string   `yaml:"filter,omitempty" json:"filter,omitempty"`
+	Default    bool     `yaml:"default,omitempty" json:"default,omitempty"`
+	Width      int      `yaml:"width,omitempty" json:"width,omitempty"`
 }
 
 type Filter struct {

--- a/web/src/api/ipfix.ts
+++ b/web/src/api/ipfix.ts
@@ -11,7 +11,7 @@ export interface Record {
   fields: Fields;
 }
 
-export const getRecordValue = (record: Record, fieldOrLabel: string, defaultValue: string | number) => {
+export const getRecordValue = (record: Record, fieldOrLabel: string, defaultValue?: string | number) => {
   // check if label exists
   if (record.labels[fieldOrLabel as keyof Labels] !== undefined) {
     return record.labels[fieldOrLabel as keyof Labels];

--- a/web/src/components/netflow-record/__tests__/record-field.spec.tsx
+++ b/web/src/components/netflow-record/__tests__/record-field.spec.tsx
@@ -15,6 +15,7 @@ describe('<RecordField />', () => {
     isDelete: false
   };
   const mocks = {
+    allowPktDrops: true,
     size: 'm' as Size,
     useLinks: true
   };

--- a/web/src/components/netflow-record/record-panel.tsx
+++ b/web/src/components/netflow-record/record-panel.tsx
@@ -328,6 +328,7 @@ export const RecordPanel: React.FC<RecordDrawerProps> = ({
                           </Text>
                         )}
                         <RecordField
+                          allowPktDrops={allowPktDrops}
                           flow={record}
                           column={c}
                           filter={getFilter(c)}

--- a/web/src/components/netflow-table/__tests__/netflow-table-row.spec.tsx
+++ b/web/src/components/netflow-table/__tests__/netflow-table-row.spec.tsx
@@ -11,6 +11,7 @@ import { Size } from '../../dropdowns/table-display-dropdown';
 describe('<NetflowTableRow />', () => {
   let flows: Record[] = [];
   const mocks = {
+    allowPktDrops: true,
     size: 'm' as Size,
     onSelect: jest.fn(),
     tableWidth: 100,

--- a/web/src/components/netflow-table/__tests__/netflow-table.spec.tsx
+++ b/web/src/components/netflow-table/__tests__/netflow-table.spec.tsx
@@ -19,6 +19,7 @@ const noResultsFoundQuery = `Bullseye[data-test="no-results-found"]`;
 
 describe('<NetflowTable />', () => {
   const mocks = {
+    allowPktDrops: true,
     size: 'm' as Size,
     onSelect: jest.fn(),
     filterActionLinks: <></>,

--- a/web/src/components/netflow-table/netflow-table-row.tsx
+++ b/web/src/components/netflow-table/netflow-table-row.tsx
@@ -8,6 +8,7 @@ import './netflow-table-row.css';
 import CSSTransition from 'react-transition-group/CSSTransition';
 
 const NetflowTableRow: React.FC<{
+  allowPktDrops: boolean;
   lastRender?: string;
   flow: Record;
   selectedRecord?: Record;
@@ -20,6 +21,7 @@ const NetflowTableRow: React.FC<{
   tableWidth: number;
   isDark?: boolean;
 }> = ({
+  allowPktDrops,
   lastRender,
   flow,
   selectedRecord,
@@ -55,7 +57,16 @@ const NetflowTableRow: React.FC<{
               key={c.id}
               style={{ height: '100%', width: `${Math.floor((100 * c.width) / tableWidth)}%` }}
             >
-              {<RecordField flow={flow} column={c} size={size} useLinks={false} isDark={isDark} />}
+              {
+                <RecordField
+                  allowPktDrops={allowPktDrops}
+                  flow={flow}
+                  column={c}
+                  size={size}
+                  useLinks={false}
+                  isDark={isDark}
+                />
+              }
             </Td>
           ))}
       </Tr>

--- a/web/src/components/netflow-table/netflow-table.tsx
+++ b/web/src/components/netflow-table/netflow-table.tsx
@@ -29,6 +29,7 @@ import { LokiError } from '../messages/loki-error';
 import { convertRemToPixels } from '../../utils/panel';
 
 const NetflowTable: React.FC<{
+  allowPktDrops: boolean;
   flows: Record[];
   selectedRecord?: Record;
   columns: Column[];
@@ -42,6 +43,7 @@ const NetflowTable: React.FC<{
   filterActionLinks: JSX.Element;
   isDark?: boolean;
 }> = ({
+  allowPktDrops,
   flows,
   selectedRecord,
   columns,
@@ -186,6 +188,7 @@ const NetflowTable: React.FC<{
     return getSortedFlows().map((f, i) => (
       <NetflowTableRow
         key={f.key}
+        allowPktDrops={allowPktDrops}
         flow={f}
         lastRender={lastRender}
         columns={columns}
@@ -206,6 +209,7 @@ const NetflowTable: React.FC<{
       />
     ));
   }, [
+    allowPktDrops,
     lastRender,
     activeSortDirection,
     activeSortId,

--- a/web/src/components/netflow-traffic.tsx
+++ b/web/src/components/netflow-traffic.tsx
@@ -1390,6 +1390,7 @@ export const NetflowTraffic: React.FC<{
           <NetflowTable
             loading={loading}
             error={error}
+            allowPktDrops={isPktDrop()}
             flows={flows}
             selectedRecord={selectedRecord}
             size={size}

--- a/web/src/utils/columns.ts
+++ b/web/src/utils/columns.ts
@@ -80,6 +80,7 @@ export interface ColumnConfigDef {
   group?: string;
   name: string;
   field?: string;
+  fields?: string[];
   calculated?: string;
   tooltip?: string;
   docURL?: string;
@@ -301,6 +302,12 @@ export const getDefaultColumns = (columnDefs: ColumnConfigDef[]): Column[] => {
           } else {
             return calculatedValue(r, d.calculated!);
           }
+        } else if (d.fields) {
+          const arr: (string | number | undefined)[] = [];
+          d.fields.forEach(f => {
+            arr.push(getRecordValue(r, f, undefined) as number);
+          });
+          return arr;
         } else {
           return getRecordValue(r, d.field!, '');
         }


### PR DESCRIPTION
## Description

Fix missing drops information in table view

![image](https://github.com/netobserv/network-observability-console-plugin/assets/91894519/de14119b-a0dc-4117-a530-20b7de8ebd49)

FYI there is also https://github.com/netobserv/network-observability-console-plugin/pull/437 opened on `pktDrop` filters

## Dependencies

https://github.com/netobserv/network-observability-operator/pull/514

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
