### PR TITLE
NETOBSERV-1503 Console plugin fields config

### DIFF
--- a/config/sample-config.yaml
+++ b/config/sample-config.yaml
@@ -6,11 +6,16 @@ loki:
   labels: 
     - SrcK8S_Namespace
     - SrcK8S_OwnerName
+    - SrcK8S_Type
     - DstK8S_Namespace
     - DstK8S_OwnerName
+    - DstK8S_Type
+    - K8S_FlowLayer
     - FlowDirection
-    - Duplicate
 #    - _RecordType
+#    - K8S_ClusterName
+#    - SrcK8S_Zone
+#    - DstK8S_Zone
   tenantID: netobserv
   authCheck: none
   useMocks: false
@@ -32,7 +37,34 @@ frontend:
     enable: true
     portNames:
       "3100": loki
-  columns: 
+  quickFilters:
+    - name: Applications
+      filter:
+        flow_layer: 'app'
+      default: true
+    - name: Infrastructure
+      filter:
+        flow_layer: 'infra'
+    - name: Pods network
+      filter:
+        src_kind: 'Pod'
+        dst_kind: 'Pod'
+      default: true
+    - name: Services network
+      filter:
+        dst_kind: 'Service'
+    - name: DNS
+      filter:
+        dns_id!: '0'
+  alertNamespaces:
+    - netobserv
+  sampling: 50
+  deduper:
+    mark: true
+    merge: false
+# The following configuration is taken from Network Observability Operator
+# see https://github.com/netobserv/network-observability-operator/blob/main/controllers/consoleplugin/config/static-frontend-config.yaml
+  columns:
     - id: StartTime
       name: Start Time
       tooltip: Time of the first packet observed. Unlike End Time, it is not used in queries
@@ -412,7 +444,7 @@ frontend:
       width: 10
     - id: FlowDirection
       name: Direction
-      tooltip: The direction of the Flow observed at the Node observation point.
+      tooltip: The direction of the flow observed at the Node observation point.
       field: FlowDirection
       filter: direction
       default: false
@@ -433,7 +465,7 @@ frontend:
     - id: Bytes
       name: Bytes
       tooltip: The total aggregated number of bytes.
-      fields: 
+      fields:
         - Bytes
         - PktDropBytes
       default: true
@@ -441,7 +473,7 @@ frontend:
     - id: Packets
       name: Packets
       tooltip: The total aggregated number of packets.
-      fields: 
+      fields:
         - Packets
         - PktDropPackets
       filter: pkt_drop_cause
@@ -504,7 +536,7 @@ frontend:
       feature: dnsTracking
     - id: TimeFlowRttMs
       name: Flow RTT
-      tooltip: TCP handshake Round Trip Time
+      tooltip: TCP Smoothed Round Trip Time (SRTT)
       field: TimeFlowRttNs
       filter: time_flow_rtt
       default: true
@@ -852,30 +884,182 @@ frontend:
       name: Flow RTT
       component: number
       hint: Specify a TCP handshake Round Trip Time in nanoseconds.
