### PR TITLE
NETOBSERV-1429 Netflow tab crash followup

### DIFF
--- a/web/src/components/netflow-traffic-parent.tsx
+++ b/web/src/components/netflow-traffic-parent.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
 import { clearURLParams } from '../utils/url';
 import { clearLocalStorage } from '../utils/local-storage-hook';
-import NetflowTraffic from './netflow-traffic';
+import NetflowTraffic, { NetflowTrafficProps } from './netflow-traffic';
 import AlertFetcher from './alerts/fetcher';
 import DynamicLoader from './dynamic-loader/dynamic-loader';
 
-type Props = {};
+type Props = NetflowTrafficProps & {};
+
 type State = {
   error?: Error;
 };
@@ -47,15 +48,14 @@ class NetflowTrafficParent extends React.Component<Props, State> {
         </div>
       );
     }
-    if (this.props.children) {
-      return this.props.children;
-    }
-    // else render default NetworkTraffic
-
     return (
       <DynamicLoader>
         <AlertFetcher>
-          <NetflowTraffic forcedFilters={null} />
+          <NetflowTraffic
+            isTab={this.props.isTab}
+            forcedFilters={this.props.isTab ? this.props.forcedFilters : null}
+            parentConfig={this.props.parentConfig}
+          />
         </AlertFetcher>
       </DynamicLoader>
     );

--- a/web/src/components/netflow-traffic.tsx
+++ b/web/src/components/netflow-traffic.tsx
@@ -169,11 +169,13 @@ import { SearchComponent, SearchEvent, SearchHandle } from './search/search';
 
 export type ViewId = 'overview' | 'table' | 'topology';
 
-export const NetflowTraffic: React.FC<{
-  forcedFilters: Filters | null;
+export type NetflowTrafficProps = {
+  forcedFilters?: Filters | null;
   isTab?: boolean;
   parentConfig?: Config;
-}> = ({ forcedFilters, isTab, parentConfig }) => {
+};
+
+export const NetflowTraffic: React.FC<NetflowTrafficProps> = ({ forcedFilters, isTab, parentConfig }) => {
   const { t } = useTranslation('plugin__netobserv-plugin');
   const [extensions] = useResolvedExtensions<ModelFeatureFlag>(isModelFeatureFlag);
   const k8sModels = useK8sModelsWithColors();


### PR DESCRIPTION
## Description

This PR is a followup of https://github.com/netobserv/network-observability-console-plugin/pull/439 to fix tab crash when loading from direct url / cypress.

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
