### PR TITLE
NETOBSERV-1720: fix issues with topology scopes

### DIFF
--- a/web/src/components/netflow-topology/netflow-topology.tsx
+++ b/web/src/components/netflow-topology/netflow-topology.tsx
@@ -109,6 +109,7 @@ export const NetflowTopology: React.FC<NetflowTopologyProps> = ({
             metricType={metricType}
             metricScope={metricScope}
             setMetricScope={setMetricScope}
+            allowedScopes={allowedScopes}
             metrics={displayedMetrics}
             droppedMetrics={droppedMetrics}
             options={options}


### PR DESCRIPTION
Fixes also [NETOBSERV-1721](https://issues.redhat.com//browse/NETOBSERV-1721) and [NETOBSERV-1722](https://issues.redhat.com//browse/NETOBSERV-1722)

- new func getStepIntoNext that provides the next scope for 'stepInto' and cares about the allowed scopes
- fix call to toggleDirElementFilter on stepInto (it was *removing* the filter instead of adding it), and prevent adding duplicate filters
- Do not link groups invalidation to scope via useEffect, as it results in doing 2 queries (first with the invalid group, then without). Make them more strictly tied instead.

Also, this PR changes the stepInto workflow when coming from nodes, it jumps directly to pods. Two reasons for that:
- this seems more logical to see pods rather than namespaces when "stepping into a node". Namespaces and Nodes are orthogonal, whereas Pods are contained in Nodes.
- more pragmatically, this also is a better workflow in lokiless, since having scope=namespace + filtering on a node generates an error.

The new stepInto workflow is:

```
                         
 CLUSTER                 
    │                    
    ▼                    
  ZONE                   
    │                    
    ▼                    
  NODE         NAMESPACE 
    │              │     
    │              ▼     
    │            OWNER   
    │              │     
    └──────┬───────┘     
           │             
           ▼             
        RESOURCE         
                         
```

## Description

<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [x] Does this PR require a product release notes entry?
  * [x] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
