### PR TITLE
NETOBSERV-2244: show topology when expectedNodes is set

### DIFF
--- a/web/src/components/tabs/netflow-topology/2d/topology-content.tsx
+++ b/web/src/components/tabs/netflow-topology/2d/topology-content.tsx
@@ -471,7 +471,7 @@ export const TopologyContent: React.FC<TopologyContentProps> = ({
   useEventListener(graphLayoutEndEvent, onLayoutEnd);
   useEventListener(graphPositionChangeEvent, onLayoutPositionChange);
 
-  if (_.isEmpty(metrics) && _.isEmpty(droppedMetrics)) {
+  if (_.isEmpty(metrics) && _.isEmpty(droppedMetrics) && _.isEmpty(expectedNodes)) {
     return (
       <Bullseye data-test="no-results-found">
         <Empty showDetails={true} resetDefaultFilters={resetDefaultFilters} clearFilters={clearFilters} />

--- a/web/src/model/topology.ts
+++ b/web/src/model/topology.ts
@@ -71,7 +71,7 @@ export const DefaultOptions: TopologyOptions = {
   medScale: 0.5,
   metricFunction: defaultMetricFunction,
   metricType: defaultMetricType,
-  showEmpty: true
+  showEmpty: false
 };
 
 export type GraphElementPeer = GraphElement<ElementModel, NodeData>;


### PR DESCRIPTION
## Description

Fix empty UDN's filtering not working as expected

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
