### PR TITLE
NETOBSERV-2665: Refactor custom time range error unit test to use @testing-library/react

### DIFF
--- a/web/src/components/modals/__tests__/time-range-modal.spec.tsx
+++ b/web/src/components/modals/__tests__/time-range-modal.spec.tsx
@@ -93,29 +93,29 @@ describe('<TimeRangeModal />', () => {
   });
 
   it('should allow same day with different times (NETOBSERV-2665)', async () => {
-    const wrapper = mount(<TimeRangeModal {...props} />);
-    const datePickers = wrapper.find(DatePicker);
-    const timePickers = wrapper.find(TimePicker);
+    render(<TimeRangeModal {...props} />);
+    await act(async () => {
+      jest.runAllTimers();
+    });
+
+    const fromDateInput = document.querySelector('[data-test="from-date-picker"] input') as HTMLInputElement;
+    const fromTimeInput = document.querySelector('[data-test="from-time-picker"] input') as HTMLInputElement;
+    const toDateInput = document.querySelector('[data-test="to-date-picker"] input') as HTMLInputElement;
+    const toTimeInput = document.querySelector('[data-test="to-time-picker"] input') as HTMLInputElement;
 
     // Set both dates to the same day but different times
     // From: 2026-03-12 10:00:00
     // To: 2026-03-12 10:30:00
-    const testDate = new Date(2026, 2, 12); // March 12, 2026 in local timezone
-    act(() => {
-      datePickers.at(0).props().onChange!(fakeEvent, '2026-03-12', testDate);
-      timePickers.at(0).props().onChange!(fakeEvent, '10:00:00');
-      datePickers.at(1).props().onChange!(fakeEvent, '2026-03-12', testDate);
-      timePickers.at(1).props().onChange!(fakeEvent, '10:30:00');
+    await act(async () => {
+      fireEvent.change(fromDateInput, { target: { value: '2026-03-12' } });
+      fireEvent.change(fromTimeInput, { target: { value: '10:00:00' } });
+      fireEvent.change(toDateInput, { target: { value: '2026-03-12' } });
+      fireEvent.change(toTimeInput, { target: { value: '10:30:00' } });
+      jest.runAllTimers();
     });
 
-    wrapper.update();
-
-    // The save button should be enabled (no error)
-    const saveButton = wrapper.find('[data-test="time-range-save"]').first();
-    expect(saveButton.prop('isDisabled')).toBe(false);
-
-    // Verify no validation error is shown
-    const tooltip = wrapper.find('.time-range-tooltip-empty');
-    expect(tooltip.length).toBeGreaterThan(0);
+    const saveButton = document.querySelector('[data-test="time-range-save"]') as HTMLButtonElement;
+    // The save button should be enabled (no validation error for same day with different times)
+    expect(saveButton.disabled).toBe(false);
   });
 });


### PR DESCRIPTION
Migrate the enzyme-based test to @testing-library/react to match the rest of the test file:
- Remove enzyme mount, DatePicker, and TimePicker imports
- Remove fakeEvent variable
- Use fireEvent.change() to set input values
- Use document.querySelector() to access DOM elements
- Use native disabled property instead of enzyme's prop()

This fixes the TypeScript errors and maintains consistency with the testing approach used throughout the file.

## Description

https://github.com/netobserv/netobserv-web-console/pull/1398 broke https://github.com/netobserv/netobserv-web-console/pull/1392 changes. So updating the unit tests similarly

## Dependencies

n/a

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [x] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated time-range modal tests to use DOM-driven interactions and simulated user input for more reliable validation.
  * Switched to timer-based flushes to ensure async validations complete, and now assert actual button disabled state instead of internal props.
  * Removed brittle helpers and outdated tooltip assertions for clearer, more maintainable tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->