-  quickFilters:
-    - name: Applications
-      filter:
-        src_namespace!: 'openshift-,netobserv'
-        dst_namespace!: 'openshift-,netobserv'
-      default: true
-    - name: Infrastructure
-      filter:
-        src_namespace: 'openshift-,netobserv'
-        dst_namespace: 'openshift-,netobserv'
-    - name: Pods network
-      filter:
-        src_kind: 'Pod'
-        dst_kind: 'Pod'
-      default: true
-    - name: Services network
-      filter:
-        dst_kind: 'Service'
-    - name: DNS
-      filter:
-        dns_id!: '0'
-  alertNamespaces:
-    - netobserv
-  sampling: 50
-  deduper:
-    mark: true
-    merge: false
+  fields:
+    - name: TimeFlowStartMs
+      type: number
+      description: Start timestamp of this flow, in milliseconds
+    - name: TimeFlowEndMs
+      type: number
+      description: End timestamp of this flow, in milliseconds
+    - name: TimeReceived
+      type: number
+      description: Timestamp when this flow was received and processed by the flow collector, in seconds
+    - name: SrcK8S_Name
+      type: string
+      description: Name of the source Kubernetes object, such as Pod name, Service name or Node name.
+    - name: SrcK8S_Type
+      type: string
+      description: Kind of the source Kubernetes object, such as Pod, Service or Node.
+      lokiLabel: true
+    - name: SrcK8S_OwnerName
+      type: string
+      description: Name of the source owner, such as Deployment name, StatefulSet name, etc.
+      lokiLabel: true
+    - name: SrcK8S_OwnerType
+      type: string
+      description: Kind of the source owner, such as Deployment, StatefulSet, etc.
+    - name: SrcK8S_Namespace
+      type: string
+      description: Source namespace
+      lokiLabel: true
+    - name: SrcAddr
+      type: string
+      description: Source IP address (ipv4 or ipv6)
+    - name: SrcPort
+      type: number
+      description: Source port
+    - name: SrcMac
+      type: string
+      description: Source MAC address
+    - name: SrcK8S_HostIP
+      type: string
+      description: Source node IP
+    - name: SrcK8S_HostName
+      type: string
+      description: Source node name
+    - name: SrcK8S_Zone
+      type: string
+      description: Source availability zone
+      lokiLabel: true
+    - name: DstK8S_Name
+      type: string
+      description: Name of the destination Kubernetes object, such as Pod name, Service name or Node name.
+    - name: DstK8S_Type
+      type: string
+      description: Kind of the destination Kubernetes object, such as Pod, Service or Node.
+      lokiLabel: true
+    - name: DstK8S_OwnerName
+      type: string
+      description: Name of the destination owner, such as Deployment name, StatefulSet name, etc.
+      lokiLabel: true
+    - name: DstK8S_OwnerType
+      type: string
+      description: Kind of the destination owner, such as Deployment, StatefulSet, etc.
+    - name: DstK8S_Namespace
+      type: string
+      description: Destination namespace
+      lokiLabel: true
+    - name: DstAddr
+      type: string
+      description: Destination IP address (ipv4 or ipv6)
+    - name: DstPort
+      type: number
+      description: Destination port
+    - name: DstMac
+      type: string
+      description: Destination MAC address
+    - name: DstK8S_HostIP
+      type: string
+      description: Destination node IP
+    - name: DstK8S_HostName
+      type: string
+      description: Destination node name
+    - name: DstK8S_Zone
+      type: string
+      description: Destination availability zone
+      lokiLabel: true
+    - name: K8S_FlowLayer
+      type: string
+      description: "Flow layer: 'app' or 'infra'"
+    - name: Proto
+      type: number
+      description: L4 protocol
+    - name: Dscp
+      type: number
+      description: Differentiated Services Code Point (DSCP) value
+    - name: IcmpType
+      type: number
+      description: ICMP type
+    - name: IcmpCode
+      type: number
+      description: ICMP code
+    - name: Duplicate
+      type: boolean
+      description: Indicates if this flow was also captured from another interface on the same host
+      lokiLabel: true
+    - name: FlowDirection
+      type: number
+      description: |
+        Flow direction from the node observation point. Can be one of: +
+        - 0: Ingress (incoming traffic, from the node observation point) +
+        - 1: Egress (outgoing traffic, from the node observation point) +
+        - 2: Inner (with the same source and destination node)
+      lokiLabel: true
+    - name: IfDirection
+      type: number
+      description: |
+        Flow direction from the network interface observation point. Can be one of: +
+        - 0: Ingress (interface incoming traffic) +
+        - 1: Egress (interface outgoing traffic)
+    - name: Interface
+      type: string
+      description: Network interface
+    - name: Flags
+      type: number
+      description: |
+        Logical OR combination of unique TCP flags comprised in the flow, as per RFC-9293, with additional custom flags to represent the following per-packet combinations: +
+        - SYN+ACK (0x100) +
+        - FIN+ACK (0x200) +
+        - RST+ACK (0x400)
+    - name: Bytes
+      type: number
+      description: Number of bytes
+    - name: Packets
+      type: number
+      description: Number of packets
+    - name: PktDropBytes
+      type: number
+      description: Number of bytes dropped by the kernel
+    - name: PktDropPackets
+      type: number
+      description: Number of packets dropped by the kernel
+    - name: PktDropLatestState
+      type: string
+      description: TCP state on last dropped packet
+      filter: pkt_drop_state # couldn't guess from config
+    - name: PktDropLatestDropCause
+      type: string
+      description: Latest drop cause
+      filter: pkt_drop_cause # couldn't guess from config
+    - name: PktDropLatestFlags
+      type: number
+      description: TCP flags on last dropped packet
+    - name: DnsId
+      type: number
+      description: DNS record id
+    - name: DnsLatencyMs
+      type: number
+      description: Time between a DNS request and response, in milliseconds
+    - name: DnsFlags
+      type: number
+      description: DNS flags for DNS record
+    - name: DnsFlagsResponseCode
+      type: string
+      description: Parsed DNS header RCODEs name
+    - name: DnsErrno
+      type: number
+      description: Error number returned from DNS tracker ebpf hook function
+    - name: TimeFlowRttNs
+      type: number
+      description: TCP Smoothed Round Trip Time (SRTT), in nanoseconds
+    - name: K8S_ClusterName
+      type: string
+      description: Cluster name or identifier
+      lokiLabel: true
+    - name: _RecordType
+      type: string
+      description: "Type of record: 'flowLog' for regular flow logs, or 'newConnection', 'heartbeat', 'endConnection' for conversation tracking"
+      lokiLabel: true
+    - name: _HashId
+      type: string
+      description: In conversation tracking, the conversation identifier

