### PR TITLE
NETOBSERV-1636: add OvsMonitorMDs as field array

### DIFF
--- a/pkg/model/fields/fields.go
+++ b/pkg/model/fields/fields.go
@@ -46,6 +46,7 @@ const (
 	FlowDirection          = "FlowDirection"
 	Interfaces             = "Interfaces"
 	IfDirections           = "IfDirections"
+	OvsMonitorMDs          = "OvsMonitorMDs"
 	DNSID                  = "DnsId"
 	DNSLatency             = "DnsLatencyMs"
 	DNSErrNo               = "DnsErrno"
@@ -91,7 +92,8 @@ func IsArray(v string) bool {
 	switch v {
 	case
 		IfDirections,
-		Interfaces:
+		Interfaces,
+		OvsMonitorMDs:
 		return true
 	default:
 		return false

--- a/pkg/model/fields/fields.go
+++ b/pkg/model/fields/fields.go
@@ -46,7 +46,7 @@ const (
 	FlowDirection          = "FlowDirection"
 	Interfaces             = "Interfaces"
 	IfDirections           = "IfDirections"
-	OvsMonitorMDs          = "OvsMonitorMDs"
+	NetworkEvents          = "NetworkEvents"
 	DNSID                  = "DnsId"
 	DNSLatency             = "DnsLatencyMs"
 	DNSErrNo               = "DnsErrno"
@@ -93,7 +93,7 @@ func IsArray(v string) bool {
 	case
 		IfDirections,
 		Interfaces,
-		OvsMonitorMDs:
+		NetworkEvents:
 		return true
 	default:
 		return false

--- a/web/src/api/ipfix.ts
+++ b/web/src/api/ipfix.ts
@@ -115,6 +115,8 @@ export interface Fields {
   Interfaces?: string[];
   /** Flow direction array from the network interface observation point */
   IfDirections?: IfDirection[];
+  /** OVS monitoring metadatas */
+  OvsMonitorMDs?: string[];
   /** Logical OR combination of unique TCP flags comprised in the flow, as per RFC-9293, with additional custom flags to represent the following per-packet combinations: SYN+ACK (0x100), FIN+ACK (0x200) and RST+ACK (0x400). */
   Flags?: number;
   /** Number of packets */

--- a/web/src/api/ipfix.ts
+++ b/web/src/api/ipfix.ts
@@ -115,8 +115,8 @@ export interface Fields {
   Interfaces?: string[];
   /** Flow direction array from the network interface observation point */
   IfDirections?: IfDirection[];
-  /** OVS monitoring metadatas */
-  OvsMonitorMDs?: string[];
+  /** Network Events */
+  NetworkEvents?: string[];
   /** Logical OR combination of unique TCP flags comprised in the flow, as per RFC-9293, with additional custom flags to represent the following per-packet combinations: SYN+ACK (0x100), FIN+ACK (0x200) and RST+ACK (0x400). */
   Flags?: number;
   /** Number of packets */


### PR DESCRIPTION
## Description

Add `OvsMonitorMDs` field from https://github.com/netobserv/network-observability-operator/pull/664 & https://github.com/netobserv/netobserv-ebpf-agent/pull/286

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
