### PR TITLE
NETOBSERV-2441: fix page loading triggering autocompletion

### DIFF
--- a/web/src/components/drawer/record/record-panel.tsx
+++ b/web/src/components/drawer/record/record-panel.tsx
@@ -235,7 +235,7 @@ export const RecordPanel: React.FC<RecordDrawerProps> = ({
             const values = [
               {
                 v: Array.isArray(value) ? value.join(value.length == 2 ? '.' : ':') : valueStr,
-                display: (await def.getOptions(valueStr)).find(o => o.value === valueStr)?.name
+                display: (await def.autocomplete(valueStr)).find(o => o.value === valueStr)?.name
               }
             ];
             // TODO: is it relevant to show composed columns?

--- a/web/src/components/toolbar/filters/autocomplete-filter.tsx
+++ b/web/src/components/toolbar/filters/autocomplete-filter.tsx
@@ -86,7 +86,7 @@ export const AutocompleteFilter: React.FC<AutocompleteFilterProps> = ({
     (newValue: string) => {
       setCurrentValue(newValue);
       filterDefinition
-        .getOptions(newValue)
+        .autocomplete(newValue)
         .then(setOptions)
         .catch(err => {
           const errorMessage = getHTTPErrorDetails(err);
@@ -147,11 +147,10 @@ export const AutocompleteFilter: React.FC<AutocompleteFilterProps> = ({
       return;
     }
 
-    createFilterValue(filterDefinition, validation.val!).then(v => {
-      if (addFilterParent(v)) {
-        resetFilterValue();
-      }
-    });
+    const fv = createFilterValue(filterDefinition, validation.val!);
+    if (addFilterParent(fv)) {
+      resetFilterValue();
+    }
   }, [
     options,
     filterDefinition,

--- a/web/src/components/toolbar/filters/text-filter.tsx
+++ b/web/src/components/toolbar/filters/text-filter.tsx
@@ -74,11 +74,10 @@ export const TextFilter: React.FC<TextFilterProps> = ({
       return;
     }
 
-    createFilterValue(filterDefinition, validation.val!).then(v => {
-      if (addFilter(v)) {
-        resetFilterValue();
-      }
-    });
+    const fv = createFilterValue(filterDefinition, validation.val!);
+    if (addFilter(fv)) {
+      resetFilterValue();
+    }
   }, [currentValue, allowEmpty, filterDefinition, setMessageWithDelay, setIndicator, addFilter, resetFilterValue]);
 
   return (

--- a/web/src/model/filters.ts
+++ b/web/src/model/filters.ts
@@ -67,7 +67,8 @@ export interface FilterDefinition {
   name: string;
   component: FilterComponent;
   category?: FilterCategory;
-  getOptions: (value: string) => Promise<FilterOption[]>;
+  findOption: (value: string) => FilterOption | undefined;
+  autocomplete: (value: string) => Promise<FilterOption[]>;
   validate: (value: string) => { val?: string; err?: string };
   checkCompletion?: (value: string, selected: string) => { completed: boolean; option: FilterOption };
   autoCompleteAddsQuotes?: boolean;
@@ -101,22 +102,11 @@ export interface FilterOption {
   value: string;
 }
 
-export const createFilterValue = (def: FilterDefinition, value: string): Promise<FilterValue> => {
-  return (
-    def
-      .getOptions(value)
-      .then(opts => {
-        const option = opts.find(opt => opt.name === value || opt.value === value);
-        return option
-          ? { v: option.value, display: option.name }
-          : { v: value, display: value === undefinedValue ? 'n/a' : undefined };
-      })
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      .catch(_ => {
-        // In case of error, still create the minimal possible FilterValue
-        return { v: value };
-      })
-  );
+export const createFilterValue = (def: FilterDefinition, value: string): FilterValue => {
+  const option = def.findOption(value);
+  return option
+    ? { v: option.value, display: option.name }
+    : { v: value, display: value === undefinedValue ? 'n/a' : undefined };
 };
 
 export const hasEnabledFilterValues = (filter: Filter) => {


### PR DESCRIPTION
## Description

There was an abusive use of the autocompletion mechanism in filters.
It's primarily used to get a list of filter options out of a search value.
But it was also used, during page loading, to transform a filter textual
value (read from URL) into a normalized filter option. This is bad,
because triggers unnecessary API calls on page load.

The change consists in splitting concerns between autocompletion and
text mapping to normalized filter option.

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [x] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