--- a/pkg/handler/config.go
+++ b/pkg/handler/config.go
@@ -78,6 +78,15 @@ type QuickFilter struct {
 	Default bool `yaml:"default,omitempty" json:"default,omitempty"`
 }
 
+type FieldConfig struct {
+	Name        string `yaml:"name" json:"name"`
+	Type        string `yaml:"type" json:"type"`
+	Description string `yaml:"description" json:"description"`
+	// This flag is for documentation only. Use loki.labels instead
+	LokiLabel bool   `yaml:"lokiLabel,omitempty" json:"lokiLabel,omitempty"`
+	Filter    string `yaml:"filter,omitempty" json:"filter,omitempty"`
+}
+
 type Deduper struct {
 	Mark  bool `yaml:"mark" json:"mark"`
 	Merge bool `yaml:"merge" json:"merge"`
@@ -95,6 +104,7 @@ type Frontend struct {
 	Sampling        int           `yaml:"sampling" json:"sampling"`
 	Features        []string      `yaml:"features" json:"features"`
 	Deduper         Deduper       `yaml:"deduper" json:"deduper"`
+	Fields          []FieldConfig `yaml:"fields" json:"fields"`
 }
 
 type Config struct {
@@ -133,6 +143,11 @@ func ReadConfigFile(version, date, filename string) (*Config, error) {
 			Deduper: Deduper{
 				Mark:  true,
 				Merge: false,
+			},
+			Fields: []FieldConfig{
+				{Name: "TimeFlowEndMs", Type: "number"},
+				{Name: "SrcAddr", Type: "string"},
+				{Name: "DstAddr", Type: "string"},
 			},
 		},
 	}

--- a/pkg/handler/config.go
+++ b/pkg/handler/config.go
@@ -82,9 +82,8 @@ type FieldConfig struct {
 	Name        string `yaml:"name" json:"name"`
 	Type        string `yaml:"type" json:"type"`
 	Description string `yaml:"description" json:"description"`
-	// This flag is for documentation only. Use loki.labels instead
-	LokiLabel bool   `yaml:"lokiLabel,omitempty" json:"lokiLabel,omitempty"`
-	Filter    string `yaml:"filter,omitempty" json:"filter,omitempty"`
+	// lokiLabel flag is for documentation only. Use loki.labels instead
+	Filter string `yaml:"filter,omitempty" json:"filter,omitempty"`
 }
 
 type Deduper struct {

--- a/web/src/api/ipfix.ts
+++ b/web/src/api/ipfix.ts
@@ -13,13 +13,16 @@ export interface Record {
 }
 
 export const getRecordValue = (record: Record, fieldOrLabel: string, defaultValue?: string | number) => {
+  /* TODO: fix following behavior:
+   * Check if field exists first since /flow endpoint return fields as labels when using filters
+   * This is mandatory to ensure fields types
+   */
+  if (record.fields[fieldOrLabel as keyof Fields] !== undefined) {
+    return record.fields[fieldOrLabel as keyof Fields];
+  }
   // check if label exists
   if (record.labels[fieldOrLabel as keyof Labels] !== undefined) {
     return record.labels[fieldOrLabel as keyof Labels];
-  }
-  // check if field exists
-  if (record.fields[fieldOrLabel as keyof Fields] !== undefined) {
-    return record.fields[fieldOrLabel as keyof Fields];
   }
   // fallback on default
   return defaultValue;

--- a/web/src/api/routes.ts
+++ b/web/src/api/routes.ts
@@ -159,7 +159,8 @@ export const getConfig = (): Promise<Config> => {
       deduper: {
         mark: r.data.deduper.mark ?? defaultConfig.deduper.mark,
         merge: r.data.deduper.merge ?? defaultConfig.deduper.merge
-      }
+      },
+      fields: r.data.fields
     };
   });
 };

