### PR TITLE
NETOBSERV-2355: Rename sampling ratio/rate -> interval

### DIFF
--- a/config/sample-config.yaml
+++ b/config/sample-config.yaml
@@ -1463,7 +1463,7 @@ frontend:
       description: Differentiated Services Code Point (DSCP) value
     - name: Sampling
       type: number
-      description: Sampling rate used for this flow
+      description: Sampling interval used for this flow
     - name: IcmpType
       type: number
       description: ICMP type

--- a/web/moduleMapper/schemas.ts
+++ b/web/moduleMapper/schemas.ts
@@ -228,7 +228,7 @@ export const FlowCollectorSchema: RJSFSchema | any = {
               properties: {
                 sampling: {
                   description:
-                    'Sampling rate of the flow reporter. 100 means one flow on 100 is sent. 0 or 1 means all flows are sampled.',
+                    'Sampling interval of the flow reporter. 100 means one flow on 100 is sent. 0 or 1 means all flows are sampled.',
                   type: 'integer',
                   format: 'int32',
                   default: 50,
@@ -274,7 +274,7 @@ export const FlowCollectorSchema: RJSFSchema | any = {
                     },
                     sampling: {
                       description:
-                        '`sampling` sampling rate for the matched flows, overriding the global sampling defined at `spec.agent.ebpf.sampling`.',
+                        '`sampling` sampling interval for the matched flows, overriding the global sampling defined at `spec.agent.ebpf.sampling`.',
                       type: 'integer',
                       format: 'int32'
                     },
@@ -366,7 +366,7 @@ export const FlowCollectorSchema: RJSFSchema | any = {
                           },
                           sampling: {
                             description:
-                              '`sampling` sampling rate for the matched flows, overriding the global sampling defined at `spec.agent.ebpf.sampling`.',
+                              '`sampling` sampling interval for the matched flows, overriding the global sampling defined at `spec.agent.ebpf.sampling`.',
                             type: 'integer',
                             format: 'int32'
                           },
@@ -1648,7 +1648,7 @@ export const FlowCollectorSchema: RJSFSchema | any = {
                 },
                 sampling: {
                   description:
-                    '`sampling` is the sampling rate on the reporter. 100 means one flow on 100 is sent.\nTo ensure cluster stability, it is not possible to set a value below 2.\nIf you really want to sample every packet, which might impact the cluster stability,\nrefer to `forceSampleAll`. Alternatively, you can use the eBPF Agent instead of IPFIX.',
+                    '`sampling` is the sampling interval on the reporter. 100 means one flow on 100 is sent.\nTo ensure cluster stability, it is not possible to set a value below 2.\nIf you really want to sample every packet, which might impact the cluster stability,\nrefer to `forceSampleAll`. Alternatively, you can use the eBPF Agent instead of IPFIX.',
                   type: 'integer',
                   format: 'int32',
                   default: 400,
@@ -2875,7 +2875,7 @@ export const FlowCollectorSchema: RJSFSchema | any = {
                   enum: ['Disabled', 'Drop', 'Sample']
                 },
                 sampling: {
-                  description: '`sampling` is the sampling rate when deduper `mode` is `Sample`.',
+                  description: '`sampling` is the sampling interval when deduper `mode` is `Sample`.',
                   type: 'integer',
                   format: 'int32',
                   default: 50,
@@ -3380,7 +3380,7 @@ export const FlowCollectorSchema: RJSFSchema | any = {
                     enum: ['', 'Loki', 'Metrics', 'Exporters']
                   },
                   sampling: {
-                    description: '`sampling` is an optional sampling rate to apply to this filter.',
+                    description: '`sampling` is an optional sampling interval to apply to this filter.',
                     type: 'integer',
                     format: 'int32',
                     minimum: 0


### PR DESCRIPTION
## Description

Just doc/text renamings...

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [x] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
