### PR TITLE
NETOBSERV-1885: fix resources/names endpoint

### DIFF
--- a/config/sample-config.yaml
+++ b/config/sample-config.yaml
@@ -758,26 +758,24 @@ frontend:
       name: Resource
       component: autocomplete
       category: source
-      placeholder: 'E.g: Pod.default.my-pod'
+      placeholder: 'E.g: Deployment.example.my-dep or Pod.default.my-pod'
       hint: Specify an existing resource from its kind, namespace and name.
       examples: |-
         Specify a kind, namespace and name from existing:
                 - Select kind first from suggestions
-                - Then Select namespace from suggestions
+                - Then select namespace from suggestions
                 - Finally select name from suggestions
-                You can also directly specify a kind, namespace and name like pod.openshift.apiserver
     - id: dst_resource
       name: Resource
       component: autocomplete
       category: destination
-      placeholder: 'E.g: Pod.default.my-pod'
+      placeholder: 'E.g: Deployment.example.my-dep or Pod.default.my-pod'
       hint: Specify an existing resource from its kind, namespace and name.
       examples: |-
         Specify a kind, namespace and name from existing:
                 - Select kind first from suggestions
-                - Then Select namespace from suggestions
+                - Then select namespace from suggestions
                 - Finally select name from suggestions
-                You can also directly specify a kind, namespace and name like pod.openshift.apiserver
     - id: src_address
       name: IP
       component: text

