### PR TITLE
NETOBSERV-2398: Hide Network Traffic tab for some resources when Loki is disabled

### DIFF
--- a/web/src/components/netflow-traffic-tab.tsx
+++ b/web/src/components/netflow-traffic-tab.tsx
@@ -1,4 +1,4 @@
-import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+import { FeatureFlagHandler, K8sResourceCommon, SetFeatureFlag } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Bullseye,
   EmptyState,
@@ -228,6 +228,15 @@ export const NetflowTrafficTab: React.FC<NetflowTrafficTabProps> = ({ match, obj
       </PageSection>
     );
   }
+};
+
+export const featureFlagHandler: FeatureFlagHandler = (setFeatureFlag: SetFeatureFlag) => {
+  loadConfig().then(({ config }) => {
+    if (config) {
+      const lokiEnabled = config.dataSources.some(ds => ds === 'loki');
+      setFeatureFlag('NETOBSERV_LOKI_ENABLED', lokiEnabled);
+    }
+  });
 };
 
 export default NetflowTrafficTab;

--- a/web/webpack.config.ts
+++ b/web/webpack.config.ts
@@ -107,6 +107,12 @@ module.exports = {
           }
         },
         {
+          "type": "console.flag",
+          "properties": {
+            "handler": { "$codeRef": "netflowTab.featureFlagHandler" }
+          }
+        },
+        {
           type: "console.navigation/href",
           properties: {
             "id": "network-health-link",
@@ -172,7 +178,8 @@ module.exports = {
               name: "%plugin__netobserv-plugin~Network Traffic%",
               "href": "netflow"
             }
-          }
+          },
+          "flags": { "required": ["NETOBSERV_LOKI_ENABLED"] }
         },
         {
           type: "console.tab/horizontalNav",
@@ -189,7 +196,8 @@ module.exports = {
               name: "%plugin__netobserv-plugin~Network Traffic%",
               "href": "netflow"
             }
-          }
+          },
+          "flags": { "required": ["NETOBSERV_LOKI_ENABLED"] }
         },
         {
           type: "console.tab/horizontalNav",
@@ -206,7 +214,8 @@ module.exports = {
               name: "%plugin__netobserv-plugin~Network Traffic%",
               "href": "netflow"
             }
-          }
+          },
+          "flags": { "required": ["NETOBSERV_LOKI_ENABLED"] }
         },
         {
           type: "console.tab/horizontalNav",
@@ -223,7 +232,8 @@ module.exports = {
               name: "%plugin__netobserv-plugin~Network Traffic%",
               "href": "netflow"
             }
-          }
+          },
+          "flags": { "required": ["NETOBSERV_LOKI_ENABLED"] }
         },
         {
           type: "console.tab/horizontalNav",
@@ -240,7 +250,8 @@ module.exports = {
               name: "%plugin__netobserv-plugin~Network Traffic%",
               "href": "netflow"
             }
-          }
+          },
+          "flags": { "required": ["NETOBSERV_LOKI_ENABLED"] }
         },
         {
           type: "console.tab/horizontalNav",
@@ -257,7 +268,8 @@ module.exports = {
               name: "%plugin__netobserv-plugin~Network Traffic%",
               "href": "netflow"
             }
-          }
+          },
+          "flags": { "required": ["NETOBSERV_LOKI_ENABLED"] }
         },
         {
           type: "console.tab/horizontalNav",
@@ -274,7 +286,8 @@ module.exports = {
               name: "%plugin__netobserv-plugin~Network Traffic%",
               "href": "netflow"
             }
-          }
+          },
+          "flags": { "required": ["NETOBSERV_LOKI_ENABLED"] }
         },
         {
           type: "console.tab/horizontalNav",
@@ -291,7 +304,8 @@ module.exports = {
               name: "%plugin__netobserv-plugin~Network Traffic%",
               "href": "netflow"
             }
-          }
+          },
+          "flags": { "required": ["NETOBSERV_LOKI_ENABLED"] }
         },
         {
           type: "console.tab/horizontalNav",
@@ -308,7 +322,8 @@ module.exports = {
               name: "%plugin__netobserv-plugin~Network Traffic%",
               "href": "netflow"
             }
-          }
+          },
+          "flags": { "required": ["NETOBSERV_LOKI_ENABLED"] }
         },
         {
           type: "console.tab/horizontalNav",
@@ -325,7 +340,8 @@ module.exports = {
               name: "%plugin__netobserv-plugin~Network Traffic%",
               "href": "netflow"
             }
-          }
+          },
+          "flags": { "required": ["NETOBSERV_LOKI_ENABLED"] }
         },
         {
           type: "console.tab/horizontalNav",
@@ -342,7 +358,8 @@ module.exports = {
               name: "%plugin__netobserv-plugin~Network Traffic%",
               "href": "netflow"
             }
-          }
+          },
+          "flags": { "required": ["NETOBSERV_LOKI_ENABLED"] }
         },
         {
           type: "console.tab/horizontalNav",
@@ -359,7 +376,8 @@ module.exports = {
               name: "%plugin__netobserv-plugin~Network Traffic%",
               "href": "netflow"
             }
-          }
+          },
+          "flags": { "required": ["NETOBSERV_LOKI_ENABLED"] }
         },
         {
           type: "console.tab/horizontalNav",
@@ -376,7 +394,8 @@ module.exports = {
               name: "%plugin__netobserv-plugin~Network Traffic%",
               "href": "netflow"
             }
-          }
+          },
+          "flags": { "required": ["NETOBSERV_LOKI_ENABLED"] }
         },
         {
           type: "console.tab/horizontalNav",
@@ -393,7 +412,8 @@ module.exports = {
               name: "%plugin__netobserv-plugin~Network Traffic%",
               "href": "netflow"
             }
-          }
+          },
+          "flags": { "required": ["NETOBSERV_LOKI_ENABLED"] }
         },
         {
           type: "console.tab",


### PR DESCRIPTION
## Description

Hide Network Traffic tab for some resources when Loki is disabled.

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
