### PR TITLE
NETOBSERV-1450: use isolated states for mobx

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -73,6 +73,7 @@
         "jsdom": "19.0.0",
         "jsdom-global": "3.0.2",
         "mini-css-extract-plugin": "^2.6.0",
+        "mobx": "^5.15.7",
         "prettier": "^2.5.1",
         "pretty-quick": "^3.1.2",
         "react-transition-group": "^4.4.2",
@@ -3242,15 +3243,6 @@
       "peerDependencies": {
         "react": "^16.8 || ^17 || ^18",
         "react-dom": "^16.8 || ^17 || ^18"
-      }
-    },
-    "node_modules/@patternfly/react-topology/node_modules/mobx": {
-      "version": "5.15.7",
-      "resolved": "https://registry.npmjs.org/mobx/-/mobx-5.15.7.tgz",
-      "integrity": "sha512-wyM3FghTkhmC+hQjyPGGFdpehrcX1KOXsDuERhfK2YbJemkUhEB+6wzEN639T21onxlfYBmriA1PFnvxTUhcKw==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mobx"
       }
     },
     "node_modules/@patternfly/react-topology/node_modules/mobx-react": {
@@ -14180,6 +14172,15 @@
       "resolved": "https://registry.npmjs.org/mmd-parser/-/mmd-parser-1.0.4.tgz",
       "integrity": "sha512-Qi0VCU46t2IwfGv5KF0+D/t9cizcDug7qnNoy9Ggk7aucp0tssV8IwTMkBlDbm+VqAf3cdQHTCARKSsuS2MYFg=="
     },
+    "node_modules/mobx": {
+      "version": "5.15.7",
+      "resolved": "https://registry.npmjs.org/mobx/-/mobx-5.15.7.tgz",
+      "integrity": "sha512-wyM3FghTkhmC+hQjyPGGFdpehrcX1KOXsDuERhfK2YbJemkUhEB+6wzEN639T21onxlfYBmriA1PFnvxTUhcKw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mobx"
+      }
+    },
     "node_modules/moo": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
@@ -22395,11 +22396,6 @@
         "webcola": "3.4.0"
       },
       "dependencies": {
-        "mobx": {
-          "version": "5.15.7",
-          "resolved": "https://registry.npmjs.org/mobx/-/mobx-5.15.7.tgz",
-          "integrity": "sha512-wyM3FghTkhmC+hQjyPGGFdpehrcX1KOXsDuERhfK2YbJemkUhEB+6wzEN639T21onxlfYBmriA1PFnvxTUhcKw=="
-        },
         "mobx-react": {
           "version": "6.3.1",
           "resolved": "https://registry.npmjs.org/mobx-react/-/mobx-react-6.3.1.tgz",
@@ -30990,6 +30986,11 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mmd-parser/-/mmd-parser-1.0.4.tgz",
       "integrity": "sha512-Qi0VCU46t2IwfGv5KF0+D/t9cizcDug7qnNoy9Ggk7aucp0tssV8IwTMkBlDbm+VqAf3cdQHTCARKSsuS2MYFg=="
+    },
+    "mobx": {
+      "version": "5.15.7",
+      "resolved": "https://registry.npmjs.org/mobx/-/mobx-5.15.7.tgz",
+      "integrity": "sha512-wyM3FghTkhmC+hQjyPGGFdpehrcX1KOXsDuERhfK2YbJemkUhEB+6wzEN639T21onxlfYBmriA1PFnvxTUhcKw=="
     },
     "moo": {
       "version": "0.5.1",

--- a/web/package.json
+++ b/web/package.json
@@ -70,6 +70,7 @@
     "jsdom": "19.0.0",
     "jsdom-global": "3.0.2",
     "mini-css-extract-plugin": "^2.6.0",
+    "mobx": "^5.15.7",
     "prettier": "^2.5.1",
     "pretty-quick": "^3.1.2",
     "react-transition-group": "^4.4.2",

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-
 import i18n from 'i18next';
 import httpBackend from 'i18next-http-backend';
 import { initReactI18next } from 'react-i18next';
+import { configure } from 'mobx';
 
 import '@patternfly/patternfly/patternfly-charts-theme-dark.css';
 import '@patternfly/patternfly/patternfly-theme-dark.css';
@@ -12,6 +12,8 @@ import '@patternfly/react-core/dist/styles/base.css';
 import App from './app';
 import { getLanguage } from './utils/language';
 import './index.css';
+
+configure({ isolateGlobalState: true });
 
 //init standalone i18n translations
 i18n


### PR DESCRIPTION
## Description

As mobx is also used by the console itself, it must be configured as isolated to prevent conflicting versions.

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
