### PR TITLE
NETOBSERV-1768 force tooltip style

### DIFF
--- a/web/src/components/drawer/record/record-field.css
+++ b/web/src/components/drawer/record/record-field.css
@@ -57,12 +57,12 @@
   visibility: hidden;
   transition-property: visibility;
   transition-delay: 0.5s;
-  background-color: #151515;
-  padding: .5rem;
-  color: #fff;
+  background-color: #151515 !important;
+  padding: .5rem !important;
+  color: #fff !important;
   text-align: center;
   word-break: break-word;
-  font-size: 13px;
+  font-size: 13px !important;
   position: absolute;
   z-index: 1;
   width: max-content;


### PR DESCRIPTION
## Description

Force tooltip style to display properly on every OCP version

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
