### PR TITLE
NETOBSERV-1816 allow n/a filter

### DIFF
--- a/web/locales/en/plugin__netobserv-plugin.json
+++ b/web/locales/en/plugin__netobserv-plugin.json
@@ -411,6 +411,7 @@
   "Last 1 week": "Last 1 week",
   "Last 2 weeks": "Last 2 weeks",
   "Value is empty": "Value is empty",
+  "Value is malformed": "Value is malformed",
   "Not a valid Kubernetes name": "Not a valid Kubernetes name",
   "Incomplete resource name, either kind, namespace or name is missing.": "Incomplete resource name, either kind, namespace or name is missing.",
   "Kind is empty": "Kind is empty",

--- a/web/src/components/toolbar/filters-toolbar.tsx
+++ b/web/src/components/toolbar/filters-toolbar.tsx
@@ -121,11 +121,17 @@ export const FiltersToolbar: React.FC<FiltersToolbarProps> = ({
     switch (selectedFilter.component) {
       case 'text':
       case 'number':
-        return <TextFilter {...commonProps} regexp={selectedFilter.component === 'number' ? /\D/g : undefined} />;
+        return (
+          <TextFilter
+            {...commonProps}
+            allowEmpty={selectedCompare !== FilterCompare.moreThanOrEqual}
+            regexp={selectedFilter.component === 'number' ? /\D/g : undefined}
+          />
+        );
       case 'autocomplete':
         return <AutocompleteFilter {...commonProps} />;
     }
-  }, [selectedFilter, addFilter, indicator, setIndicator, setMessageWithDelay]);
+  }, [selectedFilter, addFilter, setMessageWithDelay, indicator, selectedCompare]);
 
   const isForced = !_.isEmpty(forcedFilters);
   const filtersOrForced = isForced ? forcedFilters : filters;

--- a/web/src/components/toolbar/filters/autocomplete-filter.tsx
+++ b/web/src/components/toolbar/filters/autocomplete-filter.tsx
@@ -14,6 +14,7 @@ import * as React from 'react';
 import { createFilterValue, FilterDefinition, FilterOption, FilterValue } from '../../../model/filters';
 import { autoCompleteCache } from '../../../utils/autocomplete-cache';
 import { getHTTPErrorDetails } from '../../../utils/errors';
+import { undefinedValue } from '../../../utils/filter-definitions';
 import { Indicator } from '../../../utils/filters-helper';
 import { usePrevious } from '../../../utils/previous-hook';
 import './autocomplete-filter.css';
