### PR TITLE
NETOBSERV-1649: remove obsolete comment

### DIFF
--- a/pkg/handler/topology.go
+++ b/pkg/handler/topology.go
@@ -296,7 +296,6 @@ func getEligiblePromMetric(promInventory *prometheus.Inventory, filters filters.
 	if in.RecordType != "" && in.RecordType != constants.RecordTypeLog {
 		return nil, fmt.Sprintf("RecordType not managed: %s", in.RecordType)
 	}
-	// TODO: packetLoss, how can we handle that?
 
 	labelsNeeded, _ := prometheus.GetLabelsAndFilter(in.Aggregate, in.Groups)
 	fromFilters, unsupportedReason := prometheus.FiltersToLabels(filters)


### PR DESCRIPTION
Note, there's just nothing to do on the console plugin side, this is all managed in https://github.com/netobserv/network-observability-operator/pull/676