### PR TITLE
NETOBSERV-1871 First request to get flow data waits indefinitely on workloads network-traffic page

### DIFF
--- a/web/src/components/netflow-traffic.tsx
+++ b/web/src/components/netflow-traffic.tsx
@@ -385,6 +385,10 @@ export const NetflowTraffic: React.FC<NetflowTrafficProps> = ({
       // also skip tick if modal is open
       console.debug('tick skipped since modal is open');
       return;
+    } else if (drawerRef.current == null) {
+      console.debug('tick called before drawer rendering. Retrying after render');
+      setTimeout(tick);
+      return;
     }
 
     model.setLoading(true);


### PR DESCRIPTION
## Description

Postpone tick if drawer not rendered

This bug was introduced by https://github.com/netobserv/network-observability-console-plugin/pull/558

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
