### PR TITLE
NETOBSERV-2233 Make IPSec filters visible if feature is enabled

### DIFF
--- a/web/src/components/netflow-traffic.tsx
+++ b/web/src/components/netflow-traffic.tsx
@@ -136,6 +136,10 @@ export const NetflowTraffic: React.FC<NetflowTrafficProps> = ({
     return model.config.features.includes('networkEvents');
   }, [model.config.features]);
 
+  const isIPSec = React.useCallback(() => {
+    return model.config.features.includes('ipsec');
+  }, [model.config.features]);
+
   const isPromOnly = React.useCallback(() => {
     return !allowLoki() || model.dataSource === 'prom';
   }, [allowLoki, model.dataSource]);
@@ -226,7 +230,8 @@ export const NetflowTraffic: React.FC<NetflowTrafficProps> = ({
         (isUdn() || fd.id !== 'udns') &&
         (isPktXlat() || !fd.id.startsWith('xlat_')) &&
         (isNetEvents() || fd.id !== 'network_events') &&
-        (!isPromOnly() || checkFilterAvailable(fd, model.config.promLabels))
+        (!isPromOnly() || checkFilterAvailable(fd, model.config.promLabels)) &&
+        (isIPSec() || !fd.id.startsWith('ipsec_'))
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [model.config.columns, model.config.filters, model.config.promLabels, isPromOnly]);

--- a/web/src/model/config.ts
+++ b/web/src/model/config.ts
@@ -13,7 +13,8 @@ export type Feature =
   | 'flowRTT'
   | 'udnMapping'
   | 'packetTranslation'
-  | 'networkEvents';
+  | 'networkEvents'
+  | 'ipsec';
 
 export type Config = {
   buildVersion: string;

--- a/web/src/model/filters.ts
+++ b/web/src/model/filters.ts
@@ -46,7 +46,9 @@ export type FilterId =
   | 'xlat_src_address'
   | 'xlat_dst_address'
   | 'xlat_src_port'
-  | 'xlat_dst_port';
+  | 'xlat_dst_port'
+  | 'ipsec_success'
+  | 'ipsec_retcode';
 
 export interface FilterConfigDef {
   id: string;


### PR DESCRIPTION
## Description

[NETOBSERV-2233](https://issues.redhat.com//browse/NETOBSERV-2233) Make IPSec filters visible if feature is enabled
## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
