### PR TITLE
NETOBSERV-1783 invalidate local storage values

### DIFF
--- a/web/src/components/dropdowns/__tests__/metric-type-dropdown.spec.tsx
+++ b/web/src/components/dropdowns/__tests__/metric-type-dropdown.spec.tsx
@@ -1,10 +1,12 @@
 import { mount, shallow } from 'enzyme';
 import * as React from 'react';
 
+import { MetricType } from '../../../model/flow-query';
 import { MetricTypeDropdown } from '../metric-type-dropdown';
 
 describe('<MetricDropdown />', () => {
   const props = {
+    allowedTypes: ['Bytes', 'Packets'] as MetricType[],
     selected: 'Bytes',
     setMetricType: jest.fn(),
     id: 'metric'

--- a/web/src/components/dropdowns/metric-type-dropdown.tsx
+++ b/web/src/components/dropdowns/metric-type-dropdown.tsx
@@ -6,10 +6,7 @@ import { MetricType } from '../../model/flow-query';
 export interface MetricTypeDropdownProps {
   selected?: string;
   setMetricType: (v: MetricType) => void;
-  isTopology?: boolean;
-  allowPktDrop?: boolean;
-  allowDNSMetric?: boolean;
-  allowRTTMetric?: boolean;
+  allowedTypes: MetricType[];
   id?: string;
 }
 
@@ -17,29 +14,10 @@ export const MetricTypeDropdown: React.FC<MetricTypeDropdownProps> = ({
   selected,
   setMetricType,
   id,
-  isTopology,
-  allowPktDrop,
-  allowDNSMetric,
-  allowRTTMetric
+  allowedTypes
 }) => {
   const { t } = useTranslation('plugin__netobserv-plugin');
   const [metricDropdownOpen, setMetricDropdownOpen] = React.useState(false);
-
-  const getMetricTypeOptions = React.useCallback(() => {
-    let options: MetricType[] = ['Bytes', 'Packets'];
-    if (isTopology) {
-      if (allowPktDrop) {
-        options = options.concat('PktDropBytes', 'PktDropPackets');
-      }
-      if (allowDNSMetric) {
-        options.push('DnsLatencyMs');
-      }
-      if (allowRTTMetric) {
-        options.push('TimeFlowRttNs');
-      }
-    }
-    return options;
-  }, [allowDNSMetric, allowPktDrop, allowRTTMetric, isTopology]);
 
   const getMetricDisplay = React.useCallback(
     (metricType: MetricType): string => {
@@ -78,7 +56,7 @@ export const MetricTypeDropdown: React.FC<MetricTypeDropdownProps> = ({
         </DropdownToggle>
       }
       isOpen={metricDropdownOpen}
-      dropdownItems={getMetricTypeOptions().map(v => (
+      dropdownItems={allowedTypes.map(v => (
         <DropdownItem
           data-test={v}
           id={v}

--- a/web/src/components/dropdowns/topology-display-dropdown.tsx
+++ b/web/src/components/dropdowns/topology-display-dropdown.tsx
@@ -15,9 +15,7 @@ export const TopologyDisplayDropdown: React.FC<{
   setMetricScope: (s: FlowScope) => void;
   topologyOptions: TopologyOptions;
   setTopologyOptions: (o: TopologyOptions) => void;
-  allowPktDrop: boolean;
-  allowDNSMetric: boolean;
-  allowRTTMetric: boolean;
+  allowedTypes: MetricType[];
   allowedScopes: FlowScope[];
 }> = ({
   metricFunction,
@@ -28,9 +26,7 @@ export const TopologyDisplayDropdown: React.FC<{
   setMetricScope,
   topologyOptions,
   setTopologyOptions,
-  allowPktDrop,
-  allowDNSMetric,
-  allowRTTMetric,
+  allowedTypes,
   allowedScopes
 }) => {
   const { t } = useTranslation('plugin__netobserv-plugin');
@@ -53,9 +49,7 @@ export const TopologyDisplayDropdown: React.FC<{
             setMetricScope={setMetricScope}
             topologyOptions={topologyOptions}
             setTopologyOptions={setTopologyOptions}
-            allowPktDrop={allowPktDrop}
-            allowDNSMetric={allowDNSMetric}
-            allowRTTMetric={allowRTTMetric}
+            allowedTypes={allowedTypes}
             allowedScopes={allowedScopes}
           />
         }

--- a/web/src/components/dropdowns/topology-display-options.tsx
+++ b/web/src/components/dropdowns/topology-display-options.tsx
@@ -24,9 +24,7 @@ export interface TopologyDisplayOptionsProps {
   setMetricScope: (s: FlowScope) => void;
   topologyOptions: TopologyOptions;
   setTopologyOptions: (o: TopologyOptions) => void;
-  allowPktDrop: boolean;
-  allowDNSMetric: boolean;
-  allowRTTMetric: boolean;
+  allowedTypes: MetricType[];
   allowedScopes: FlowScope[];
 }
 
@@ -39,9 +37,7 @@ export const TopologyDisplayOptions: React.FC<TopologyDisplayOptionsProps> = ({
   setMetricScope,
   topologyOptions,
   setTopologyOptions,
-  allowPktDrop,
-  allowDNSMetric,
-  allowRTTMetric,
+  allowedTypes,
   allowedScopes
 }) => {
   const { t } = useTranslation('plugin__netobserv-plugin');
@@ -92,12 +88,9 @@ export const TopologyDisplayOptions: React.FC<TopologyDisplayOptionsProps> = ({
               <MetricTypeDropdown
                 data-test="metricType"
                 id="metricType"
-                isTopology
                 selected={metricType}
                 setMetricType={setMetricType}
-                allowPktDrop={allowPktDrop}
-                allowDNSMetric={allowDNSMetric}
-                allowRTTMetric={allowRTTMetric}
+                allowedTypes={allowedTypes}
               />
             </FlexItem>
           </Flex>

--- a/web/src/components/netflow-traffic.tsx
+++ b/web/src/components/netflow-traffic.tsx
@@ -7,11 +7,10 @@ import { useTranslation } from 'react-i18next';
 import { defaultNetflowMetrics, Stats } from '../api/loki';
 import { Config } from '../model/config';
 import { Filters, getDisabledFiltersRecord, getEnabledFilters } from '../model/filters';
-import { filtersToString, FlowQuery, FlowScope, isTimeMetric, MetricType } from '../model/flow-query';
-import { MetricScopeOptions } from '../model/metrics';
+import { filtersToString, FlowQuery, FlowScope, MetricType } from '../model/flow-query';
 import { netflowTrafficModel } from '../model/netflow-traffic';
 import { parseQuickFilters } from '../model/quick-filters';
-import { getGroupsForScope, TopologyGroupTypes } from '../model/topology';
+import { TopologyGroupTypes } from '../model/topology';
 import { getFetchFunctions as getBackAndForthFetch } from '../utils/back-and-forth';
 import { ColumnsId, getDefaultColumns } from '../utils/columns';
 import { loadConfig } from '../utils/config';
@@ -29,8 +28,11 @@ import { mergeStats } from '../utils/metrics';
 import { dnsIdMatcher, droppedIdMatcher, getDefaultOverviewPanels, rttIdMatcher } from '../utils/overview-panels';
 import { usePoll } from '../utils/poll-hook';
 import {
+  defaultMetricScope,
+  defaultMetricType,
   defaultTimeRange,
   getFiltersFromURL,
+  setURLDatasource,
   setURLFilters,
   setURLLimit,
   setURLMatch,
@@ -44,7 +46,6 @@ import {
 import { useTheme } from '../utils/theme-hook';
 import { getURLParams, hasEmptyParams, netflowTrafficPath, removeURLParam, setURLParams, URLParam } from '../utils/url';
 import NetflowTrafficDrawer, { NetflowTrafficDrawerHandle } from './drawer/netflow-traffic-drawer';
-import { rateMetricFunctions, timeMetricFunctions } from './dropdowns/metric-function-dropdown';
 import { limitValues, topValues } from './dropdowns/query-options-panel';
 import { RefreshDropdown } from './dropdowns/refresh-dropdown';
 import TimeRangeDropdown from './dropdowns/time-range-dropdown';
@@ -171,6 +172,22 @@ export const NetflowTraffic: React.FC<NetflowTrafficProps> = ({
     return scopes;
   }, [isMultiCluster, isZones, dataSourceHasLabels]);
 
+  const getAllowedMetricTypes = React.useCallback(() => {
+    let options: MetricType[] = ['Bytes', 'Packets'];
+    if (model.selectedViewId === 'topology') {
+      if (isPktDrop()) {
+        options = options.concat('PktDropBytes', 'PktDropPackets');
+      }
+      if (isDNSTracking()) {
+        options.push('DnsLatencyMs');
+      }
+      if (isFlowRTT()) {
+        options.push('TimeFlowRttNs');
+      }
+    }
+    return options;
+  }, [isDNSTracking, isFlowRTT, isPktDrop, model.selectedViewId]);
+
   const getAvailablePanels = React.useCallback(() => {
     return model.panels.filter(
       panel =>
@@ -199,25 +216,6 @@ export const NetflowTraffic: React.FC<NetflowTrafficProps> = ({
   const getSelectedColumns = React.useCallback(() => {
     return getAvailableColumns().filter(column => column.isSelected);
   }, [getAvailableColumns]);
-
-  const updateTopologyMetricType = React.useCallback(
-    (metricType: MetricType) => {
-      if (isTimeMetric(metricType)) {
-        // fallback on average if current function not available for time queries
-        if (!timeMetricFunctions.includes(model.topologyMetricFunction)) {
-          model.setTopologyMetricFunction('avg');
-        }
-      } else {
-        // fallback on average if current function not available for rate queries
-        if (!rateMetricFunctions.includes(model.topologyMetricFunction)) {
-          model.setTopologyMetricFunction('avg');
-        }
-      }
-      model.setTopologyMetricType(metricType);
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [model.topologyMetricFunction, model.setTopologyMetricFunction, model.setTopologyMetricType]
-  );
 
   const getFilterDefs = React.useCallback(() => {
     return getFilterDefinitions(model.config.filters, model.config.columns, t).filter(
@@ -504,19 +502,6 @@ export const NetflowTraffic: React.FC<NetflowTrafficProps> = ({
   ]);
   usePoll(tick, model.interval);
 
-  const setMetricScope = React.useCallback(
-    (scope: FlowScope) => {
-      model.setMetricScope(scope);
-      // Invalidate groups if necessary, when metrics scope changed
-      const groups = getGroupsForScope(scope as MetricScopeOptions);
-      if (!groups.includes(model.topologyOptions.groupTypes)) {
-        model.setTopologyOptions({ ...model.topologyOptions, groupTypes: TopologyGroupTypes.none });
-      }
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [model.setMetricScope, model.topologyOptions, model.setTopologyOptions]
-  );
-
   const clearFilters = React.useCallback(() => {
     if (forcedFilters) {
       navigate(netflowTrafficPath);
@@ -529,6 +514,8 @@ export const NetflowTraffic: React.FC<NetflowTrafficProps> = ({
   }, [forcedFilters, model.filters, updateTableFilters]);
 
   // Effects
+
+  // invalidate record type if not available
   React.useEffect(() => {
     if (initState.current.includes('configLoaded')) {
       if (model.recordType === 'flowLog' && !isFlow() && isConnectionTracking()) {
@@ -540,6 +527,7 @@ export const NetflowTraffic: React.FC<NetflowTrafficProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [model.config.recordTypes, isConnectionTracking, isFlow, model.recordType]);
 
+  // invalidate datasource if not available
   React.useEffect(() => {
     if (
       initState.current.includes('configLoaded') &&
@@ -551,6 +539,31 @@ export const NetflowTraffic: React.FC<NetflowTrafficProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [allowLoki, allowProm, model.dataSource]);
 
+  // invalidate packet loss if not available
+  React.useEffect(() => {
+    if (initState.current.includes('configLoaded') && !isPktDrop() && model.packetLoss !== 'all') {
+      model.setPacketLoss('all');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isPktDrop, model.packetLoss, model.setPacketLoss]);
+
+  // invalidate metric scope / group if not available
+  React.useEffect(() => {
+    if (initState.current.includes('configLoaded') && !getAllowedScopes().includes(model.metricScope)) {
+      model.setMetricScope(defaultMetricScope);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [getAllowedScopes, model.metricScope, model.setMetricScope]);
+
+  // invalidate metric type / function if not available
+  React.useEffect(() => {
+    if (initState.current.includes('configLoaded') && !getAllowedMetricTypes().includes(model.topologyMetricType)) {
+      model.setTopologyMetricType(defaultMetricType);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [getAllowedMetricTypes, model.topologyMetricType, model.setTopologyMetricType]);
+
+  // select columns / panels from local storage
   React.useEffect(() => {
     if (initState.current.includes('configLoaded')) {
       model.setColumns(
@@ -670,6 +683,10 @@ export const NetflowTraffic: React.FC<NetflowTrafficProps> = ({
   React.useEffect(() => {
     setURLRecortType(model.recordType, !initState.current.includes('configLoaded'));
   }, [model.recordType]);
+
+  React.useEffect(() => {
+    setURLDatasource(model.dataSource, !initState.current.includes('configLoaded'));
+  }, [model.dataSource]);
 
   // update local storage saved query params
   React.useEffect(() => {
@@ -865,12 +882,8 @@ export const NetflowTraffic: React.FC<NetflowTrafficProps> = ({
         <ViewOptionsToolbar
           {...model}
           isDarkTheme={isDarkTheme}
-          setMetricType={updateTopologyMetricType}
-          allowPktDrop={isPktDrop()}
-          allowDNSMetric={isDNSTracking()}
-          allowRTTMetric={isFlowRTT()}
+          allowedTypes={getAllowedMetricTypes()}
           allowedScopes={getAllowedScopes()}
-          setMetricScope={setMetricScope}
           ref={searchRef}
         />
       )}
@@ -885,7 +898,6 @@ export const NetflowTraffic: React.FC<NetflowTrafficProps> = ({
           allowPktDrop={isPktDrop()}
           allowDNSMetric={isDNSTracking()}
           allowRTTMetric={isFlowRTT()}
-          setMetricScope={setMetricScope}
           resetDefaultFilters={resetDefaultFilters}
           clearFilters={clearFilters}
           filterDefinitions={getFilterDefs()}

--- a/web/src/components/tabs/netflow-overview/panel-kebab.tsx
+++ b/web/src/components/tabs/netflow-overview/panel-kebab.tsx
@@ -174,7 +174,8 @@ export const PanelKebab: React.FC<PanelKebabProps> = ({ id, options, setOptions,
         <Divider key="first-divider" component="li" />
       </div>
     );
-  }, [id, options, setGraph, t]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id, options, setGraph]);
 
   const items = [];
   if (options?.graph?.options?.length) {

--- a/web/src/components/toolbar/view-options-toolbar.tsx
+++ b/web/src/components/toolbar/view-options-toolbar.tsx
@@ -41,12 +41,10 @@ export interface ViewOptionsToolbarProps {
   topologyMetricFunction: StatFunction;
   setTopologyMetricFunction: (f: StatFunction) => void;
   topologyMetricType: MetricType;
-  setMetricType: (t: MetricType) => void;
+  setTopologyMetricType: (t: MetricType) => void;
   topologyOptions: TopologyOptions;
   setTopologyOptions: (o: TopologyOptions) => void;
-  allowPktDrop: boolean;
-  allowDNSMetric: boolean;
-  allowRTTMetric: boolean;
+  allowedTypes: MetricType[];
   allowedScopes: FlowScope[];
   size: Size;
   setSize: (v: Size) => void;
@@ -247,14 +245,12 @@ export const ViewOptionsToolbar: React.FC<ViewOptionsToolbarProps> = React.forwa
                 metricFunction={props.topologyMetricFunction}
                 setMetricFunction={props.setTopologyMetricFunction}
                 metricType={props.topologyMetricType}
-                setMetricType={props.setMetricType}
+                setMetricType={props.setTopologyMetricType}
                 metricScope={props.metricScope}
                 setMetricScope={props.setMetricScope}
                 topologyOptions={props.topologyOptions}
                 setTopologyOptions={props.setTopologyOptions}
-                allowPktDrop={props.allowPktDrop}
-                allowDNSMetric={props.allowDNSMetric}
-                allowRTTMetric={props.allowRTTMetric}
+                allowedTypes={props.allowedTypes}
                 allowedScopes={props.allowedScopes}
               />
             )}

--- a/web/src/model/netflow-traffic.ts
+++ b/web/src/model/netflow-traffic.ts
@@ -2,6 +2,7 @@
 import React from 'react';
 import { Record } from '../api/ipfix';
 import { defaultNetflowMetrics, NetflowMetrics, Stats } from '../api/loki';
+import { rateMetricFunctions, timeMetricFunctions } from '../components/dropdowns/metric-function-dropdown';
 import { limitValues, topValues } from '../components/dropdowns/query-options-panel';
 import { TruncateLength } from '../components/dropdowns/truncate-dropdown';
 import { Size } from '../components/messages/error';
@@ -36,6 +37,7 @@ import {
 import { OverviewPanel } from '../utils/overview-panels';
 import {
   defaultMetricFunction,
+  defaultMetricScope,
   defaultMetricType,
   getDataSourceFromURL,
   getLimitFromURL,
@@ -47,8 +49,18 @@ import {
 } from '../utils/router';
 import { Config, defaultConfig } from './config';
 import { DisabledFilters, Filters } from './filters';
-import { DataSource, FlowScope, Match, MetricType, PacketLoss, RecordType, StatFunction } from './flow-query';
-import { DefaultOptions, GraphElementPeer, TopologyOptions } from './topology';
+import {
+  DataSource,
+  FlowScope,
+  isTimeMetric,
+  Match,
+  MetricType,
+  PacketLoss,
+  RecordType,
+  StatFunction
+} from './flow-query';
+import { MetricScopeOptions } from './metrics';
+import { DefaultOptions, getGroupsForScope, GraphElementPeer, TopologyGroupTypes, TopologyOptions } from './topology';
 
 // NetflowTraffic model holding current states and localStorages
 export function netflowTrafficModel() {
@@ -63,7 +75,7 @@ export function netflowTrafficModel() {
   const [selectedViewId, setSelectedViewId] = useLocalStorage<ViewId>(localStorageViewIdKey, 'overview');
   const [lastLimit, setLastLimit] = useLocalStorage<number>(localStorageLastLimitKey, limitValues[0]);
   const [lastTop, setLastTop] = useLocalStorage<number>(localStorageLastTopKey, topValues[0]);
-  const [metricScope, setMetricScope] = useLocalStorage<FlowScope>(localStorageMetricScopeKey, 'namespace');
+  const [metricScope, setMetricScope] = useLocalStorage<FlowScope>(localStorageMetricScopeKey, defaultMetricScope);
   const [topologyMetricFunction, setTopologyMetricFunction] = useLocalStorage<StatFunction>(
     localStorageMetricFunctionKey,
     defaultMetricFunction
@@ -123,6 +135,38 @@ export function netflowTrafficModel() {
   const [selectedElement, setSelectedElement] = React.useState<GraphElementPeer | undefined>(undefined);
   const [searchEvent, setSearchEvent] = React.useState<SearchEvent | undefined>(undefined);
 
+  const updateMetricScope = React.useCallback(
+    (scope: FlowScope) => {
+      setMetricScope(scope);
+      // Invalidate groups if necessary, when metrics scope changed
+      const groups = getGroupsForScope(scope as MetricScopeOptions);
+      if (!groups.includes(topologyOptions.groupTypes)) {
+        setTopologyOptions({ ...topologyOptions, groupTypes: TopologyGroupTypes.none });
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [setMetricScope, topologyOptions, setTopologyOptions]
+  );
+
+  const updateTopologyMetricType = React.useCallback(
+    (metricType: MetricType) => {
+      if (isTimeMetric(metricType)) {
+        // fallback on average if current function not available for time queries
+        if (!timeMetricFunctions.includes(topologyMetricFunction)) {
+          setTopologyMetricFunction('avg');
+        }
+      } else {
+        // fallback on average if current function not available for rate queries
+        if (!rateMetricFunctions.includes(topologyMetricFunction)) {
+          setTopologyMetricFunction('avg');
+        }
+      }
+      setTopologyMetricType(metricType);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [topologyMetricFunction, setTopologyMetricFunction, setTopologyMetricType]
+  );
+
   return {
     config,
     setConfig,
@@ -140,11 +184,11 @@ export function netflowTrafficModel() {
     lastTop,
     setLastTop,
     metricScope,
-    setMetricScope,
+    setMetricScope: updateMetricScope,
     topologyMetricFunction,
     setTopologyMetricFunction,
     topologyMetricType,
-    setTopologyMetricType,
+    setTopologyMetricType: updateTopologyMetricType,
     interval,
     setInterval,
     showViewOptions,

--- a/web/src/utils/router.ts
+++ b/web/src/utils/router.ts
@@ -30,6 +30,7 @@ export const defaultMatch: Match = 'all';
 export const defaultPacketLoss: PacketLoss = 'all';
 export const defaultMetricFunction: StatFunction = 'last';
 export const defaultMetricType: MetricType = 'Bytes';
+export const defaultMetricScope = 'namespace';
 const defaultShowDuplicates = false;
 
 export const getRangeFromURL = (): number | TimeRange => {
@@ -148,6 +149,10 @@ export const setURLRange = (range: number | TimeRange, replace?: boolean) => {
 
 export const setURLRecortType = (recordType: RecordType, replace?: boolean) => {
   setURLParam(URLParam.RecordType, recordType, replace);
+};
+
+export const setURLDatasource = (datasource: DataSource, replace?: boolean) => {
+  setURLParam(URLParam.DataSource, datasource, replace);
 };
 
 export const setURLLimit = (limit: number, replace?: boolean) => {


### PR DESCRIPTION
## Description

Invalidate local storage values when necessary:
- record type
- datasource
- packet loss
- metric scope / group
- metric type / function

Columns / panels should not be impacted as already working properly.

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
