### PR TITLE
Fix cypress dockerfile to use --legacy-peer-deps

### DIFF
--- a/Dockerfile.cypress
+++ b/Dockerfile.cypress
@@ -10,7 +10,7 @@ WORKDIR /opt/app-root
 COPY --chown=node web/package.json web/package.json
 COPY --chown=node web/package-lock.json web/package-lock.json
 WORKDIR /opt/app-root/web
-RUN npm ci
+RUN npm --legacy-peer-deps ci
 
 WORKDIR /opt/app-root
 COPY --chown=node web web

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -32,7 +32,7 @@ WORKDIR /opt/app-root/web
 COPY web/package.json web/package-lock.json ./
 
 # Install npm dependencies
-RUN npm ci
+RUN npm --legacy-peer-deps ci
 
 # Copy the rest of the web application
 COPY web/ ./

--- a/web/src/components/modals/__tests__/time-range-modal.spec.tsx
+++ b/web/src/components/modals/__tests__/time-range-modal.spec.tsx
@@ -93,29 +93,34 @@ describe('<TimeRangeModal />', () => {
   });
 
   it('should allow same day with different times (NETOBSERV-2665)', async () => {
-    const wrapper = mount(<TimeRangeModal {...props} />);
-    const datePickers = wrapper.find(DatePicker);
-    const timePickers = wrapper.find(TimePicker);
-
-    // Set both dates to the same day but different times
-    // From: 2026-03-12 10:00:00
-    // To: 2026-03-12 10:30:00
-    const testDate = new Date(2026, 2, 12); // March 12, 2026 in local timezone
-    act(() => {
-      datePickers.at(0).props().onChange!(fakeEvent, '2026-03-12', testDate);
-      timePickers.at(0).props().onChange!(fakeEvent, '10:00:00');
-      datePickers.at(1).props().onChange!(fakeEvent, '2026-03-12', testDate);
-      timePickers.at(1).props().onChange!(fakeEvent, '10:30:00');
+    render(<TimeRangeModal {...props} />);
+    await act(async () => {
+      jest.runAllTimers();
     });
 
-    wrapper.update();
+    const fromDateInput = document.querySelector('[data-test="from-date-picker"] input') as HTMLInputElement;
+    const fromTimeInput = document.querySelector('[data-test="from-time-picker"] input') as HTMLInputElement;
+    const toDateInput = document.querySelector('[data-test="to-date-picker"] input') as HTMLInputElement;
+    const toTimeInput = document.querySelector('[data-test="to-time-picker"] input') as HTMLInputElement;
+    const saveButton = document.querySelector('[data-test="time-range-save"]') as HTMLElement;
 
-    // The save button should be enabled (no error)
-    const saveButton = wrapper.find('[data-test="time-range-save"]').first();
-    expect(saveButton.prop('isDisabled')).toBe(false);
+    await act(async () => {
+      fireEvent.change(fromDateInput, { target: { value: '2026-03-12' } });
+      fireEvent.change(fromTimeInput, { target: { value: '10:00:00' } });
+      fireEvent.change(toDateInput, { target: { value: '2026-03-12' } });
+      fireEvent.change(toTimeInput, { target: { value: '10:30:00' } });
+      jest.runAllTimers();
+    });
 
-    // Verify no validation error is shown
-    const tooltip = wrapper.find('.time-range-tooltip-empty');
-    expect(tooltip.length).toBeGreaterThan(0);
+    await act(async () => {
+      fireEvent.click(saveButton);
+      jest.runAllTimers();
+    });
+
+    const expectedRange: TimeRange = {
+      from: new Date(2026, 2, 12, 10, 0, 0, 0).getTime() / 1000,
+      to: new Date(2026, 2, 12, 10, 30, 0, 0).getTime() / 1000
+    };
+    expect(props.setRange).toHaveBeenCalledWith(expectedRange);
   });
 });


### PR DESCRIPTION
## Description

Fix cypress dockerfile to use --legacy-peer-deps for `npm ci` command for node version 24 and npm 11.

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [X] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved dependency resolution during Docker image builds and applied the update across regular, test, and end-to-end build setups for more consistent images.

* **Tests**
  * Reworked a time-range modal test to use DOM-based interactions and now verifies the save callback is invoked with the exact from/to timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->