### PR TITLE
Remove old contributors from OWNERS file, add new ones

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,19 +1,13 @@
 approvers:
-- mariomac
 - jotak
 - jpinsonneau
 - OlivierCazade
-- eranra
-- KalmanMeth
-- ronensc
 - stleerh
+- luisjira
+- leandroberetta
 options: {}
 reviewers:
-- mariomac
 - jotak
 - jpinsonneau
 - OlivierCazade
 - stleerh
-- eranra
-- KalmanMeth
-- ronensc


### PR DESCRIPTION
We are refreshing the list of maintainers to keep it aligned with the current state of contributions, removing accounts who haven't contributed in the past year.

Thanks @mariomac @eranra @KalmanMeth and @ronensc for your contributions! You are of course welcome to come back if you wish :-)

