### PR TITLE
NETOBSERV-2104 Filters in UI are visible despite features are disabled

### DIFF
--- a/web/src/components/netflow-traffic.tsx
+++ b/web/src/components/netflow-traffic.tsx
@@ -122,6 +122,18 @@ export const NetflowTraffic: React.FC<NetflowTrafficProps> = ({
     return model.config.features.includes('pktDrop');
   }, [model.config.features]);
 
+  const isUdn = React.useCallback(() => {
+    return model.config.features.includes('udnMapping');
+  }, [model.config.features]);
+
+  const isPktXlat = React.useCallback(() => {
+    return model.config.features.includes('packetTranslation');
+  }, [model.config.features]);
+
+  const isNetEvents = React.useCallback(() => {
+    return model.config.features.includes('networkEvents');
+  }, [model.config.features]);
+
   const isPromOnly = React.useCallback(() => {
     return !allowLoki() || model.dataSource === 'prom';
   }, [allowLoki, model.dataSource]);
@@ -209,6 +221,9 @@ export const NetflowTraffic: React.FC<NetflowTrafficProps> = ({
         (isDNSTracking() || !fd.id.startsWith('dns_')) &&
         (isPktDrop() || !fd.id.startsWith('pkt_drop_')) &&
         (isFlowRTT() || fd.id !== 'time_flow_rtt') &&
+        (isUdn() || fd.id !== 'udns') &&
+        (isPktXlat() || fd.id.startsWith('xlat_')) &&
+        (isNetEvents() || fd.id !== 'network_events') &&
         (!isPromOnly() || checkFilterAvailable(fd, model.config.promLabels))
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/web/src/components/netflow-traffic.tsx
+++ b/web/src/components/netflow-traffic.tsx
@@ -222,7 +222,7 @@ export const NetflowTraffic: React.FC<NetflowTrafficProps> = ({
         (isPktDrop() || !fd.id.startsWith('pkt_drop_')) &&
         (isFlowRTT() || fd.id !== 'time_flow_rtt') &&
         (isUdn() || fd.id !== 'udns') &&
-        (isPktXlat() || fd.id.startsWith('xlat_')) &&
+        (isPktXlat() || !fd.id.startsWith('xlat_')) &&
         (isNetEvents() || fd.id !== 'network_events') &&
         (!isPromOnly() || checkFilterAvailable(fd, model.config.promLabels))
     );

--- a/web/src/model/config.ts
+++ b/web/src/model/config.ts
@@ -5,7 +5,15 @@ import { RecordType } from './flow-query';
 import { RawQuickFilter } from './quick-filters';
 import { ScopeConfigDef } from './scope';
 
-export type Feature = 'multiCluster' | 'zones' | 'pktDrop' | 'dnsTracking' | 'flowRTT';
+export type Feature =
+  | 'multiCluster'
+  | 'zones'
+  | 'pktDrop'
+  | 'dnsTracking'
+  | 'flowRTT'
+  | 'udnMapping'
+  | 'packetTranslation'
+  | 'networkEvents';
 
 export type Deduper = {
   mark: boolean;

--- a/web/src/model/filters.ts
+++ b/web/src/model/filters.ts
@@ -32,6 +32,7 @@ export type FilterId =
   | 'dscp'
   | 'icmp_type'
   | 'icmp_code'
+  | 'udns'
   | 'id'
   | 'pkt_drop_state'
   | 'pkt_drop_cause'
@@ -39,7 +40,13 @@ export type FilterId =
   | 'dns_latency'
   | 'dns_flag_response_code'
   | 'dns_errno'
-  | 'time_flow_rtt';
+  | 'time_flow_rtt'
+  | 'network_events'
+  | 'xlat_zone_id'
+  | 'xlat_src_address'
+  | 'xlat_dst_address'
+  | 'xlat_src_port'
+  | 'xlat_dst_port';
 
 export interface FilterConfigDef {
   id: string;


### PR DESCRIPTION
## Description

Some of the features filtering is still hardcoded such as for filters.
I would suggest to merge this for now as a quick win and investigate about a more generic solution in parallel.

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
