### PR TITLE
Temporary disabling multi arch builds

### DIFF
--- a/.tekton/network-observability-console-plugin-pull-request.yaml
+++ b/.tekton/network-observability-console-plugin-pull-request.yaml
@@ -28,6 +28,10 @@ spec:
     value: 5d
   - name: dockerfile
     value: Dockerfile.downstream
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/ppc64le
   pipelineRef:
     name: build-pipeline
   taskRunTemplate: {}

--- a/.tekton/network-observability-console-plugin-push.yaml
+++ b/.tekton/network-observability-console-plugin-push.yaml
@@ -26,6 +26,10 @@ spec:
     value: quay.io/redhat-user-workloads/ocp-network-observab-tenant/netobserv-operator/network-observability-console-plugin:{{revision}}
   - name: dockerfile
     value: Dockerfile.downstream
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/ppc64le
   pipelineRef:
     name: build-pipeline
   taskRunTemplate: {}


### PR DESCRIPTION
## Description

Disabling multi arch builds to unblock builds while we investigate.

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
