### PR TITLE
NETOBSERV-1596 fix latest not resetting on DNS / RTT metrics

### DIFF
--- a/web/src/model/flow-query.ts
+++ b/web/src/model/flow-query.ts
@@ -59,5 +59,5 @@ export const filterByHashId = (hashId: string): string => {
 };
 
 export const isTimeMetric = (metricType: MetricType | undefined) => {
-  return ['dnsLatencies', 'flowRtt'].includes(metricType || '');
+  return ['DnsLatencyMs', 'TimeFlowRttNs'].includes(metricType || '');
 };


### PR DESCRIPTION
## Description

Steps to reproduce:
- Show latest bytes
- Switch to DNS

Metric function `must` switch to `average`.

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
