### PR TITLE
NETOBSERV-2400: Implement alerts feature gate

### DIFF
--- a/web/src/components/health/network-health.tsx
+++ b/web/src/components/health/network-health.tsx
@@ -1,4 +1,4 @@
-import { AlertStates, Rule } from '@openshift-console/dynamic-plugin-sdk';
+import { AlertStates, FeatureFlagHandler, Rule, SetFeatureFlag } from '@openshift-console/dynamic-plugin-sdk';
 import { Button, Flex, FlexItem, PageSection, Tab, Tabs, TextVariants, Title } from '@patternfly/react-core';
 import { SyncAltIcon } from '@patternfly/react-icons';
 import * as _ from 'lodash';
@@ -18,6 +18,7 @@ import { HealthGlobal } from './health-global';
 import { buildStats, isSilenced } from './health-helper';
 import { HealthSummary } from './health-summary';
 import { HealthTabTitle } from './tab-title';
+import { loadConfig } from '../../utils/config';
 
 import './health.css';
 
@@ -173,6 +174,15 @@ export const NetworkHealth: React.FC<{}> = ({}) => {
       )}
     </PageSection>
   );
+};
+
+export const featureFlagHandler: FeatureFlagHandler = (setFeatureFlag: SetFeatureFlag) => {
+  loadConfig().then(({ config }) => {
+    if (config) {
+      const enabled = config.features.includes('experimentalAlertsHealth');
+      setFeatureFlag('NETOBSERV_NETWORK_HEALTH', enabled);
+    }
+  });
 };
 
 NetworkHealth.displayName = 'NetworkHealth';

--- a/web/src/model/config.ts
+++ b/web/src/model/config.ts
@@ -14,7 +14,8 @@ export type Feature =
   | 'udnMapping'
   | 'packetTranslation'
   | 'networkEvents'
-  | 'ipsec';
+  | 'ipsec'
+  | 'experimentalAlertsHealth';
 
 export type Config = {
   buildVersion: string;

--- a/web/webpack.config.ts
+++ b/web/webpack.config.ts
@@ -101,6 +101,12 @@ module.exports = {
       },
       extensions: [
         {
+          "type": "console.flag",
+          "properties": {
+            "handler": { "$codeRef": "networkHealth.featureFlagHandler" }
+          }
+        },
+        {
           type: "console.navigation/href",
           properties: {
             "id": "network-health-link",
@@ -108,7 +114,8 @@ module.exports = {
             "section": "observe",
             name: "%plugin__netobserv-plugin~Network Health%",
             "href": "/network-health"
-          }
+          },
+          "flags": { "required": ["NETOBSERV_NETWORK_HEALTH"] }
         },
         {
           type: "console.navigation/href",
@@ -147,7 +154,8 @@ module.exports = {
             component: {
               "$codeRef": "networkHealth.default"
             }
-          }
+          },
+          "flags": { "required": ["NETOBSERV_NETWORK_HEALTH"] }
         },
         {
           type: "console.tab/horizontalNav",


### PR DESCRIPTION
## Description

Add flag condition to the new health page hook, based on features passed by config from the operator.
On the operator side, this is controlled through the env `EXPERIMENTAL_ALERTS_HEALTH` in `spec.processor.advanced.env`.

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
- Operator: https://github.com/netobserv/network-observability-operator/pull/2011

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
