### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for network-observability-console-plugin-zstream

### DIFF
--- a/Dockerfile.downstream
+++ b/Dockerfile.downstream
@@ -48,7 +48,7 @@ ENTRYPOINT ["./plugin-backend"]
 
 LABEL com.redhat.component="network-observability-console-plugin-container"
 LABEL name="network-observability/network-observability-console-plugin-rhel9"
-LABEL cpe="cpe:/a:redhat:network_observ_optr:$BUILDVERSION_Y::el9"
+LABEL cpe="cpe:/a:redhat:network_observ_optr:1.9::el9"
 LABEL io.k8s.display-name="Network Observability Console Plugin"
 LABEL io.k8s.description="Network Observability Console Plugin"
 LABEL summary="Network Observability Console Plugin"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
