### PR TITLE
Fix Uncaught TypeError: e.currentTarget.children[0] is undefined

### DIFF
--- a/web/src/components/drawer/record/record-field.tsx
+++ b/web/src/components/drawer/record/record-field.tsx
@@ -52,7 +52,7 @@ export const RecordField: React.FC<RecordFieldProps> = ({
       const isTruncated =
         event.currentTarget.offsetHeight < event.currentTarget.scrollHeight ||
         event.currentTarget.offsetWidth < event.currentTarget.scrollWidth ||
-        event.currentTarget.children[0].className === 'force-truncate';
+        (event.currentTarget.children.length > 0 && event.currentTarget.children[0].className === 'force-truncate');
       event.currentTarget.className = isTruncated ? `${className} truncated ${size}` : `${className} ${size}`;
     }
   };


### PR DESCRIPTION
I am often seeing JS errors in the console, I think happens when I'm switching between browser tabs and DOM not fully rendered yet, but not sure ...
The error is like:

```
Uncaught TypeError: e.currentTarget.children[0] is undefined
    D record-field.tsx:25
    onMouseOver record-field.tsx:117
    React 11
    unstable_runWithPriority scheduler.production.min.js:18
    React 9
    <anonymous> app.jsx:356
    Webpack 6
record-field.tsx:25:16
    D record-field.tsx:25
    onMouseOver record-field.tsx:117
    React 11
    unstable_runWithPriority scheduler.production.min.js:18
    React 4
    forEach self-hosted:4297
    React 5
    <anonyme> app.jsx:356
    Webpack 6
```

So this should fix it