### PR TITLE
NETOBSERV-1818: Topology split pod when using two IPs

### DIFF
--- a/web/src/utils/ids.ts
+++ b/web/src/utils/ids.ts
@@ -40,10 +40,11 @@ export const getPeerId = (fields: Partial<TopologyMetricPeer>): string => {
   if (fields.owner) {
     parts.push('o=' + fields.owner.type + '.' + fields.owner.name);
   }
+  // add either resource info or address but not both
+  // as some items can have multiple IPs
   if (fields.resource) {
     parts.push('r=' + fields.resource.type + '.' + fields.resource.name);
-  }
-  if (fields.addr) {
+  } else if (fields.addr) {
     parts.push('a=' + fields.addr);
   }
   return parts.length > 0 ? parts.join(',') : idUnknown;


### PR DESCRIPTION
## Description

Don't append ip to topology ids when not needed.

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
