### PR TITLE
NETOBSERV-2139 remove observe menu entry

### DIFF
--- a/web/console-extensions.json
+++ b/web/console-extensions.json
@@ -10,16 +10,6 @@
     }
   },
   {
-    "type": "console.navigation/section",
-    "properties": {
-      "perspective": "admin",
-      "id": "observe-projectadmin",
-      "insertBefore": ["compute", "usermanagement"],
-      "name": "%plugin__netobserv-plugin~Observe%"
-    },
-    "flags": { "disallowed": ["CAN_LIST_NS"] }
-  },
-  {
     "type": "console.navigation/href",
     "properties": {
       "id": "netflow-traffic-link-projectadmin",


### PR DESCRIPTION
## Description

Console is now showing Observe menu without Prom & Monitoring flags
We must remove the Observe menu entry from our plugin since it now duplicates in the console.

This is a good candidate for 1.8.1 release for users on 4.14 and below

## Dependencies

Ensure https://github.com/openshift/console/pull/14697 is properly backported before merging this !

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
