### PR TITLE
NETOBSERV-1990: fix NOT filters with multiple values

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,5 +26,8 @@ linters-settings:
       - rangeValCopy
       - indexAlloc
       - deprecatedComment
+    settings:
+      ifElseChain:
+        minThreshold: 3
   cyclop:
     max-complexity: 20

--- a/pkg/model/filters/logql_test.go
+++ b/pkg/model/filters/logql_test.go
@@ -74,3 +74,22 @@ func TestWriteInto_7654(t *testing.T) {
 		assert.Equal(t, reg.MatchString(val), i >= 7654, fmt.Sprintf("Value: %d", i))
 	}
 }
+
+func TestMultiStrings(t *testing.T) {
+	lf, ok := StringLineFilterCheckExact("foo", []string{`"a"`, `"b"`}, false)
+	assert.False(t, ok)
+	sb := strings.Builder{}
+	lf.WriteInto(&sb)
+	assert.Equal(t, "|~"+backtick(`foo":"a"|foo":"b"`), sb.String())
+
+	// Repeat with "not" (here we expect foo being neither a nor b)
+	lf, ok = StringLineFilterCheckExact("foo", []string{`"a"`, `"b"`}, true)
+	assert.False(t, ok)
+	sb = strings.Builder{}
+	lf.WriteInto(&sb)
+	assert.Equal(t, "|~"+backtick(`"foo"`)+"!~"+backtick(`foo":"a"`)+"!~"+backtick(`foo":"b"`), sb.String())
+}
+
+func backtick(str string) string {
+	return "`" + str + "`"
+}

--- a/pkg/server/server_flows_test.go
+++ b/pkg/server/server_flows_test.go
@@ -65,6 +65,12 @@ func TestLokiFiltering(t *testing.T) {
 			"?query={app=\"netobserv-flowcollector\"}|~`SrcK8S_Name\":\"(?i)[^\"]*name1.*\"|SrcK8S_Name\":\"(?i)[^\"]*name2.*\"`",
 		},
 	}, {
+		name:      "NOT line filter same key",
+		inputPath: "?filters=" + url.QueryEscape(`SrcK8S_Name!="name1","name2"`),
+		outputQueries: []string{
+			"?query={app=\"netobserv-flowcollector\"}|~`\"SrcK8S_Name\"`!~`SrcK8S_Name\":\"name1\"`!~`SrcK8S_Name\":\"name2\"`",
+		},
+	}, {
 		name:      "OR label filter same key",
 		inputPath: "?filters=" + url.QueryEscape("SrcK8S_Namespace=ns1,ns2"),
 		outputQueries: []string{
@@ -89,6 +95,12 @@ func TestLokiFiltering(t *testing.T) {
 		inputPath: "?filters=" + url.QueryEscape("SrcAddr=10.128.0.1,10.128.0.2"),
 		outputQueries: []string{
 			"?query={app=\"netobserv-flowcollector\"}|json|SrcAddr=ip(\"10.128.0.1\")+or+SrcAddr=ip(\"10.128.0.2\")",
+		},
+	}, {
+		name:      "NOT IP filters",
+		inputPath: "?filters=" + url.QueryEscape(`SrcAddr!=10.128.0.1,10.128.0.2`),
+		outputQueries: []string{
+			"?query={app=\"netobserv-flowcollector\"}|json|SrcAddr!=ip(\"10.128.0.1\")|SrcAddr!=ip(\"10.128.0.2\")",
 		},
 	}, {
 		name:      "Several OR filters",

--- a/web/src/model/__tests__/filters.spec.ts
+++ b/web/src/model/__tests__/filters.spec.ts
@@ -1,6 +1,7 @@
 import { FilterDefinitionSample } from '../../components/__tests-data__/filters';
 import { findFilter } from '../../utils/filter-definitions';
 import { doesIncludeFilter, Filter, filtersEqual } from '../filters';
+import { filtersToString } from '../flow-query';
 
 describe('doesIncludeFilter', () => {
   const srcNameFilter = findFilter(FilterDefinitionSample, 'src_name')!;
@@ -17,6 +18,11 @@ describe('doesIncludeFilter', () => {
       values: [{ v: 'abc' }, { v: 'def' }]
     }
   ];
+
+  it('should encode as', () => {
+    const asString = filtersToString(activeFilters, false);
+    expect(asString).toEqual(encodeURIComponent('SrcK8S_Name=abc,def&DstK8S_Name!=abc,def'));
+  });
 
   it('should not include filter due to different key', () => {
     const isIncluded = doesIncludeFilter(activeFilters, { def: findFilter(FilterDefinitionSample, 'protocol')! }, [


### PR DESCRIPTION
## Description

NOT filters with multiple values should generate AND queries, not OR E.g. IP=10.0.0.1,10.0.0.2 generates IP=10.0.0.1 OR IP=10.0.0.2, which is correct

But, IP!=10.0.0.1,10.0.0.2 should not generate IP!=10.0.0.1 OR IP!=10.0.0.2 (which would be always true) but IP!=10.0.0.1 AND IP!=10.0.0.2 instead

Reasoning with CIDRs is the same:
IP!=10.0.0.0/8,172.0.0.0/8 translates into IP NOT IN 10.0.0.0/8 AND IP NOT IN 172.0.0.0/8

Screens:

Filtering out traffic to pods
![Capture d’écran du 2024-12-04 14-29-24](https://github.com/user-attachments/assets/5c600fcf-3954-4e49-afc9-4f40e704f617)

Filtering our traffic to services and pods
![Capture d’écran du 2024-12-04 14-29-12](https://github.com/user-attachments/assets/2c95ae86-3e2f-4ce0-8551-2402320af324)




## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [x] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
