### PR TITLE
NETOBSERV-2438: fix issues when filtering on subnet labels

### DIFF
--- a/web/src/model/filters.ts
+++ b/web/src/model/filters.ts
@@ -19,7 +19,8 @@ export type TargetedFilterId =
   | 'mac'
   | 'port'
   | 'host_address'
-  | 'host_name';
+  | 'host_name'
+  | 'subnet_label';
 
 export type FilterId =
   | 'cluster_name'

--- a/web/src/model/topology.ts
+++ b/web/src/model/topology.ts
@@ -126,10 +126,15 @@ const getDirFilterDefValue = (
     });
   }
 
-  // fallback on addr if not found
-  if (!def && fields.addr) {
-    def = findFilter(filterDefinitions, `${dir}_address`)!;
-    value = fields.addr!;
+  // fallback on addr and/or subnet label if not found
+  if (!def) {
+    if (fields.subnetLabel) {
+      def = findFilter(filterDefinitions, `${dir}_subnet_label`)!;
+      value = fields.subnetLabel!;
+    } else if (fields.addr) {
+      def = findFilter(filterDefinitions, `${dir}_address`)!;
+      value = fields.addr!;
+    }
   }
   return def && value ? { def, value } : undefined;
 };
@@ -213,7 +218,7 @@ export const toggleDirElementFilter = (
   const result = _.cloneDeep(filters);
   const defValue = getDirFilterDefValue(nodeType, fields, dir, filterDefinitions);
   if (!defValue) {
-    console.error("can't find defValue for fields", fields);
+    console.error("can't find directional filter definition and value for fields", fields);
     return;
   }
   toggleFilter(result, defValue, isFiltered, setFilters);
@@ -229,7 +234,7 @@ export const toggleElementFilter = (
   const result = _.cloneDeep(filters);
   const defValue = getFilterDefValue(fields, filterDefinitions);
   if (!defValue) {
-    console.error("can't find defValue for fields", fields);
+    console.error("can't find filter definition and value for fields", fields);
     return;
   }
   toggleFilter(result, defValue, isFiltered, setFilters);


### PR DESCRIPTION

## Description

Filtering using the filter icons in side panel didn't work

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
