### PR TITLE
NETOBSERV-2097 styling fixes for OCP 4.21

### DIFF
--- a/web/src/components/dropdowns/query-options-panel.tsx
+++ b/web/src/components/dropdowns/query-options-panel.tsx
@@ -187,13 +187,15 @@ export const QueryOptionsPanel: React.FC<QueryOptionsProps> = ({
         <Tooltip
           content={
             <div>
-              <p>{t('Filter flows by their drop status. Only packets dropped by the kernel are monitored here.')}</p>
-              <p className="netobserv-align-start">- {t('Fully dropped shows the flows that are 100% dropped')}</p>
+              <p className="netobserv-align-start">
+                {t('Filter flows by their drop status. Only packets dropped by the kernel are monitored here.')}
+              </p>
+              <p className="netobserv-align-start"> - {t('Fully dropped shows the flows that are 100% dropped')}</p>
               <p className="netobserv-align-start">
                 - {t('Containing drops shows the flows having at least one packet dropped')}
               </p>
-              <p className="netobserv-align-start">- {t('Without drops show the flows having 0% dropped')}</p>
-              <p className="netobserv-align-start">- {t('All shows everything')}</p>
+              <p className="netobserv-align-start"> - {t('Without drops show the flows having 0% dropped')}</p>
+              <p className="netobserv-align-start"> - {t('All shows everything')}</p>
             </div>
           }
         >

--- a/web/src/components/dropdowns/query-options-panel.tsx
+++ b/web/src/components/dropdowns/query-options-panel.tsx
@@ -1,9 +1,8 @@
-import { Radio, Text, TextContent, TextVariants, Tooltip } from '@patternfly/react-core';
+import { Radio, Text, TextVariants, Tooltip } from '@patternfly/react-core';
 import { InfoAltIcon } from '@patternfly/react-icons';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { DataSource, PacketLoss, RecordType } from '../../model/flow-query';
-import { useTheme } from '../../utils/theme-hook';
 import { QueryOptionsProps } from './query-options-dropdown';
 
 export const topValues = [5, 10, 15];
@@ -30,8 +29,6 @@ export const QueryOptionsPanel: React.FC<QueryOptionsProps> = ({
   packetLoss,
   setPacketLoss
 }) => {
-  const isDark = useTheme();
-  const contentStyle = { color: isDark ? '#000' : '#fff' };
   const { t } = useTranslation('plugin__netobserv-plugin');
 
   const recordTypeOptions: RecordTypeOption[] = [
@@ -189,23 +186,15 @@ export const QueryOptionsPanel: React.FC<QueryOptionsProps> = ({
       <div className="pf-v5-c-menu__group">
         <Tooltip
           content={
-            <TextContent className="netobserv-tooltip-text">
-              <Text component={TextVariants.p} style={contentStyle}>
-                {t('Filter flows by their drop status. Only packets dropped by the kernel are monitored here.')}
-              </Text>
-              <Text component={TextVariants.p} className="netobserv-align-start" style={contentStyle}>
-                - {t('Fully dropped shows the flows that are 100% dropped')}
-              </Text>
-              <Text component={TextVariants.p} className="netobserv-align-start" style={contentStyle}>
+            <div>
+              <p>{t('Filter flows by their drop status. Only packets dropped by the kernel are monitored here.')}</p>
+              <p className="netobserv-align-start">- {t('Fully dropped shows the flows that are 100% dropped')}</p>
+              <p className="netobserv-align-start">
                 - {t('Containing drops shows the flows having at least one packet dropped')}
-              </Text>
-              <Text component={TextVariants.p} className="netobserv-align-start" style={contentStyle}>
-                - {t('Without drops show the flows having 0% dropped')}
-              </Text>
-              <Text component={TextVariants.p} className="netobserv-align-start" style={contentStyle}>
-                - {t('All shows everything')}
-              </Text>
-            </TextContent>
+              </p>
+              <p className="netobserv-align-start">- {t('Without drops show the flows having 0% dropped')}</p>
+              <p className="netobserv-align-start">- {t('All shows everything')}</p>
+            </div>
           }
         >
           <div className="pf-v5-c-menu__group-title">

--- a/web/src/components/dropdowns/time-range-dropdown.tsx
+++ b/web/src/components/dropdowns/time-range-dropdown.tsx
@@ -1,13 +1,4 @@
-import {
-  Dropdown,
-  DropdownItem,
-  MenuToggle,
-  MenuToggleElement,
-  Text,
-  TextContent,
-  TextVariants,
-  Tooltip
-} from '@patternfly/react-core';
+import { Dropdown, DropdownItem, MenuToggle, MenuToggleElement, Tooltip } from '@patternfly/react-core';
 import * as _ from 'lodash';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -19,8 +10,6 @@ import {
   getDateSInMiliseconds,
   parseDuration
 } from '../../utils/duration';
-import { useTheme } from '../../utils/theme-hook';
-
 export interface TimeRangeDropdownProps {
   range: number | TimeRange;
   setRange: (v: number) => void;
@@ -31,8 +20,6 @@ export interface TimeRangeDropdownProps {
 export const customTimeRangeKey = 'CUSTOM_TIME_RANGE_KEY';
 
 export const TimeRangeDropdown: React.FC<TimeRangeDropdownProps> = ({ id, range, setRange, openCustomModal }) => {
-  const isDark = useTheme();
-  const contentStyle = { color: isDark ? '#000' : '#fff' };
   const [isOpen, setOpen] = React.useState<boolean>(false);
   const { t } = useTranslation('plugin__netobserv-plugin');
 
@@ -60,10 +47,10 @@ export const TimeRangeDropdown: React.FC<TimeRangeDropdownProps> = ({ id, range,
       let toText = getFormattedDate(to);
       if (prettyPrint) {
         return (
-          <TextContent className="netobserv-tooltip-text">
-            <Text component={TextVariants.p} style={contentStyle}>{`${t('From')} ${fromText}`}</Text>
-            <Text component={TextVariants.p} style={contentStyle}>{`${t('To')} ${toText}`}</Text>
-          </TextContent>
+          <div>
+            <p>{`${t('From')} ${fromText}`}</p>
+            <p>{`${t('To')} ${toText}`}</p>
+          </div>
         );
       } else {
         //remove common part of date if possible

--- a/web/src/components/metrics/chart-voronoi.tsx
+++ b/web/src/components/metrics/chart-voronoi.tsx
@@ -2,17 +2,34 @@ import { ChartLegendTooltip, createContainer } from '@patternfly/react-charts';
 import React from 'react';
 import { ChartDataPoint, LegendDataItem } from '../../utils/metrics-helper';
 
+const CursorVoronoiContainer = createContainer('voronoi', 'cursor');
+
+const CHAR_AVG_WIDTH = 7.5;
+const FLYOUT_PADDING = 40;
+const TITLE_ESTIMATED_LEN = 28;
+const VALUE_ESTIMATED_LEN = 12;
+
 export const chartVoronoi = (legendData: LegendDataItem[], f: (v: number) => string) => {
-  const CursorVoronoiContainer = createContainer('voronoi', 'cursor');
   const tooltipData = legendData.map(item => ({ ...item, name: item.tooltipName || item.name }));
+  const maxNameLen = Math.max(0, ...tooltipData.map(d => (d.name || '').length));
+  const legendWidth = (maxNameLen + VALUE_ESTIMATED_LEN + 2) * CHAR_AVG_WIDTH;
+  const titleWidth = TITLE_ESTIMATED_LEN * CHAR_AVG_WIDTH;
+  const flyoutWidth = Math.max(titleWidth, legendWidth) + FLYOUT_PADDING;
+
   return (
     <CursorVoronoiContainer
       cursorDimension="x"
       labels={(dp: { datum: ChartDataPoint }) => {
         return dp.datum.y || dp.datum.y === 0 ? f(dp.datum.y) : 'n/a';
       }}
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      labelComponent={<ChartLegendTooltip legendData={tooltipData} title={cb => cb.datum?.date || (cb as any).date} />}
+      labelComponent={
+        <ChartLegendTooltip
+          legendData={tooltipData}
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          title={(cb: any) => cb.datum?.date || cb.date}
+          flyoutWidth={flyoutWidth}
+        />
+      }
       mouseFollowTooltips
       voronoiDimension="x"
       voronoiPadding={50}

--- a/web/src/components/metrics/chart-voronoi.tsx
+++ b/web/src/components/metrics/chart-voronoi.tsx
@@ -26,7 +26,7 @@ export const chartVoronoi = (legendData: LegendDataItem[], f: (v: number) => str
         <ChartLegendTooltip
           legendData={tooltipData}
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          title={(cb: any) => cb.datum?.date || cb.date}
+          title={(cb: any) => cb.datum?.date}
           flyoutWidth={flyoutWidth}
         />
       }

--- a/web/src/components/metrics/histogram.tsx
+++ b/web/src/components/metrics/histogram.tsx
@@ -44,6 +44,7 @@ import { TruncateLength } from '../dropdowns/truncate-dropdown';
 import { GuidedTourHandle } from '../guided-tour/guided-tour';
 import BrushHandleComponent from './brush-handle';
 import './histogram.css';
+import './metrics-content.css';
 
 export const VoronoiContainer = createContainer('voronoi', 'brush');
 

--- a/web/src/components/metrics/metrics-content.css
+++ b/web/src/components/metrics/metrics-content.css
@@ -1,4 +1,64 @@
 @import '@patternfly/patternfly/patternfly-charts.css';
+@import '@patternfly/patternfly/patternfly-charts-theme-dark.css';
+
+/* OCP 4.22+ uses pf-v6-theme-dark, but chart dark overrides are scoped to pf-v5-theme-dark.
+   Duplicate chart dark theme variables under pf-v6-theme-dark, scoped to our chart containers. */
+.pf-v6-theme-dark .metrics-content-div .pf-v5-chart svg g[clip-path] {
+  mix-blend-mode: normal;
+}
+.pf-v6-theme-dark .metrics-content-div {
+  --pf-v5-chart-color-blue-100: #add6ff;
+  --pf-v5-chart-color-blue-200: #85c2ff;
+  --pf-v5-chart-color-blue-300: #47a3ff;
+  --pf-v5-chart-color-blue-400: #0a85ff;
+  --pf-v5-chart-color-blue-500: #06c;
+  --pf-v5-chart-color-green-100: #d6eed3;
+  --pf-v5-chart-color-green-200: #aedca7;
+  --pf-v5-chart-color-green-300: #85cb7c;
+  --pf-v5-chart-color-green-400: #5cb950;
+  --pf-v5-chart-color-green-500: #3e8635;
+  --pf-v5-chart-color-cyan-100: #b9feff;
+  --pf-v5-chart-color-cyan-200: #86fdff;
+  --pf-v5-chart-color-cyan-300: #00b5b8;
+  --pf-v5-chart-color-cyan-400: #008c8f;
+  --pf-v5-chart-color-cyan-500: #005f60;
+  --pf-v5-chart-color-purple-100: #cec8e4;
+  --pf-v5-chart-color-purple-200: #a99fd1;
+  --pf-v5-chart-color-purple-300: #9183c3;
+  --pf-v5-chart-color-purple-400: #7968b6;
+  --pf-v5-chart-color-purple-500: #6753ac;
+  --pf-v5-chart-color-red-100: #ffadad;
+  --pf-v5-chart-color-red-200: #ff7070;
+  --pf-v5-chart-color-red-300: #ff4747;
+  --pf-v5-chart-color-red-400: #ff0a0a;
+  --pf-v5-chart-color-red-500: #a30000;
+  --pf-v5-chart-global--BorderColor: var(--pf-t--global--border--color--default, #d2d2d2);
+  --pf-v5-chart-global--BorderColor--accent: var(--pf-t--global--border--color--default, #d2d2d2);
+  --pf-v5-chart-global--label--Fill: var(--pf-t--global--text--color--regular, #e0e0e0);
+  --pf-v5-chart-global--title--Fill: var(--pf-t--global--text--color--regular, #e0e0e0);
+  --pf-v5-chart-global--subtitle--Fill: var(--pf-t--global--text--color--subtle, #c0c0c0);
+  --pf-v5-chart-global--tooltip--Fill: #e0e0e0;
+  --pf-v5-chart-global--tooltip--bg--Fill: #1b1d21;
+  --pf-v5-chart-global--tooltip--BorderWidth: 1;
+  --pf-v5-chart-global--tooltip--BorderColor: var(--pf-t--global--border--color--default, #d2d2d2);
+  --pf-v5-chart-axis--axis--stroke--Color: var(--pf-v5-chart-global--BorderColor);
+  --pf-v5-chart-axis--grid--stroke--Color: var(--pf-v5-chart-global--BorderColor);
+  --pf-v5-chart-axis--tick--stroke--Color: var(--pf-v5-chart-global--BorderColor);
+  --pf-v5-chart-axis--axis--tick--stroke--Color: var(--pf-v5-chart-global--BorderColor);
+  --pf-v5-chart-axis--grid--Fill: var(--pf-v5-chart-global--BorderColor);
+  --pf-v5-chart-axis--tick-label--Fill: var(--pf-v5-chart-global--label--Fill);
+  --pf-v5-chart-donut--label--title--Fill: var(--pf-v5-chart-global--title--Fill);
+  --pf-v5-chart-donut--label--subtitle--Fill: var(--pf-v5-chart-global--subtitle--Fill);
+  --pf-v5-chart-line--data--stroke--Color: var(--pf-v5-chart-global--BorderColor);
+  --pf-v5-chart-tooltip--Fill: var(--pf-v5-chart-global--tooltip--Fill);
+  --pf-v5-chart-voronoi--labels--Fill: var(--pf-v5-chart-global--tooltip--Fill);
+  --pf-v5-chart-tooltip--flyoutStyle--Fill: var(--pf-v5-chart-global--tooltip--bg--Fill);
+  --pf-v5-chart-voronoi--flyout--stroke--Fill: var(--pf-v5-chart-global--tooltip--bg--Fill);
+  --pf-v5-chart-tooltip--flyoutStyle--stroke--Width: var(--pf-v5-chart-global--tooltip--BorderWidth);
+  --pf-v5-chart-tooltip--flyoutStyle--stroke--Color: var(--pf-v5-chart-global--tooltip--BorderColor);
+  --pf-v5-chart-voronoi--flyout--stroke--Width: var(--pf-v5-chart-global--tooltip--BorderWidth);
+  --pf-v5-chart-voronoi--flyout--stroke--Color: var(--pf-v5-chart-global--tooltip--BorderColor);
+}
 
 .metrics-content-div {
   width: 100%;

--- a/web/src/components/modals/__tests__/time-range-modal.spec.tsx
+++ b/web/src/components/modals/__tests__/time-range-modal.spec.tsx
@@ -93,29 +93,34 @@ describe('<TimeRangeModal />', () => {
   });
 
   it('should allow same day with different times (NETOBSERV-2665)', async () => {
-    const wrapper = mount(<TimeRangeModal {...props} />);
-    const datePickers = wrapper.find(DatePicker);
-    const timePickers = wrapper.find(TimePicker);
-
-    // Set both dates to the same day but different times
-    // From: 2026-03-12 10:00:00
-    // To: 2026-03-12 10:30:00
-    const testDate = new Date(2026, 2, 12); // March 12, 2026 in local timezone
-    act(() => {
-      datePickers.at(0).props().onChange!(fakeEvent, '2026-03-12', testDate);
-      timePickers.at(0).props().onChange!(fakeEvent, '10:00:00');
-      datePickers.at(1).props().onChange!(fakeEvent, '2026-03-12', testDate);
-      timePickers.at(1).props().onChange!(fakeEvent, '10:30:00');
+    render(<TimeRangeModal {...props} />);
+    await act(async () => {
+      jest.runAllTimers();
     });
 
-    wrapper.update();
+    const fromDateInput = document.querySelector('[data-test="from-date-picker"] input') as HTMLInputElement;
+    const fromTimeInput = document.querySelector('[data-test="from-time-picker"] input') as HTMLInputElement;
+    const toDateInput = document.querySelector('[data-test="to-date-picker"] input') as HTMLInputElement;
+    const toTimeInput = document.querySelector('[data-test="to-time-picker"] input') as HTMLInputElement;
+    const saveButton = document.querySelector('[data-test="time-range-save"]') as HTMLElement;
 
-    // The save button should be enabled (no error)
-    const saveButton = wrapper.find('[data-test="time-range-save"]').first();
-    expect(saveButton.prop('isDisabled')).toBe(false);
+    await act(async () => {
+      fireEvent.change(fromDateInput, { target: { value: '2026-03-12' } });
+      fireEvent.change(fromTimeInput, { target: { value: '10:00:00' } });
+      fireEvent.change(toDateInput, { target: { value: '2026-03-12' } });
+      fireEvent.change(toTimeInput, { target: { value: '10:30:00' } });
+      jest.runAllTimers();
+    });
 
-    // Verify no validation error is shown
-    const tooltip = wrapper.find('.time-range-tooltip-empty');
-    expect(tooltip.length).toBeGreaterThan(0);
+    await act(async () => {
+      fireEvent.click(saveButton);
+      jest.runAllTimers();
+    });
+
+    const expectedRange: TimeRange = {
+      from: new Date(2026, 2, 12, 10, 0, 0, 0).getTime() / 1000,
+      to: new Date(2026, 2, 12, 10, 30, 0, 0).getTime() / 1000
+    };
+    expect(props.setRange).toHaveBeenCalledWith(expectedRange);
   });
 });

--- a/web/src/components/modals/columns-modal.css
+++ b/web/src/components/modals/columns-modal.css
@@ -5,19 +5,11 @@
 }
 
 
-/* vertical align drag icon*/
+/* vertical align data list items */
 
-.pf-v5-c-data-list__cell {
-    margin-top: auto;
-    margin-bottom: auto;
-}
-
-
-/* vertical align label*/
-
-button.pf-v5-c-data-list__item-draggable-button {
-    margin-top: auto;
-    margin-bottom: auto;
+.netobserv-data-list-control {
+    align-items: center;
+    align-self: center;
 }
 
 label {

--- a/web/src/components/modals/columns-modal.tsx
+++ b/web/src/components/modals/columns-modal.tsx
@@ -279,7 +279,7 @@ export const ColumnsModal: React.FC<ColumnsModalProps> = ({
                   <Draggable key={column.id} hasNoWrapper>
                     <DataListItem aria-labelledby={rowLabelId} id={`table-column-management-row-${column.id}`}>
                       <DataListItemRow>
-                        <DataListControl>
+                        <DataListControl className="netobserv-data-list-control">
                           <DataListDragButton
                             aria-label={t('Reorder column')}
                             aria-labelledby={rowLabelId}

--- a/web/src/components/modals/overview-panels-modal.css
+++ b/web/src/components/modals/overview-panels-modal.css
@@ -5,19 +5,11 @@
 }
 
 
-/* vertical align drag icon*/
+/* vertical align data list items */
 
-.pf-v5-c-data-list__cell {
-    margin-top: auto;
-    margin-bottom: auto;
-}
-
-
-/* vertical align label*/
-
-button.pf-v5-c-data-list__item-draggable-button {
-    margin-top: auto;
-    margin-bottom: auto;
+.netobserv-data-list-control {
+    align-items: center;
+    align-self: center;
 }
 
 label {

--- a/web/src/components/modals/overview-panels-modal.tsx
+++ b/web/src/components/modals/overview-panels-modal.tsx
@@ -296,7 +296,7 @@ export const OverviewPanelsModal: React.FC<OverviewPanelsModalProps> = ({
                   <Draggable key={panel.id} hasNoWrapper>
                     <DataListItem aria-labelledby={rowLabelId} id={`overview-panel-management-row-${panel.id}`}>
                       <DataListItemRow>
-                        <DataListControl>
+                        <DataListControl className="netobserv-data-list-control">
                           <DataListDragButton
                             aria-label={t('Reorder panel')}
                             aria-labelledby={rowLabelId}

--- a/web/src/components/query-summary/stats-query-summary.tsx
+++ b/web/src/components/query-summary/stats-query-summary.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Warning } from '../../model/warnings';
 import { formatDurationAboveMillisecond } from '../../utils/duration';
-import { useTheme } from '../../utils/theme-hook';
 import './query-summary.css';
 
 export interface StatsQuerySummaryProps {
@@ -26,8 +25,6 @@ export const StatsQuerySummary: React.FC<StatsQuerySummaryProps> = ({
   loading,
   warning
 }) => {
-  const isDark = useTheme();
-  const contentStyle = { color: isDark ? '#000' : '#fff' };
   const { t } = useTranslation('plugin__netobserv-plugin');
 
   const dateText = lastRefresh ? lastRefresh.toLocaleTimeString() : t('Loading...');
@@ -42,37 +39,21 @@ export const StatsQuerySummary: React.FC<StatsQuerySummaryProps> = ({
       <Tooltip
         content={
           <>
-            <Text component="p" style={contentStyle}>
+            <p>
               {lastRefresh
                 ? t('Last refresh: {{time}}', {
                     time: dateText
                   })
                 : dateText}
-            </Text>
-            {dataSources?.length && (
-              <Text component="p" style={contentStyle}>
-                {t('Datasource(s): {{sources}}', { sources: formatDatasources() })}
-              </Text>
-            )}
-            {numQueries && (
-              <Text component="p" style={contentStyle}>
-                {t('Query count: {{numQueries}}', { numQueries })}
-              </Text>
-            )}
-            {durationText !== '' && (
-              <Text component="p" style={contentStyle}>
-                {t('Duration: {{duration}}', { duration: durationText })}
-              </Text>
-            )}
+            </p>
+            {dataSources?.length && <p>{t('Datasource(s): {{sources}}', { sources: formatDatasources() })}</p>}
+            {numQueries && <p>{t('Query count: {{numQueries}}', { numQueries })}</p>}
+            {durationText !== '' && <p>{t('Duration: {{duration}}', { duration: durationText })}</p>}
             {warning !== undefined && (
               <>
                 <br />
-                <Text component="p" style={contentStyle}>
-                  {warning.summary}
-                </Text>
-                <Text component="p" style={contentStyle}>
-                  {warning.details}
-                </Text>
+                <p>{warning.summary}</p>
+                <p>{warning.details}</p>
               </>
             )}
           </>

--- a/web/src/standalone/app.tsx
+++ b/web/src/standalone/app.tsx
@@ -131,7 +131,7 @@ export const App: React.FunctionComponent<{ endUser?: boolean }> = ({ endUser })
 
   const withContext = (content: JSX.Element, name: string) => {
     return (
-      <PageSection id="consolePageSection" className={`tab' ${isDark ? 'dark' : 'light'}`}>
+      <PageSection id="netobservPageSection" className={`tab' ${isDark ? 'dark' : 'light'}`}>
         <div style={{ padding: '1rem' }}>
           <Title headingLevel="h1">{`${name} example`}</Title>
         </div>

--- a/web/src/standalone/app.tsx
+++ b/web/src/standalone/app.tsx
@@ -131,7 +131,7 @@ export const App: React.FunctionComponent<{ endUser?: boolean }> = ({ endUser })
 
   const withContext = (content: JSX.Element, name: string) => {
     return (
-      <PageSection id="netobservPageSection" className={`tab' ${isDark ? 'dark' : 'light'}`}>
+      <PageSection id="netobservPageSection" className={`tab ${isDark ? 'dark' : 'light'}`}>
         <div style={{ padding: '1rem' }}>
           <Title headingLevel="h1">{`${name} example`}</Title>
         </div>

--- a/web/src/standalone/index.css
+++ b/web/src/standalone/index.css
@@ -25,11 +25,11 @@ section#pageSection.light {
   background: #fff !important;
 }
 
-#consolePageSection {
+#netobservPageSection {
   display: contents;
 }
 
-#consolePageSection>section {
+#netobservPageSection>section {
   flex: 1;
 }
 
@@ -53,6 +53,40 @@ label.pf-v5-c-menu__menu-item {
   position: relative;
   left: 16px;
   padding: 0;
+}
+
+/* Map PF6 semantic tokens for standalone mode (light).
+   In OCP Console, these are provided by the Console shell. */
+#pageSection, #netobservPageSection {
+  --pf-t--global--background--color--primary--default: #fff;
+  --pf-t--global--background--color--secondary--default: #f0f0f0;
+  --pf-t--global--border--color--default: #d2d2d2;
+  --pf-t--global--text--color--subtle: #6a6e73;
+  --pf-t--global--text--color--inverse: #fff;
+  --pf-t--global--text--color--regular: #151515;
+  --pf-t--global--text--color--status--danger--default: #c9190b;
+  --pf-t--global--text--color--status--warning--default: #f0ab00;
+  --pf-t--global--text--color--status--info--default: #2b9af3;
+  --pf-t--global--color--brand--default: #06c;
+  --pf-t--global--color--status--danger--default: #c9190b;
+  --pf-t--global--spacer--xs: 0.25rem;
+}
+
+/* Map PF6 semantic tokens for standalone mode (dark). */
+.pf-v5-theme-dark #pageSection,
+.pf-v5-theme-dark #netobservPageSection {
+  --pf-t--global--background--color--primary--default: #1b1d21;
+  --pf-t--global--background--color--secondary--default: #0f1214;
+  --pf-t--global--border--color--default: #444548;
+  --pf-t--global--text--color--subtle: #aaabac;
+  --pf-t--global--text--color--inverse: #1b1d21;
+  --pf-t--global--text--color--regular: #e0e0e0;
+  --pf-t--global--text--color--status--danger--default: #fe5142;
+  --pf-t--global--text--color--status--warning--default: #f0ab00;
+  --pf-t--global--text--color--status--info--default: #2b9af3;
+  --pf-t--global--color--brand--default: #1fa7f8;
+  --pf-t--global--color--status--danger--default: #fe5142;
+  --pf-t--global--spacer--xs: 0.25rem;
 }
 
 /*set font & titles styles*/

--- a/web/src/utils/fullscreen-hook.ts
+++ b/web/src/utils/fullscreen-hook.ts
@@ -4,27 +4,22 @@ export function useFullScreen(): [boolean, React.Dispatch<React.SetStateAction<b
   const [isFullScreen, setFullScreen] = React.useState(false);
 
   React.useEffect(() => {
-    if (isFullScreen && document.getElementsByClassName('pf-v5-c-page__sidebar pf-m-expanded').length) {
+    const sidebarExpanded = document.querySelector(
+      '.pf-v5-c-page__sidebar.pf-m-expanded, .pf-v6-c-page__sidebar.pf-m-expanded'
+    );
+    if (isFullScreen && sidebarExpanded) {
       document.getElementById('nav-toggle')?.click();
     }
 
-    const header = document.getElementById('page-main-header');
-    const headersCompat = document.getElementsByClassName('pf-v5-c-masthead');
-    const sideBar = document.getElementById('page-sidebar');
-    const sideBarsCompat = document.getElementsByClassName('pf-v5-c-page__sidebar');
-    const notification = document.getElementsByClassName('co-global-notifications');
+    const elements = document.querySelectorAll(
+      '#page-main-header, .pf-v5-c-masthead, .pf-v6-c-masthead, #page-sidebar, .pf-v5-c-page__sidebar, .pf-v6-c-page__sidebar'
+    );
 
-    [
-      header,
-      ...(headersCompat ? Array.from(headersCompat) : []),
-      sideBar,
-      ...(sideBarsCompat ? Array.from(sideBarsCompat) : []),
-      ...(notification ? Array.from(notification) : [])
-    ].forEach(e => {
+    elements.forEach(e => {
       if (isFullScreen) {
-        e?.classList.add('hidden');
+        e.classList.add('hidden');
       } else {
-        e?.classList.remove('hidden');
+        e.classList.remove('hidden');
       }
     });
   }, [isFullScreen]);


### PR DESCRIPTION
## Description

Since OCP 4.21 handle both PF5 and PF6, some styling is breaking. We need to address those changes to make it work:

- Tooltip text fixes: Replace <TextContent>/<Text> inside tooltips with plain HTML elements so text inherits the tooltip's default font size. Use --pf-t--global--text--color--inverse instead of hardcoded color logic. (query-options-panel.tsx, time-range-dropdown.tsx, stats-query-summary.tsx)

- DataList control alignment: Add netobserv-data-list-control class with align-items: center and align-self: center to vertically center drag buttons and checkboxes, including when labels wrap to two lines. Remove dead CSS. (columns-modal.tsx/css, overview-panels-modal.tsx/css)

- Chart dark mode for OCP 4.21+: Add PF5 chart dark theme overrides under .pf-v6-theme-dark .metrics-content-div since the bundled patternfly-charts-theme-dark.css only targets .pf-v5-theme-dark. Uses --pf-t--* tokens from the Console shell for text and border colors. (metrics-content.css, histogram.tsx)

- Chart tooltip improvements: Hoist createContainer('voronoi', 'cursor') to module level to prevent re-creation on every render (fixes intermittent tooltip display). Compute flyoutWidth to account for both title and legend content width. (chart-voronoi.tsx)

- Standalone PF6 token mapping: Define --pf-t--* semantic tokens scoped to #pageSection/#consolePageSection with explicit light and dark values, instead of chaining through PF5 tokens on :root. (standalone/index.css)

- Fullscreen hook PF5/PF6 compat: Update fullscreen-hook.ts to hide both .pf-v5-c-masthead/.pf-v6-c-masthead and sidebar elements for compatibility across Console versions.

Assisted-by: `claude-4.6-opus-high`

## Dependencies

https://github.com/netobserv/netobserv-operator/pull/2598 for easier testing all in one

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enhanced dark-mode chart theming for clearer metrics visualization
  * Simplified tooltip markup for more consistent text rendering
  * Adjusted standalone layout and theme tokens for improved standalone appearance

* **Refactor**
  * Removed theme-dependent inline color styling across several tooltips
  * Standardized data-list vertical alignment via updated container styling
  * Optimized tooltip container instantiation and legend sizing

* **Bug Fixes**
  * Improved tooltip sizing for clearer legend/title display
  * More robust fullscreen sidebar/header detection

* **Tests**
  * Rewrote time-range test to use DOM interactions and assert correct range handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->