### PR TITLE
NETOBSERV-1551: show cross-nodes duplicates in merge mode

### DIFF
--- a/web/src/components/netflow-traffic.tsx
+++ b/web/src/components/netflow-traffic.tsx
@@ -572,7 +572,7 @@ export const NetflowTraffic: React.FC<NetflowTrafficProps> = ({ forcedFilters, i
       }
       const promises: Promise<Stats>[] = [
         getRecords(tableQuery).then(res => {
-          const flows = showDuplicates ? res.records : mergeFlowReporters(res.records);
+          const flows = (showDuplicates || !config.deduper.mark) ? res.records : mergeFlowReporters(res.records);
           setFlows(flows);
           return res.stats;
         })

--- a/web/src/components/netflow-traffic.tsx
+++ b/web/src/components/netflow-traffic.tsx
@@ -572,7 +572,7 @@ export const NetflowTraffic: React.FC<NetflowTrafficProps> = ({ forcedFilters, i
       }
       const promises: Promise<Stats>[] = [
         getRecords(tableQuery).then(res => {
-          const flows = (showDuplicates || !config.deduper.mark) ? res.records : mergeFlowReporters(res.records);
+          const flows = showDuplicates ? res.records : mergeFlowReporters(res.records);
           setFlows(flows);
           return res.stats;
         })

--- a/web/src/utils/columns.ts
+++ b/web/src/utils/columns.ts
@@ -283,7 +283,7 @@ export const getDefaultColumns = (columnDefs: ColumnConfigDef[], fieldConfigs: F
       console.error('Column ' + id + " doesn't specify type");
     }
     // check if value type match and convert it if needed
-    if (value && value !== '' && typeof value !== type) {
+    if (value && value !== '' && typeof value !== type && !Array.isArray(value)) {
       switch (type) {
         case 'number':
           return Number(value);

--- a/web/src/utils/flows.ts
+++ b/web/src/utils/flows.ts
@@ -1,21 +1,54 @@
 import * as _ from 'lodash';
-import { Record } from '../api/ipfix';
+import { IfDirection, Record } from '../api/ipfix';
 import { get5Tuple } from './ids';
+
+const electMostRelevant = (flowsFor5Tuples: Record[]): Record => {
+  // Get most relevant record, in priority with Dns or Drops info
+  // Fallback on first entry
+  return (
+    flowsFor5Tuples.find(
+      f => f.fields.DnsId !== undefined || f.fields.PktDropBytes !== undefined || f.fields.PktDropPackets !== undefined
+    ) || flowsFor5Tuples[0]
+  );
+};
+
+const getInvolvedInterfaces = (flowsFor5Tuples: Record[]): { ifnames: string[]; ifdirs: IfDirection[] } => {
+  const cache = new Set();
+  const ifnames: string[] = [];
+  const ifdirs: IfDirection[] = [];
+  flowsFor5Tuples.forEach(f => {
+    if (f.fields.IfDirections && f.fields.Interfaces) {
+      _.zip(f.fields.IfDirections, f.fields.Interfaces).forEach(([ifdir, ifname]) => {
+        const key = `${ifdir}@${ifname}`;
+        if (!cache.has(key)) {
+          cache.add(key);
+          ifnames.push(ifname!);
+          ifdirs.push(ifdir!);
+        }
+      });
+    }
+  });
+  return { ifnames, ifdirs };
+};
 
 export const mergeFlowReporters = (flows: Record[]): Record[] => {
   // The purpose of this function is to determine if, for a given 5 tuple, we'll look at INGRESS, EGRESS or INNER reporter
   // The assumption is that INGRESS alone, EGRESS alone or INNER alone always provide a complete visiblity
   // Favor whichever contains pktDrop and/or DNS responses
   const grouped = _.groupBy(flows, get5Tuple);
-  const filtersIndex = _.mapValues(
-    grouped,
-    (recs: Record[]) =>
-      (
-        recs.find(
-          r =>
-            r.fields.DnsId !== undefined || r.fields.PktDropBytes !== undefined || r.fields.PktDropPackets !== undefined
-        ) || recs[0]
-      ).labels.FlowDirection!
-  );
-  return flows.filter((r: Record) => r.labels.FlowDirection! === filtersIndex[get5Tuple(r)]);
+  const filtersIndex = _.mapValues(grouped, (records: Record[]) => electMostRelevant(records));
+  const involvedInterfaces = _.mapValues(grouped, (records: Record[]) => getInvolvedInterfaces(records));
+  // Filter and inject other interfaces in elected flows
+  // An assumption is made that interfaces involved for a 5 tuples will keep being involved in the whole flows sequence
+  // If that assumption proves wrong, we may refine by looking at time overlaps between flows
+  return flows
+    .filter((r: Record) => r.labels.FlowDirection === filtersIndex[get5Tuple(r)].labels.FlowDirection)
+    .map(r => {
+      const interfaces = involvedInterfaces[get5Tuple(r)];
+      if (interfaces) {
+        r.fields.Interfaces = interfaces.ifnames;
+        r.fields.IfDirections = interfaces.ifdirs;
+      }
+      return r;
+    });
 };


### PR DESCRIPTION
## Description

This PR currently just shows the cross-nodes duplicates.

Following the reproduce steps described in [NETOBSERV-1551](https://issues.redhat.com//browse/NETOBSERV-1551), I'm now seeing both interfaces:
![image](https://github.com/netobserv/network-observability-console-plugin/assets/2153442/25275b8e-a765-4ea8-bf27-ce342dd9ac0e)

But they are displayed as distinct flows. So it raises the question: should we reintroduce the "Show duplicates" checkbox, since there are still the cross-nodes duplicates even in merge mode? Or should we merge them post-query without asking? If we do so, what to put in Node Direction? "both" ?

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
