### PR TITLE
NETOBSERV-1630 allow not for ip filters

### DIFF
--- a/pkg/model/filters/logql.go
+++ b/pkg/model/filters/logql.go
@@ -114,6 +114,15 @@ func IPLabelFilter(labelKey, cidr string) LabelFilter {
 	}
 }
 
+func NotIPLabelFilter(labelKey, cidr string) LabelFilter {
+	return LabelFilter{
+		key:       labelKey,
+		matcher:   labelNotEqual,
+		value:     cidr,
+		valueType: typeIP,
+	}
+}
+
 func MultiValuesRegexFilter(labelKey string, values []string, not bool) (LabelFilter, bool) {
 	regexStr := strings.Builder{}
 	for i, value := range values {


### PR DESCRIPTION
## Description

Allow `not` for ip filters
![image](https://github.com/netobserv/network-observability-console-plugin/assets/91894519/ed329f14-5454-4bec-9e31-f70d6d10df25)

https://grafana.com/docs/loki/latest/query/ip/

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
