### PR TITLE
Konflux building frontend only once

### DIFF
--- a/.tekton/pipeline-ref.yaml
+++ b/.tekton/pipeline-ref.yaml
@@ -42,6 +42,11 @@ spec:
       path-context
     name: dockerfile
     type: string
+  - default: "Dockerfile.front.downstream"
+    description: Path to the frontend Dockerfile inside the context specified by parameter
+      path-context
+    name: front-dockerfile
+    type: string
   - default: "false"
     description: Force rebuild image
     name: rebuild
@@ -173,6 +178,52 @@ spec:
       workspace: git-auth
     - name: netrc
       workspace: netrc
+  - name: build-front-container
+    params:
+    - name: IMAGE
+      value: "$(params.output-image)-front"
+    - name: DOCKERFILE
+      value: $(params.front-dockerfile)
+    - name: CONTEXT
+      value: $(params.path-context)
+    - name: HERMETIC
+      value: $(params.hermetic)
+    - name: PREFETCH_INPUT
+      value: $(params.prefetch-input)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.image-expires-after)
+    - name: COMMIT_SHA
+      value: $(tasks.clone-repository.results.commit)
+    - name: BUILD_ARGS
+      value:
+      - $(params.build-args[*])
+      - "COMMIT=$(tasks.clone-repository.results.commit)"
+      - "BUILDVERSION=$(params.build-version)"
+      - "DATE=$(tasks.clone-repository.results.commit-timestamp)"
+    - name: BUILD_ARGS_FILE
+      value: $(params.build-args-file)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    - name: CACHI2_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    - name: PLATFORM
+      value: "linux/x86_64"
+    runAfter:
+    - prefetch-dependencies
+    taskRef:
+      params:
+      - name: name
+        value: buildah-remote-oci-ta
+      - name: bundle
+        value:  quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.3@sha256:3070ee1a75e9a5a0a082008e1f9b3d2df7a9508ca107678b2613dc201eb2e279
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
   - name: build-container
     matrix:
       params:
@@ -200,6 +251,7 @@ spec:
       - "COMMIT=$(tasks.clone-repository.results.commit)"
       - "BUILDVERSION=$(params.build-version)"
       - "DATE=$(tasks.clone-repository.results.commit-timestamp)"
+      - "FRONTBUILD=$(params.output-image)-front"
     - name: BUILD_ARGS_FILE
       value: $(params.build-args-file)
     - name: SOURCE_ARTIFACT
@@ -210,6 +262,7 @@ spec:
       value: "true"
     runAfter:
     - prefetch-dependencies
+    - build-front-container
     taskRef:
       params:
       - name: name

--- a/Dockerfile.downstream
+++ b/Dockerfile.downstream
@@ -1,23 +1,7 @@
 ARG COMMIT
+ARG FRONTBUILD
 
-FROM registry.access.redhat.com/ubi9/nodejs-18:1-108.1716477799 as web-builder
-
-ARG BUILDSCRIPT
-WORKDIR /opt/app-root
-
-COPY  --chown=default web/package.json web/package.json
-COPY  --chown=default web/package-lock.json web/package-lock.json
-WORKDIR /opt/app-root/web
-
-RUN CYPRESS_INSTALL_BINARY=0 node --max-old-space-size=6000 $(which npm) --legacy-peer-deps ci
-
-WORKDIR /opt/app-root
-COPY  --chown=default web web
-COPY  --chown=default mocks mocks
-
-WORKDIR /opt/app-root/web
-RUN npm run format-all
-RUN npm run build$BUILDSCRIPT
+FROM $FRONTBUILD as web-builder
 
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.23 as go-builder
 

--- a/Dockerfile.front.downstream
+++ b/Dockerfile.front.downstream
@@ -1,0 +1,22 @@
+FROM registry.access.redhat.com/ubi9/nodejs-18:1-108.1716477799 as web-builder
+
+ARG BUILDSCRIPT
+WORKDIR /opt/app-root
+
+COPY  --chown=default web/package.json web/package.json
+COPY  --chown=default web/package-lock.json web/package-lock.json
+WORKDIR /opt/app-root/web
+
+RUN CYPRESS_INSTALL_BINARY=0 node --max-old-space-size=6000 $(which npm) --legacy-peer-deps ci
+
+WORKDIR /opt/app-root
+COPY  --chown=default web web
+COPY  --chown=default mocks mocks
+
+WORKDIR /opt/app-root/web
+RUN npm run format-all
+RUN npm run build$BUILDSCRIPT
+
+FROM scratch
+
+COPY --from=web-builder /opt/app-root/web/dist /opt/app-root/web/dist


### PR DESCRIPTION
## Description

Similar to what was done for upstream in https://github.com/netobserv/network-observability-console-plugin/pull/707

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
