### PR TITLE
NETOBSERV-1496 netflow page table view crashes when using Destination IP as filter

### DIFF
--- a/web/src/api/ipfix.ts
+++ b/web/src/api/ipfix.ts
@@ -13,13 +13,16 @@ export interface Record {
 }
 
 export const getRecordValue = (record: Record, fieldOrLabel: string, defaultValue?: string | number) => {
+  /* TODO: fix following behavior:
+   * Check if field exists first since /flow endpoint return fields as labels when using filters
+   * This is mandatory to ensure fields types
+   */
+  if (record.fields[fieldOrLabel as keyof Fields] !== undefined) {
+    return record.fields[fieldOrLabel as keyof Fields];
+  }
   // check if label exists
   if (record.labels[fieldOrLabel as keyof Labels] !== undefined) {
     return record.labels[fieldOrLabel as keyof Labels];
-  }
-  // check if field exists
-  if (record.fields[fieldOrLabel as keyof Fields] !== undefined) {
-    return record.fields[fieldOrLabel as keyof Fields];
   }
   // fallback on default
   return defaultValue;

--- a/web/src/components/netflow-record/record-panel.tsx
+++ b/web/src/components/netflow-record/record-panel.tsx
@@ -302,7 +302,7 @@ export const RecordPanel: React.FC<RecordDrawerProps> = ({
   }, [record.labels._RecordType, t]);
 
   const getSortedJSON = React.useCallback(() => {
-    const flat = { ...record.fields, ...record.labels };
+    const flat = { ...record.labels, ...record.fields };
     return JSON.stringify(flat, Object.keys(flat).sort(), 2);
   }, [record]);
 


### PR DESCRIPTION
## Description

Flow query is buggy and returns all fields as labels when using some filters.
Since we moved to dynamic config, we check both labels and fields and pick the first match.

This PR invert check order: fields before labels, to keep correct field types.

A followup for 1.6 is coming with proper field type parsing:
https://issues.redhat.com/browse/NETOBSERV-1503

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
