### PR TITLE
NETOBSERV-1475 zoom-in button on topology view is unclickable in collapse mode

### DIFF
--- a/web/src/components/scope-slider/scope-slider.css
+++ b/web/src/components/scope-slider/scope-slider.css
@@ -1,8 +1,5 @@
 #scope-slider {
   position: relative;
   height: 0;
-  width: 400px;
-  top: 200px;
-  left: -165px;
   z-index: 2;
 }

--- a/web/src/components/scope-slider/scope-slider.tsx
+++ b/web/src/components/scope-slider/scope-slider.tsx
@@ -10,9 +10,10 @@ export interface ScopeSliderProps {
   setScope: (ms: FlowScope) => void;
   allowMultiCluster: boolean;
   allowZone: boolean;
+  sizePx: number;
 }
 
-export const ScopeSlider: React.FC<ScopeSliderProps> = ({ scope, setScope, allowMultiCluster, allowZone }) => {
+export const ScopeSlider: React.FC<ScopeSliderProps> = ({ scope, setScope, allowMultiCluster, allowZone, sizePx }) => {
   const { t } = useTranslation('plugin__netobserv-plugin');
 
   const scopes: [FlowScope, string][] = [
@@ -25,17 +26,32 @@ export const ScopeSlider: React.FC<ScopeSliderProps> = ({ scope, setScope, allow
   ].filter(s => (allowMultiCluster || s[0] !== 'cluster') && (allowZone || s[0] !== 'zone')) as [FlowScope, string][];
 
   const index = scopes.findIndex(s => s[0] === scope);
-
+  /* TODO: refactor vertical slider
+   * In between the display is block to working dimensions managing two cases
+   * Non supported dimensions simply hide the slider from the view
+   * since we can manage scopes from advanced view
+   */
+  const canDisplay = sizePx > 350 && sizePx < 2000;
+  const isBig = sizePx > 700;
   return (
-    <div id={'scope-slider'}>
-      <Slider
-        value={index < 0 ? 2 : index}
-        showTicks
-        max={scopes.length - 1}
-        customSteps={scopes.map((s, idx) => ({ value: idx, label: s[1] }))}
-        onChange={(value: number) => setScope(scopes[value][0])}
-        vertical
-      />
+    <div
+      id={'scope-slider'}
+      style={{
+        width: sizePx * (isBig ? 0.85 : 0.7),
+        top: sizePx * (isBig ? 0.45 : 0.4),
+        left: -sizePx * (isBig ? 0.38 : 0.28)
+      }}
+    >
+      {canDisplay && (
+        <Slider
+          value={index < 0 ? 2 : index}
+          showTicks
+          max={scopes.length - 1}
+          customSteps={scopes.map((s, idx) => ({ value: idx, label: s[1] }))}
+          onChange={(value: number) => setScope(scopes[value][0])}
+          vertical
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Description

This is a temporary fix to manage scope slider positionning. 
Currently, the slider can cover other components and mess up with zoom buttons.
In this patch, the scope slider only display when possible and adapt it size and position.

I would suggest to backport this to 1.5 if that works for everyone.

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