@@ -128,13 +129,19 @@ export const AutocompleteFilter: React.FC<AutocompleteFilterProps> = ({
   );
 
   const onEnter = React.useCallback(() => {
+    // override empty value by undefined value
+    let v = currentValue;
+    if (currentValue.length === 0) {
+      v = undefinedValue;
+    }
+
     // Only one choice is present, consider this is what is desired
     if (options.length === 1) {
       onAutoCompleteOptionSelected(options[0]);
       return;
     }
 
-    const validation = filterDefinition.validate(currentValue);
+    const validation = filterDefinition.validate(v);
     //show tooltip and icon when user try to validate filter
     if (!_.isEmpty(validation.err)) {
       setMessageWithDelay(validation.err);

--- a/web/src/components/toolbar/filters/text-filter.tsx
+++ b/web/src/components/toolbar/filters/text-filter.tsx
@@ -3,6 +3,7 @@ import { SearchIcon } from '@patternfly/react-icons';
 import * as _ from 'lodash';
 import * as React from 'react';
 import { createFilterValue, FilterDefinition, FilterValue } from '../../../model/filters';
+import { doubleQuoteValue, undefinedValue } from '../../../utils/filter-definitions';
 import { Indicator } from '../../../utils/filters-helper';
 
 export interface TextFilterProps {
@@ -38,7 +39,7 @@ export const TextFilter: React.FC<TextFilterProps> = ({
   const updateValue = React.useCallback(
     (v: string) => {
       let filteredValue = v;
-      if (regexp) {
+      if (![doubleQuoteValue, undefinedValue].includes(filteredValue) && regexp) {
         filteredValue = filteredValue.replace(regexp, '');
       }
       setCurrentValue(filteredValue);

--- a/web/src/components/toolbar/filters/text-filter.tsx
+++ b/web/src/components/toolbar/filters/text-filter.tsx
@@ -12,6 +12,7 @@ export interface TextFilterProps {
   setMessageWithDelay: (m: string | undefined) => void;
   indicator: Indicator;
   setIndicator: (ind: Indicator) => void;
+  allowEmpty?: boolean;
   regexp?: RegExp;
 }
 
@@ -21,6 +22,7 @@ export const TextFilter: React.FC<TextFilterProps> = ({
   setMessageWithDelay,
   indicator,
   setIndicator,
+  allowEmpty,
   regexp
 }) => {
   const searchInputRef = React.useRef<HTMLInputElement | null>(null);
@@ -56,8 +58,12 @@ export const TextFilter: React.FC<TextFilterProps> = ({
   const onSelect = React.useCallback(() => {
     // override empty value by undefined value
     let v = currentValue;
-    if (currentValue.length === 0) {
-      v = undefinedValue;
+    if (allowEmpty) {
+      if (currentValue.length === 0) {
+        v = undefinedValue;
+      }
+    } else if (v === undefinedValue) {
+      v = '';
     }
 
     const validation = filterDefinition.validate(String(v));
@@ -73,7 +79,7 @@ export const TextFilter: React.FC<TextFilterProps> = ({
         resetFilterValue();
       }
     });
-  }, [filterDefinition, currentValue, setMessageWithDelay, setIndicator, addFilter, resetFilterValue]);
+  }, [currentValue, allowEmpty, filterDefinition, setMessageWithDelay, setIndicator, addFilter, resetFilterValue]);
 
   return (
     <>

--- a/web/src/components/toolbar/filters/text-filter.tsx
+++ b/web/src/components/toolbar/filters/text-filter.tsx
@@ -54,7 +54,13 @@ export const TextFilter: React.FC<TextFilterProps> = ({
   }, [setCurrentValue, setMessageWithDelay, setIndicator]);
 
   const onSelect = React.useCallback(() => {
-    const validation = filterDefinition.validate(String(currentValue));
+    // override empty value by undefined value
+    let v = currentValue;
+    if (currentValue.length === 0) {
+      v = undefinedValue;
+    }
+
+    const validation = filterDefinition.validate(String(v));
     //show tooltip and icon when user try to validate filter
     if (!_.isEmpty(validation.err)) {
       setMessageWithDelay(validation.err);

--- a/web/src/model/filters.ts
+++ b/web/src/model/filters.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import { isEqual } from '../utils/base-compare';
+import { undefinedValue } from '../utils/filter-definitions';
 
 export type FiltersEncoder = (values: FilterValue[], matchAny: boolean, not: boolean, moreThan: boolean) => string;
 
@@ -94,7 +95,9 @@ export interface FilterOption {
 export const createFilterValue = (def: FilterDefinition, value: string): Promise<FilterValue> => {
   return def.getOptions(value).then(opts => {
     const option = opts.find(opt => opt.name === value || opt.value === value);
-    return option ? { v: option.value, display: option.name } : { v: value };
+    return option
+      ? { v: option.value, display: option.name }
+      : { v: value, display: value === undefinedValue ? 'n/a' : undefined };
   });
 };
 

--- a/web/src/utils/filter-definitions.ts
+++ b/web/src/utils/filter-definitions.ts
@@ -38,6 +38,8 @@ import { validateK8SName, validateStrictK8SName } from './label';
 
 // Convenience string to filter by undefined field values
 export const undefinedValue = '""';
+// Unique double are allowed while typing but invalid
+export const doubleQuoteValue = '"';
 
 const matcher = (left: string, right: string[], not: boolean, moreThan: boolean) =>
   `${left}${not ? '!=' : moreThan ? '>=' : '='}${right.join(',')}`;
@@ -136,15 +138,19 @@ export const getFilterDefinitions = (
     if (_.isEmpty(value)) {
       return invalid(t('Value is empty'));
     }
+    if (value === doubleQuoteValue) {
+      return invalid(t('Value is malformed'));
+    }
     return valid(value);
   };
 
   const k8sNameValidation = (value: string) => {
     if (_.isEmpty(value)) {
-      // Replace with exact match
-      return valid('""');
+      return invalid(t('Value is empty'));
     }
-    return value === '""' || validateK8SName(value) ? valid(value) : invalid(t('Not a valid Kubernetes name'));
+    return value === undefinedValue || validateK8SName(value)
+      ? valid(value)
+      : invalid(t('Not a valid Kubernetes name'));
   };
 
   const k8sResourceValidation = (value: string) => {
@@ -208,7 +214,7 @@ export const getFilterDefinitions = (
     if (_.isEmpty(value)) {
       return invalid(t('Value is empty'));
     }
-    return /^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})/.test(value)
+    return value == undefinedValue || /^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})/.test(value)
       ? valid(value)
       : invalid(t('Not a valid MAC address'));
   };


### PR DESCRIPTION
## Description

Allow filtering on `n/a` by searching on strict value `""` in the text input.

![image](https://github.com/user-attachments/assets/40806975-f5f3-44d0-b461-f0a735872121)
![image](https://github.com/user-attachments/assets/5afa96e7-8e29-4aed-91fb-9f3bb6e8228e)
![image](https://github.com/user-attachments/assets/226a6857-98ed-4214-9b1e-a9acc63fa9aa)
![image](https://github.com/user-attachments/assets/1d00e241-7d99-42a6-8500-1320b5f6f7ed)

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
