### PR TITLE
NETOBSERV-1355 autocomplete menu button

### DIFF
--- a/web/src/components/filters/autocomplete-filter.css
+++ b/web/src/components/filters/autocomplete-filter.css
@@ -1,0 +1,4 @@
+#autocomplete-menu-button {
+  width: 30px;
+  padding: 0;
+}

--- a/web/src/utils/filter-definitions.ts
+++ b/web/src/utils/filter-definitions.ts
@@ -23,7 +23,6 @@ import {
   getProtocolOptions,
   getResourceOptions,
   noOption,
-  cap10,
   getDnsResponseCodeOptions,
   getDropStateOptions,
   getDropCauseOptions,
@@ -251,16 +250,16 @@ export const getFilterDefinitions = (
       | undefined = undefined;
 
     if (d.id.includes('namespace')) {
-      getOptions = cap10(getNamespaceOptions);
+      getOptions = getNamespaceOptions;
       validate = k8sNameValidation;
     } else if (d.id.includes('name')) {
       validate = k8sNameValidation;
     } else if (d.id.includes('kind')) {
-      getOptions = cap10(getKindOptions);
+      getOptions = getKindOptions;
       validate = rejectEmptyValue;
       encoder = kindFiltersEncoder(`${isSrc ? 'Src' : 'Dst'}K8S_Type`, `${isSrc ? 'Src' : 'Dst'}K8S_OwnerType`);
     } else if (d.id.includes('resource')) {
-      getOptions = cap10(getResourceOptions);
+      getOptions = getResourceOptions;
       validate = k8sResourceValidation;
       checkCompletion = k8sResourceCompletion;
       encoder = k8sResourceFiltersEncoder(
@@ -273,28 +272,28 @@ export const getFilterDefinitions = (
     } else if (d.id.includes('address')) {
       validate = addressValidation;
     } else if (d.id.includes('port')) {
-      getOptions = cap10(getPortOptions);
+      getOptions = getPortOptions;
       validate = portValidation;
     } else if (d.id.includes('mac')) {
       validate = macValidation;
     } else if (d.id.includes('proto')) {
-      getOptions = cap10(getProtocolOptions);
+      getOptions = getProtocolOptions;
       validate = protoValidation;
     } else if (d.id.includes('direction')) {
       getOptions = v => getDirectionOptionsAsync(v, t);
       validate = dirValidation;
     } else if (d.id.includes('drop_state')) {
-      getOptions = cap10(getDropStateOptions);
+      getOptions = getDropStateOptions;
       encoder = simpleFiltersEncoder('PktDropLatestState');
     } else if (d.id.includes('drop_cause')) {
-      getOptions = cap10(getDropCauseOptions);
+      getOptions = getDropCauseOptions;
       encoder = simpleFiltersEncoder('PktDropLatestDropCause');
     } else if (d.id.includes('dns_flag_response_code')) {
-      getOptions = cap10(getDnsResponseCodeOptions);
+      getOptions = getDnsResponseCodeOptions;
     } else if (d.id.includes('dns_errno')) {
-      getOptions = cap10(getDnsErrorCodeOptions);
+      getOptions = getDnsErrorCodeOptions;
     } else if (d.id.includes('dscp')) {
-      getOptions = cap10(getDSCPOptions);
+      getOptions = getDSCPOptions;
     }
     return { getOptions, validate, encoder, checkCompletion };
   };

--- a/web/src/utils/filter-options.ts
+++ b/web/src/utils/filter-options.ts
@@ -149,11 +149,3 @@ export const findProtocolOption = (nameOrVal: string) => {
 export const findDirectionOption = (nameOrVal: string, t: TFunction) => {
   return getDirectionOptions(t).find(o => o.name.toLowerCase() === nameOrVal.toLowerCase() || o.value === nameOrVal);
 };
-
-export const cap10 = (getOptions: (value: string) => Promise<FilterOption[]>) => {
-  return (value: string) => {
-    return getOptions(value).then(opts => {
-      return opts.length <= 10 ? opts : opts.slice(0, 10);
-    });
-  };
-};


### PR DESCRIPTION
## Description

Add a button next to `autocompletes` to open / close suggestions.
Also added a scroller when options are more than 8.

[Screencast from 2024-01-23 11-17-14.webm](https://github.com/netobserv/network-observability-console-plugin/assets/91894519/9351f3e2-e79a-4be1-9132-cf1070281c4e)

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
