### PR TITLE
NETOBSERV-1493 Netobserv / Monitoring plugins not showing

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -66,6 +66,11 @@ func corsHeader(cfg *Config) func(next http.Handler) http.Handler {
 			}
 			if cfg.CORSMaxAge != "" {
 				headers.Set("Access-Control-Max-Age", cfg.CORSMaxAge)
+			} else {
+				// disable cache to avoid issues between updates / plugin-manifest not parsed correctly by the console
+				headers.Set("Cache-Control", "no-cache, no-store, must-revalidate, proxy-revalidate, max-age=0")
+				headers.Set("Pragma", "no-cache")
+				headers.Set("Expires", "0")
 			}
 			next.ServeHTTP(w, r)
 		})

--- a/web/webpack.config.ts
+++ b/web/webpack.config.ts
@@ -71,7 +71,10 @@ module.exports = {
     headers: {
       "Access-Control-Allow-Origin": "*",
       "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, PATCH, OPTIONS",
-      "Access-Control-Allow-Headers": "X-Requested-With, Content-Type, Authorization"
+      "Access-Control-Allow-Headers": "X-Requested-With, Content-Type, Authorization",
+      "Cache-Control": "no-cache, no-store, must-revalidate, proxy-revalidate, max-age=0",
+      "Pragma": "no-cache",
+      "Expires": "0"
     },
     devMiddleware: {
       writeToDisk: true,


### PR DESCRIPTION
## Description

This PR disable plugin cache to avoid Console issues.

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
