### PR TITLE
updates for cypress Dockerfile

### DIFF
--- a/Dockerfile.cypress
+++ b/Dockerfile.cypress
@@ -1,15 +1,59 @@
-# syntax = edrevo/dockerfile-plus
-INCLUDE+ Dockerfile
+ARG BUILDSCRIPT=
+ARG LDFLAGS=
+FROM docker.io/library/node:16-alpine as web-builder
+USER node
+
+ARG BUILDSCRIPT
+WORKDIR /opt/app-root
+
+COPY --chown=node web/package.json web/package.json
+COPY --chown=node web/package-lock.json web/package-lock.json
+WORKDIR /opt/app-root/web
+RUN npm ci
+
+WORKDIR /opt/app-root
+COPY --chown=node web web
+COPY mocks mocks
+
+WORKDIR /opt/app-root/web
+RUN npm run format-all
+RUN npm run build$BUILDSCRIPT
+
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.21 as go-builder
+
+ARG LDFLAGS
+WORKDIR /opt/app-root
+
+COPY go.mod go.mod
+COPY go.sum go.sum
+COPY vendor/ vendor/
+COPY .mk/ .mk/
+COPY cmd/ cmd/
+COPY pkg/ pkg/
+
+RUN CGO_ENABLED=0 go build -ldflags "$LDFLAGS" -mod vendor -o plugin-backend cmd/plugin-backend.go
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3
+
+COPY --from=web-builder /opt/app-root/web/dist ./web/dist
+COPY --from=go-builder /opt/app-root/plugin-backend ./
 
 FROM cypress/included:13.6.5
-
+RUN whoami
 WORKDIR /opt/app-root
 COPY --from=web-builder /opt/app-root/web/ ./web
 COPY --from=go-builder /opt/app-root/plugin-backend ./
+
 COPY mocks mocks
 COPY config/sample-config.yaml ./config/config.yaml
 RUN sed -i -e 's/useMocks: false/useMocks: true/g' ./config/config.yaml
 COPY scripts/cypress.sh .
-RUN chmod 775 -R ./cypress.sh
+RUN mkdir -p /.config && chmod 775 -R /.config
+ENV HOME=/home/user
+RUN mkdir -p /home/user && chmod -R 775 ./cypress.sh && \
+    chmod 775 plugin-backend && \
+    cp -r /root/.cache /home/user/ && \
+    chgrp -R 0 /opt/app-root /home/user && \
+    chmod -R g+rwX /opt/app-root /root web /home/user
 
-ENTRYPOINT ["./cypress.sh"]
+ENTRYPOINT ["./plugin-backend", "--loglevel", "info", "--config", "./config/config.yaml"]

--- a/scripts/cypress.sh
+++ b/scripts/cypress.sh
@@ -12,6 +12,6 @@ npm run cypress:run
 cypress=$?
 
 kill $backend
-wait $backend
+wait $backend || true
 
 exit $cypress


### PR DESCRIPTION
## Description

NETOBSERV-1520 Cypress Dockerfile updates based on changes tested here: https://github.com/openshift/release/pull/48810 


## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