--- a/pkg/server/routes.go
+++ b/pkg/server/routes.go
@@ -53,8 +53,7 @@ func setupRoutes(ctx context.Context, cfg *config.Config, authChecker auth.Check
 	api.HandleFunc("/resources/clusters", h.GetClusters(ctx))
 	api.HandleFunc("/resources/zones", h.GetZones(ctx))
 	api.HandleFunc("/resources/namespaces", h.GetNamespaces(ctx))
-	api.HandleFunc("/resources/namespace/{namespace}/kind/{kind}/names", h.GetNames(ctx))
-	api.HandleFunc("/resources/kind/{kind}/names", h.GetNames(ctx))
+	api.HandleFunc("/resources/names", h.GetNames(ctx))
 
 	// Frontend files
 	api.HandleFunc("/frontend-config", h.GetFrontendConfig())

--- a/web/src/api/routes.ts
+++ b/web/src/api/routes.ts
@@ -96,11 +96,11 @@ export const getNamespaces = (forcedNamespace?: string): Promise<string[]> => {
 };
 
 export const getResources = (namespace: string, kind: string, forcedNamespace?: string): Promise<string[]> => {
-  const params = { namespace: forcedNamespace };
-  const url = namespace
-    ? `${ContextSingleton.getHost()}/api/resources/namespace/${namespace}/kind/${kind}/names`
-    : `${ContextSingleton.getHost()}/api/resources/kind/${kind}/names`;
-  return axios.get(url, { params }).then(r => {
+  const params = {
+    namespace: forcedNamespace || namespace,
+    kind
+  };
+  return axios.get(ContextSingleton.getHost() + '/api/resources/names', { params }).then(r => {
     if (r.status >= 400) {
       throw new Error(`${r.statusText} [code=${r.status}]`);
     }

--- a/web/src/components/toolbar/filters-toolbar.tsx
+++ b/web/src/components/toolbar/filters-toolbar.tsx
@@ -59,8 +59,8 @@ export const FiltersToolbar: React.FC<FiltersToolbarProps> = ({
   const { t } = useTranslation('plugin__netobserv-plugin');
   const [indicator, setIndicator] = React.useState<Indicator>(ValidatedOptions.default);
   const [message, setMessage] = React.useState<string | undefined>();
-  const [selectedFilter, setSelectedFilter] = React.useState<FilterDefinition>(
-    findFilter(filterDefinitions, 'src_namespace')!
+  const [selectedFilter, setSelectedFilter] = React.useState<FilterDefinition | null>(
+    findFilter(filterDefinitions, 'src_namespace') || filterDefinitions.length ? filterDefinitions[0] : null
   );
   const [selectedCompare, setSelectedCompare] = React.useState<FilterCompare>(FilterCompare.equal);
   const [showFilters, setShowFilters] = useLocalStorage<boolean>(localStorageShowFiltersKey, true);
@@ -89,6 +89,10 @@ export const FiltersToolbar: React.FC<FiltersToolbarProps> = ({
 
   const addFilter = React.useCallback(
     (filterValue: FilterValue) => {
+      if (selectedFilter === null) {
+        console.error('addFilter called with', selectedFilter);
+        return false;
+      }
       const newFilters = _.cloneDeep(filters?.list) || [];
       const not = selectedCompare === FilterCompare.notEqual;
       const moreThan = selectedCompare === FilterCompare.moreThanOrEqual;
@@ -111,6 +115,10 @@ export const FiltersToolbar: React.FC<FiltersToolbarProps> = ({
   );
 
   const getFilterControl = React.useCallback(() => {
+    if (selectedFilter === null) {
+      return <></>;
+    }
+
     const commonProps = {
       filterDefinition: selectedFilter,
       addFilter: addFilter,
@@ -132,6 +140,43 @@ export const FiltersToolbar: React.FC<FiltersToolbarProps> = ({
         return <AutocompleteFilter {...commonProps} />;
     }
   }, [selectedFilter, addFilter, setMessageWithDelay, indicator, selectedCompare]);
+
+  const getFilterToolbar = React.useCallback(() => {
+    if (selectedFilter === null) {
+      return <></>;
+    }
+
+    return (
+      <ToolbarItem className="flex-start">
+        <Tooltip
+          //css hide tooltip here to avoid render issue
+          className={`filters-tooltip${_.isEmpty(message) ? '-empty' : ''}`}
+          isVisible={!_.isEmpty(message)}
+          content={message}
+          trigger={_.isEmpty(message) ? 'manual' : 'click'}
+          enableFlip={false}
+          position={'top'}
+        >
+          <div>
+            <InputGroup>
+              <FiltersDropdown
+                filterDefinitions={filterDefinitions}
+                selectedFilter={selectedFilter}
+                setSelectedFilter={setSelectedFilter}
+              />
+              <CompareFilter
+                value={selectedCompare}
+                setValue={setSelectedCompare}
+                component={selectedFilter.component}
+              />
+              {getFilterControl()}
+            </InputGroup>
+            <FilterHints def={selectedFilter} />
+          </div>
+        </Tooltip>
+      </ToolbarItem>
+    );
+  }, [filterDefinitions, getFilterControl, message, selectedCompare, selectedFilter]);
 
   const isForced = !_.isEmpty(forcedFilters);
   const filtersOrForced = isForced ? forcedFilters : filters;
@@ -156,38 +201,7 @@ export const FiltersToolbar: React.FC<FiltersToolbarProps> = ({
             <QuickFilters quickFilters={quickFilters} activeFilters={filters?.list || []} setFilters={setFiltersList} />
           </ToolbarItem>
         )}
-        {!isForced && (
-          <>
-            <ToolbarItem className="flex-start">
-              <Tooltip
-                //css hide tooltip here to avoid render issue
-                className={`filters-tooltip${_.isEmpty(message) ? '-empty' : ''}`}
-                isVisible={!_.isEmpty(message)}
-                content={message}
-                trigger={_.isEmpty(message) ? 'manual' : 'click'}
-                enableFlip={false}
-                position={'top'}
-              >
-                <div>
-                  <InputGroup>
-                    <FiltersDropdown
-                      filterDefinitions={filterDefinitions}
-                      selectedFilter={selectedFilter}
-                      setSelectedFilter={setSelectedFilter}
-                    />
-                    <CompareFilter
-                      value={selectedCompare}
-                      setValue={setSelectedCompare}
-                      component={selectedFilter.component}
-                    />
-                    {getFilterControl()}
-                  </InputGroup>
-                  <FilterHints def={selectedFilter} />
-                </div>
-              </Tooltip>
-            </ToolbarItem>
-          </>
-        )}
+        {!isForced && getFilterToolbar()}
         {showHideText && (
           <ToolbarItem className="flex-start">
             <Button


### PR DESCRIPTION
## Description

- Fix `resources` endpoint params not working. The routes:
```
"/resources/namespace/{namespace}/kind/{kind}/names"
"/resources/kind/{kind}/names"
```
are now moved to a single one:
```
"/resources/names"
```
The namespace and kind are now parameters instead of url parts.

- Improve filter toolbar to not crash when namespace filter is not available (mainly for dev purposes)

## Dependencies

https://github.com/netobserv/network-observability-operator/pull/820 for field descriptions update

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
