### PR TITLE
NETOBSERV-1435 Duplicate Id fields in Query Summary panel when PacketDrop enabled

### DIFF
--- a/web/src/components/query-summary/__tests__/flows-query-summary.spec.tsx
+++ b/web/src/components/query-summary/__tests__/flows-query-summary.spec.tsx
@@ -32,7 +32,7 @@ describe('<FlowsQuerySummary />', () => {
     expect(wrapper.find('#flowsCount').last().text()).toBe('3 Flows');
     expect(wrapper.find('#bytesCount').last().text()).toBe('161 kB');
     expect(wrapper.find('#packetsCount').last().text()).toBe('1k Packets');
-    expect(wrapper.find('#bpsCount').last().text()).toBe('538 Bps');
+    expect(wrapper.find('#bytesPerSecondsCount').last().text()).toBe('538 Bps');
     expect(wrapper.find('#lastRefresh').last().text()).toBe(now.toLocaleTimeString());
   });
 
@@ -43,7 +43,7 @@ describe('<FlowsQuerySummary />', () => {
     expect(wrapper.find('#flowsCount').last().text()).toBe('1k+ Flows');
     expect(wrapper.find('#bytesCount').last().text()).toBe('757+ MB');
     expect(wrapper.find('#packetsCount').last().text()).toBe('1k+ Packets');
-    expect(wrapper.find('#bpsCount').last().text()).toBe('2.52+ MBps');
+    expect(wrapper.find('#bytesPerSecondsCount').last().text()).toBe('2.52+ MBps');
     expect(wrapper.find('#lastRefresh').last().text()).toBe(now.toLocaleTimeString());
   });
 

--- a/web/src/components/query-summary/__tests__/metrics-query-summary.spec.tsx
+++ b/web/src/components/query-summary/__tests__/metrics-query-summary.spec.tsx
@@ -27,7 +27,7 @@ describe('<MetricsQuerySummary />', () => {
     const wrapper = mount(<MetricsQuerySummary {...mocks} />);
     expect(wrapper.find('#bytesCount').last().text()).toBe('6.8 MB');
     expect(wrapper.find('#packetsCount')).toHaveLength(0);
-    expect(wrapper.find('#bpsCount').last().text()).toBe('22.79 kBps');
+    expect(wrapper.find('#bytesPerSecondsCount').last().text()).toBe('22.79 kBps');
     expect(wrapper.find('#lastRefresh').last().text()).toBe(now.toLocaleTimeString());
   });
 

--- a/web/src/components/query-summary/flows-query-summary.tsx
+++ b/web/src/components/query-summary/flows-query-summary.tsx
@@ -68,7 +68,7 @@ export const FlowsQuerySummaryContent: React.FC<{
         {bytes > 0 && (
           <FlexItem>
             <Tooltip content={<Text component={TextVariants.p}>{t('Filtered average speed')}</Text>}>
-              <Text id="bpsCount" component={TextVariants.p}>
+              <Text id="bytesPerSecondsCount" component={TextVariants.p}>
                 {valueFormat(bytes / rangeInSeconds, 2, t('Bps'), limitReached)}
               </Text>
             </Tooltip>

--- a/web/src/components/query-summary/metrics-query-summary.tsx
+++ b/web/src/components/query-summary/metrics-query-summary.tsx
@@ -91,20 +91,20 @@ export const MetricsQuerySummaryContent: React.FC<{
             ? valueFormat(avgSum, 2, t('Bps')) + ' / ' + valueFormat(appMetrics.stats.avg, 2, t('Bps'))
             : valueFormat(avgSum, 2, t('Bps'));
           return [
-            <FlexItem key="bytesCount">
+            <FlexItem key={`${metricType}Count`}>
               <Tooltip content={<Text component={TextVariants.p}>{textAbs}</Text>}>
                 <div className="stats-query-summary-container">
-                  <Text id="bytesCount" component={TextVariants.p} style={{ color: textColor }}>
+                  <Text id={`${metricType}Count`} component={TextVariants.p} style={{ color: textColor }}>
                     {valAbs}
                   </Text>
                 </div>
               </Tooltip>
             </FlexItem>,
-            <FlexItem key="bpsCount">
+            <FlexItem key={`${metricType}PerSecondsCount`}>
               <Tooltip content={<Text component={TextVariants.p}>{textRate}</Text>}>
                 <div className="stats-query-summary-container-with-icon">
                   <TachometerAltIcon />
-                  <Text id="bpsCount" component={TextVariants.p} style={{ color: textColor }}>
+                  <Text id={`${metricType}PerSecondsCount`} component={TextVariants.p} style={{ color: textColor }}>
                     {valRate}
                   </Text>
                 </div>
@@ -122,10 +122,10 @@ export const MetricsQuerySummaryContent: React.FC<{
           const valAbs =
             (appMetrics ? `${absTotal} / ${appMetrics.stats.total}` : String(absTotal)) + ' ' + t('packets');
           return [
-            <FlexItem key="packetsCount">
+            <FlexItem key={`${metricType}Count`}>
               <Tooltip content={<Text component={TextVariants.p}>{textAbs}</Text>}>
                 <div className="stats-query-summary-container">
-                  <Text id="packetsCount" component={TextVariants.p} style={{ color: textColor }}>
+                  <Text id={`${metricType}Count`} component={TextVariants.p} style={{ color: textColor }}>
                     {valAbs}
                   </Text>
                 </div>


### PR DESCRIPTION
## Description

Renammed `bytes` / `packets` counter ids as follow:
- bytesCount
- bytesPerSecondsCount
- droppedBytesCount
- droppedBytesPerSecondsCount
- packetsCount
- droppedPacketsCount

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