--- a/web/src/components/__tests-data__/columns.ts
+++ b/web/src/components/__tests-data__/columns.ts
@@ -1,5 +1,7 @@
+/* eslint-disable max-len */
 import * as _ from 'lodash';
 import { Column, ColumnsId, getDefaultColumns } from '../../utils/columns';
+import { FieldConfig } from '../../utils/fields';
 
 export const ColumnConfigSampleDefs = [
   {
@@ -455,6 +457,7 @@ export const ColumnConfigSampleDefs = [
     group: 'DNS',
     name: 'DNS Latency',
     tooltip: 'Time elapsed between DNS request and response.',
+    field: 'DnsLatencyMs',
     default: false,
     width: 5
   },
@@ -470,8 +473,284 @@ export const ColumnConfigSampleDefs = [
   }
 ];
 
+export const FieldConfigSample = [
+  {
+    name: 'TimeFlowStartMs',
+    type: 'number',
+    description: 'Start timestamp of this flow, in milliseconds'
+  },
+  {
+    name: 'TimeFlowEndMs',
+    type: 'number',
+    description: 'End timestamp of this flow, in milliseconds'
+  },
+  {
+    name: 'TimeReceived',
+    type: 'number',
+    description: 'Timestamp when this flow was received and processed by the flow collector, in seconds'
+  },
+  {
+    name: 'SrcK8S_Name',
+    type: 'string',
+    description: 'Name of the source Kubernetes object, such as Pod name, Service name or Node name.'
+  },
+  {
+    name: 'SrcK8S_Type',
+    type: 'string',
+    description: 'Kind of the source Kubernetes object, such as Pod, Service or Node.',
+    lokiLabel: true
+  },
+  {
+    name: 'SrcK8S_OwnerName',
+    type: 'string',
+    description: 'Name of the source owner, such as Deployment name, StatefulSet name, etc.',
+    lokiLabel: true
+  },
+  {
+    name: 'SrcK8S_OwnerType',
+    type: 'string',
+    description: 'Kind of the source owner, such as Deployment, StatefulSet, etc.'
+  },
+  {
+    name: 'SrcK8S_Namespace',
+    type: 'string',
+    description: 'Source namespace',
+    lokiLabel: true
+  },
+  {
+    name: 'SrcAddr',
+    type: 'string',
+    description: 'Source IP address (ipv4 or ipv6)'
+  },
+  {
+    name: 'SrcPort',
+    type: 'number',
+    description: 'Source port'
+  },
+  {
+    name: 'SrcMac',
+    type: 'string',
+    description: 'Source MAC address'
+  },
+  {
+    name: 'SrcK8S_HostIP',
+    type: 'string',
+    description: 'Source node IP'
+  },
+  {
+    name: 'SrcK8S_HostName',
+    type: 'string',
+    description: 'Source node name'
+  },
+  {
+    name: 'SrcK8S_Zone',
+    type: 'string',
+    description: 'Source availability zone',
+    lokiLabel: true
+  },
+  {
+    name: 'DstK8S_Name',
+    type: 'string',
+    description: 'Name of the destination Kubernetes object, such as Pod name, Service name or Node name.'
+  },
+  {
+    name: 'DstK8S_Type',
+    type: 'string',
+    description: 'Kind of the destination Kubernetes object, such as Pod, Service or Node.',
+    lokiLabel: true
+  },
+  {
+    name: 'DstK8S_OwnerName',
+    type: 'string',
+    description: 'Name of the destination owner, such as Deployment name, StatefulSet name, etc.',
+    lokiLabel: true
+  },
+  {
+    name: 'DstK8S_OwnerType',
+    type: 'string',
+    description: 'Kind of the destination owner, such as Deployment, StatefulSet, etc.'
+  },
+  {
+    name: 'DstK8S_Namespace',
+    type: 'string',
+    description: 'Destination namespace',
+    lokiLabel: true
+  },
+  {
+    name: 'DstAddr',
+    type: 'string',
+    description: 'Destination IP address (ipv4 or ipv6)'
+  },
+  {
+    name: 'DstPort',
+    type: 'number',
+    description: 'Destination port'
+  },
+  {
+    name: 'DstMac',
+    type: 'string',
+    description: 'Destination MAC address'
+  },
+  {
+    name: 'DstK8S_HostIP',
+    type: 'string',
+    description: 'Destination node IP'
+  },
+  {
+    name: 'DstK8S_HostName',
+    type: 'string',
+    description: 'Destination node name'
+  },
+  {
+    name: 'DstK8S_Zone',
+    type: 'string',
+    description: 'Destination availability zone',
+    lokiLabel: true
+  },
+  {
+    name: 'K8S_FlowLayer',
+    type: 'string',
+    description: "Flow layer: 'app' or 'infra'"
+  },
+  {
+    name: 'Proto',
+    type: 'number',
+    description: 'L4 protocol'
+  },
+  {
+    name: 'Dscp',
+    type: 'number',
+    description: 'Differentiated Services Code Point (DSCP) value'
+  },
+  {
+    name: 'IcmpType',
+    type: 'number',
+    description: 'ICMP type'
+  },
+  {
+    name: 'IcmpCode',
+    type: 'number',
+    description: 'ICMP code'
+  },
+  {
+    name: 'Duplicate',
+    type: 'boolean',
+    description: 'Indicates if this flow was also captured from another interface on the same host',
+    lokiLabel: true
+  },
+  {
+    name: 'FlowDirection',
+    type: 'number',
+    description:
+      'Flow direction from the node observation point. Can be one of: +\n- 0: Ingress (incoming traffic, from the node observation point) +\n- 1: Egress (outgoing traffic, from the node observation point) +\n- 2: Inner (with the same source and destination node)\n',
+    lokiLabel: true
+  },
+  {
+    name: 'IfDirection',
+    type: 'number',
+    description:
+      'Flow direction from the network interface observation point. Can be one of: +\n- 0: Ingress (interface incoming traffic) +\n- 1: Egress (interface outgoing traffic)\n'
+  },
+  {
+    name: 'Interface',
+    type: 'string',
+    description: 'Network interface'
+  },
+  {
+    name: 'Flags',
+    type: 'number',
+    description:
+      'Logical OR combination of unique TCP flags comprised in the flow, as per RFC-9293, with additional custom flags to represent the following per-packet combinations: +\n- SYN+ACK (0x100) +\n- FIN+ACK (0x200) +\n- RST+ACK (0x400)\n'
+  },
+  {
+    name: 'Bytes',
+    type: 'number',
+    description: 'Number of bytes'
+  },
+  {
+    name: 'Packets',
+    type: 'number',
+    description: 'Number of packets'
+  },
+  {
+    name: 'PktDropBytes',
+    type: 'number',
+    description: 'Number of bytes dropped by the kernel'
+  },
+  {
+    name: 'PktDropPackets',
+    type: 'number',
+    description: 'Number of packets dropped by the kernel'
+  },
+  {
+    name: 'PktDropLatestState',
+    type: 'string',
+    description: 'TCP state on last dropped packet',
+    filter: 'pkt_drop_state'
+  },
+  {
+    name: 'PktDropLatestDropCause',
+    type: 'string',
+    description: 'Latest drop cause',
+    filter: 'pkt_drop_cause'
+  },
+  {
+    name: 'PktDropLatestFlags',
+    type: 'number',
+    description: 'TCP flags on last dropped packet'
+  },
+  {
+    name: 'DnsId',
+    type: 'number',
+    description: 'DNS record id'
+  },
+  {
+    name: 'DnsLatencyMs',
+    type: 'number',
+    description: 'Time between a DNS request and response, in milliseconds'
+  },
+  {
+    name: 'DnsFlags',
+    type: 'number',
+    description: 'DNS flags for DNS record'
+  },
+  {
+    name: 'DnsFlagsResponseCode',
+    type: 'string',
+    description: 'Parsed DNS header RCODEs name'
+  },
+  {
+    name: 'DnsErrno',
+    type: 'number',
+    description: 'Error number returned from DNS tracker ebpf hook function'
+  },
+  {
+    name: 'TimeFlowRttNs',
+    type: 'number',
+    description: 'TCP Smoothed Round Trip Time (SRTT), in nanoseconds'
+  },
+  {
+    name: 'K8S_ClusterName',
+    type: 'string',
+    description: 'Cluster name or identifier',
+    lokiLabel: true
+  },
+  {
+    name: '_RecordType',
+    type: 'string',
+    description:
+      "Type of record: 'flowLog' for regular flow logs, or 'newConnection', 'heartbeat', 'endConnection' for conversation tracking",
+    lokiLabel: true
+  },
+  {
+    name: '_HashId',
+    type: 'string',
+    description: 'In conversation tracking, the conversation identifier'
+  }
+] as FieldConfig[];
+
 // Customize columns order
-export const DefaultColumnSample = getDefaultColumns(ColumnConfigSampleDefs);
+export const DefaultColumnSample = getDefaultColumns(ColumnConfigSampleDefs, FieldConfigSample);
 export const AllSelectedColumnSample = DefaultColumnSample.map(c => {
   c.isSelected = true;
   return c;

--- a/web/src/components/__tests-data__/config.ts
+++ b/web/src/components/__tests-data__/config.ts
@@ -1,5 +1,5 @@
 import { defaultConfig } from '../../model/config';
-import { ColumnConfigSampleDefs } from './columns';
+import { ColumnConfigSampleDefs, FieldConfigSample } from './columns';
 import { FilterDefinitionSample } from './filters';
 
 export const FullConfigResultSample = {
@@ -12,7 +12,8 @@ export const FullConfigResultSample = {
   columns: ColumnConfigSampleDefs,
   filters: FilterDefinitionSample,
   sampling: 1,
-  features: ['pktDrop', 'dnsTracking', 'flowRTT']
+  features: ['pktDrop', 'dnsTracking', 'flowRTT'],
+  fields: FieldConfigSample
 };
 
 export const SimpleConfigResultSample = {

--- a/web/src/components/modals/columns-modal.tsx
+++ b/web/src/components/modals/columns-modal.tsx
@@ -85,8 +85,10 @@ export const ColumnsModal: React.FC<{
 
   const onReset = React.useCallback(() => {
     setResetClicked(true);
-    setUpdatedColumns(getDefaultColumns(config.columns).filter(c => columns.some(existing => existing.id === c.id)));
-  }, [columns, config.columns]);
+    setUpdatedColumns(
+      getDefaultColumns(config.columns, config.fields).filter(c => columns.some(existing => existing.id === c.id))
+    );
+  }, [columns, config.columns, config.fields]);
 
   const isSaveDisabled = React.useCallback(() => {
     return _.isEmpty(updatedColumns.filter(c => c.isSelected));

--- a/web/src/components/modals/export-modal.tsx
+++ b/web/src/components/modals/export-modal.tsx
@@ -70,7 +70,7 @@ export const ExportModal: React.FC<ExportModalProps> = ({
     if (isExportAll) {
       return undefined;
     }
-    return selectedColumns.filter(c => c.isSelected && c.fieldName != undefined).map(c => c.fieldName) as
+    return selectedColumns.filter(c => c.isSelected && c.field != undefined).map(c => c.field!.name) as
       | string[]
       | undefined;
   }, [isExportAll, selectedColumns]);

--- a/web/src/components/netflow-record/record-panel.tsx
+++ b/web/src/components/netflow-record/record-panel.tsx
@@ -76,9 +76,10 @@ export const RecordPanel: React.FC<RecordDrawerProps> = ({
   // hide empty columns
   const getVisibleColumns = React.useCallback(() => {
     const forbiddenColumns = deduperMerge ? [ColumnsId.flowdir, ColumnsId.interface] : [ColumnsId.flowdirints];
-    return columns.filter(
-      c => !forbiddenColumns.includes(c.id) && c.value(record) !== '' && !Number.isNaN(c.value(record))
-    );
+    return columns.filter((c: Column) => {
+      const value = c.value(record);
+      return !forbiddenColumns.includes(c.id) && value !== null && value !== '' && !Number.isNaN(value);
+    });
   }, [columns, deduperMerge, record]);
 
   const toggle = React.useCallback(
@@ -302,7 +303,7 @@ export const RecordPanel: React.FC<RecordDrawerProps> = ({
   }, [record.labels._RecordType, t]);
 
   const getSortedJSON = React.useCallback(() => {
-    const flat = { ...record.fields, ...record.labels };
+    const flat = { ...record.labels, ...record.fields };
     return JSON.stringify(flat, Object.keys(flat).sort(), 2);
   }, [record]);
 

--- a/web/src/components/netflow-traffic.tsx
+++ b/web/src/components/netflow-traffic.tsx
@@ -942,7 +942,7 @@ export const NetflowTraffic: React.FC<NetflowTrafficProps> = ({ forcedFilters, i
   React.useEffect(() => {
     if (initState.current.includes('configLoaded')) {
       setColumns(
-        getLocalStorage(LOCAL_STORAGE_COLS_KEY, getDefaultColumns(config.columns), {
+        getLocalStorage(LOCAL_STORAGE_COLS_KEY, getDefaultColumns(config.columns, config.fields), {
           id: 'id',
           criteria: 'isSelected'
         })
@@ -1827,7 +1827,7 @@ export const NetflowTraffic: React.FC<NetflowTrafficProps> = ({ forcedFilters, i
             isModalOpen={isExportModalOpen}
             setModalOpen={setExportModalOpen}
             flowQuery={buildFlowQuery()}
-            columns={columns.filter(c => c.fieldName && !c.fieldName.startsWith('Time'))}
+            columns={columns.filter(c => c.field && !c.field.name.startsWith('Time'))}
             range={range}
             filters={(forcedFilters || filters).list}
           />

--- a/web/src/model/config.ts
+++ b/web/src/model/config.ts
@@ -1,3 +1,4 @@
+import { FieldConfig } from '../utils/fields';
 import { ColumnConfigDef } from '../utils/columns';
 import { FilterConfigDef } from './filters';
 import { RecordType } from './flow-query';
@@ -25,6 +26,7 @@ export type Config = {
   sampling: number;
   features: Feature[];
   deduper: Deduper;
+  fields: FieldConfig[];
 };
 
 export const defaultConfig: Config = {
@@ -44,5 +46,6 @@ export const defaultConfig: Config = {
   deduper: {
     mark: true,
     merge: false
-  }
+  },
+  fields: []
 };

--- a/web/src/utils/fields.ts
+++ b/web/src/utils/fields.ts
@@ -1,0 +1,10 @@
+export type FieldType = 'string' | 'number';
+
+export interface FieldConfig {
+  name: string;
+  type: FieldType;
+  description: string;
+  // This flag is for documentation only. Use loki.labels instead
+  lokiLabel?: boolean;
+  filter?: string;
+}

--- a/web/src/utils/fields.ts
+++ b/web/src/utils/fields.ts
@@ -4,7 +4,5 @@ export interface FieldConfig {
   name: string;
   type: FieldType;
   description: string;
-  // This flag is for documentation only. Use loki.labels instead
-  lokiLabel?: boolean;
   filter?: string;
 }


### PR DESCRIPTION
## Description

Followup on https://github.com/netobserv/network-observability-operator/pull/550:
- [X] get fields from ConfigMap
- [X] force types when necessary

I decided to keep `loki.labels` instead of reusing fields `lokiLabel` since these are generated only for documentation purpose for now.

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
