### PR TITLE
NETOBSERV-2376 fix conditions icons / colors

### DIFF
--- a/web/src/components/forms/resource-status.tsx
+++ b/web/src/components/forms/resource-status.tsx
@@ -69,17 +69,17 @@ const stateColor = (state: string | undefined): LabelColor => {
 const StateIcon: FC<{ state: string | undefined }> = ({ state }) => {
   switch (state) {
     case 'Ready':
-      return <CheckCircleIcon color="var(--pf-v5-global--success-color--100)" />;
+      return <CheckCircleIcon color="var(--pf-t--global--icon--color--status--success--default)" />;
     case 'Degraded':
-      return <ExclamationTriangleIcon color="var(--pf-v5-global--warning-color--100)" />;
+      return <ExclamationTriangleIcon color="var(--pf-t--global--icon--color--status--warning--default)" />;
     case 'Failure':
-      return <ExclamationCircleIcon color="var(--pf-v5-global--danger-color--100)" />;
+      return <ExclamationCircleIcon color="var(--pf-t--global--icon--color--status--danger--default)" />;
     case 'InProgress':
-      return <HourglassHalfIcon color="var(--pf-v5-global--info-color--100)" />;
+      return <HourglassHalfIcon color="var(--pf-t--global--icon--color--status--info--default)" />;
     case 'Unused':
-      return <BanIcon color="var(--pf-v5-global--disabled-color--100)" />;
+      return <BanIcon color="var(--pf-t--global--icon--color--disabled)" />;
     default:
-      return <UnknownIcon color="var(--pf-v5-global--disabled-color--100)" />;
+      return <UnknownIcon color="var(--pf-t--global--icon--color--disabled)" />;
   }
 };
 
@@ -158,7 +158,7 @@ const ComponentStatusTable: FC<{
           ))}
           {unusedComponents.length > 0 && (
             <Tr>
-              <Td colSpan={4} style={{ color: 'var(--pf-v5-global--disabled-color--100)', fontStyle: 'italic' }}>
+              <Td colSpan={4} style={{ color: 'var(--pf-t--global--text--color--disabled)', fontStyle: 'italic' }}>
                 {t('Unused: {{list}}', { list: unusedComponents.map(c => c.name).join(', ') })}
               </Td>
             </Tr>
@@ -224,6 +224,7 @@ function conditionTone(c: K8sResourceCondition, fcStatus: FlowCollectorStatus | 
     return WAITING_NO_STATUS_FIELD.has(suffix) ? 'error' : 'progress';
   }
 
+  if (type === 'Ready' && status === 'True' && reason === 'Ready,Degraded') return 'warning';
   if (status === 'True') return 'success';
   if (status === 'False' && reason === 'Pending') return 'progress';
   if (status === 'False' && reason !== 'Valid') return 'error';
@@ -328,17 +329,17 @@ export const ResourceStatus: FC<ResourceStatusProps> = ({
               >
                 <Td>
                   {tone === 'error' ? (
-                    <ExclamationCircleIcon color="var(--pf-v5-global--danger-color--100)" />
+                    <ExclamationCircleIcon color="var(--pf-t--global--icon--color--status--danger--default)" />
                   ) : tone === 'warning' ? (
-                    <ExclamationTriangleIcon color="var(--pf-v5-global--warning-color--100)" />
+                    <ExclamationTriangleIcon color="var(--pf-t--global--icon--color--status--warning--default)" />
                   ) : tone === 'progress' ? (
-                    <HourglassHalfIcon color="var(--pf-v5-global--info-color--100)" />
+                    <HourglassHalfIcon color="var(--pf-t--global--icon--color--status--info--default)" />
                   ) : tone === 'unused' ? (
-                    <BanIcon color="var(--pf-v5-global--disabled-color--100)" />
+                    <BanIcon color="var(--pf-t--global--icon--color--disabled)" />
                   ) : tone === 'success' ? (
-                    <CheckCircleIcon color="var(--pf-v5-global--success-color--100)" />
+                    <CheckCircleIcon color="var(--pf-t--global--icon--color--status--success--default)" />
                   ) : (
-                    <UnknownIcon color="var(--pf-v5-global--disabled-color--100)" />
+                    <UnknownIcon color="var(--pf-t--global--icon--color--disabled)" />
                   )}{' '}
                   {condition.type}
                 </Td>
@@ -347,9 +348,9 @@ export const ResourceStatus: FC<ResourceStatusProps> = ({
                 <Td
                   style={
                     tone === 'warning'
-                      ? { color: 'var(--pf-v5-global--warning-color--200)' }
+                      ? { color: 'var(--pf-t--global--text--color--status--warning--default)' }
                       : tone === 'error'
-                      ? { color: 'var(--pf-v5-global--danger-color--100)' }
+                      ? { color: 'var(--pf-t--global--text--color--status--danger--default)' }
                       : undefined
                   }
                 >

--- a/web/src/components/forms/resource-status.tsx
+++ b/web/src/components/forms/resource-status.tsx
@@ -15,6 +15,29 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from '../../utils/url';
 import { ComponentStatus, ExporterStatus } from './pipeline';
 
+/** `FlowCollector.status` fields used by this form (mirrors operator CRD shape). */
+export type FlowCollectorStatus = {
+  conditions?: K8sResourceCondition[];
+  components?: {
+    agent?: ComponentStatus;
+    processor?: ComponentStatus;
+    plugin?: ComponentStatus;
+  };
+  integrations?: {
+    loki?: ComponentStatus;
+    monitoring?: ComponentStatus;
+    exporters?: ExporterStatus[];
+  };
+};
+
+function flowCollectorStatus(existing: K8sResourceKind | null): FlowCollectorStatus | undefined {
+  const raw = existing?.status;
+  if (raw == null || typeof raw !== 'object') {
+    return undefined;
+  }
+  return raw as FlowCollectorStatus;
+}
+
 export type ResourceStatusProps = {
   group: string;
   version: string;
@@ -154,8 +177,7 @@ const WAITING_NO_STATUS_FIELD = new Set(['FlowCollectorController', 'StaticContr
 
 type ConditionTone = 'error' | 'warning' | 'progress' | 'success' | 'unused' | 'unknown';
 
-function waitingComponentState(existing: K8sResourceKind | null, suffix: string): string | undefined {
-  const st = existing?.status as any;
+function waitingComponentState(st: FlowCollectorStatus | undefined, suffix: string): string | undefined {
   if (!st) return undefined;
   const { components, integrations } = st;
   switch (suffix) {
@@ -178,7 +200,7 @@ function waitingComponentState(existing: K8sResourceKind | null, suffix: string)
 }
 
 /** One tone per row: drives icon and message color. */
-function conditionTone(c: K8sResourceCondition, existing: K8sResourceKind | null): ConditionTone {
+function conditionTone(c: K8sResourceCondition, fcStatus: FlowCollectorStatus | undefined): ConditionTone {
   const { type, status, reason } = c;
 
   if (type === 'ConfigurationIssue') {
@@ -190,10 +212,11 @@ function conditionTone(c: K8sResourceCondition, existing: K8sResourceKind | null
   if (type.startsWith('Waiting')) {
     const suffix = type.slice('Waiting'.length);
     if (status === 'False' && reason === 'Ready') return 'success';
-    if (status === 'Unknown' && reason === 'Unused') return 'unused';
+    // Operator `setUnused` sets reason `ComponentUnused`; `toCondition` default is `Unused`.
+    if (status === 'Unknown' && (reason === 'Unused' || reason === 'ComponentUnused')) return 'unused';
     if (status !== 'True') return 'unknown';
 
-    const st = waitingComponentState(existing, suffix);
+    const st = waitingComponentState(fcStatus, suffix);
     if (st === 'Failure') return 'error';
     if (st === 'Degraded') return 'warning';
     if (st === 'InProgress') return 'progress';
@@ -233,30 +256,32 @@ export const ResourceStatus: FC<ResourceStatusProps> = ({
     );
   }
 
+  const fcStatus = flowCollectorStatus(existing);
+
   const components: ComponentRowData[] = [];
-  if (existing.status?.components?.agent) {
-    components.push({ id: 'agent', name: t('eBPF Agent'), status: existing.status.components.agent });
+  if (fcStatus?.components?.agent) {
+    components.push({ id: 'agent', name: t('eBPF Agent'), status: fcStatus.components.agent });
   }
-  if (existing.status?.components?.processor) {
-    components.push({ id: 'processor', name: t('Flowlogs Pipeline'), status: existing.status.components.processor });
+  if (fcStatus?.components?.processor) {
+    components.push({ id: 'processor', name: t('Flowlogs Pipeline'), status: fcStatus.components.processor });
   }
-  if (existing.status?.components?.plugin) {
-    components.push({ id: 'plugin', name: t('Console Plugin'), status: existing.status.components.plugin });
+  if (fcStatus?.components?.plugin) {
+    components.push({ id: 'plugin', name: t('Console Plugin'), status: fcStatus.components.plugin });
   }
-  if (existing.status?.integrations?.loki) {
-    components.push({ id: 'loki', name: 'Loki', status: existing.status.integrations.loki });
+  if (fcStatus?.integrations?.loki) {
+    components.push({ id: 'loki', name: 'Loki', status: fcStatus.integrations.loki });
   }
-  if (existing.status?.integrations?.monitoring) {
-    components.push({ id: 'monitoring', name: t('Monitoring'), status: existing.status.integrations.monitoring });
+  if (fcStatus?.integrations?.monitoring) {
+    components.push({ id: 'monitoring', name: t('Monitoring'), status: fcStatus.integrations.monitoring });
   }
-  const exporters: ExporterStatus[] = existing.status?.integrations?.exporters || [];
+  const exporters: ExporterStatus[] = fcStatus?.integrations?.exporters || [];
 
   const sortConditions = [
     (c: K8sResourceCondition) => c.type === 'Ready',
     (c: K8sResourceCondition) => c.type === 'ConfigurationIssue',
     (c: K8sResourceCondition) => c.type === 'KafkaReady'
   ];
-  const conditions = ((existing?.status?.conditions || []) as K8sResourceCondition[]).sort((a, b) => {
+  const conditions = (fcStatus?.conditions || []).sort((a, b) => {
     for (const pred of sortConditions) {
       if (pred(a) && pred(b)) {
         return 0;
@@ -293,7 +318,7 @@ export const ResourceStatus: FC<ResourceStatusProps> = ({
         </Thead>
         <Tbody>
           {conditions.map((condition, i) => {
-            const tone = conditionTone(condition, existing);
+            const tone = conditionTone(condition, fcStatus);
             return (
               <Tr
                 id={`${condition.type}-row`}

--- a/web/src/components/forms/resource-status.tsx
+++ b/web/src/components/forms/resource-status.tsx
@@ -146,6 +146,67 @@ const ComponentStatusTable: FC<{
   );
 };
 
+/**
+ * `Waiting*` FlowCollector conditions use inverted polarity (operator `statuses.go`): `True` means not ready.
+ * Component state on the same status object is the source of truth for Failure / Degraded / InProgress.
+ */
+const WAITING_NO_STATUS_FIELD = new Set(['FlowCollectorController', 'StaticController', 'NetworkPolicy']);
+
+type ConditionTone = 'error' | 'warning' | 'progress' | 'success' | 'unused' | 'unknown';
+
+function waitingComponentState(existing: K8sResourceKind | null, suffix: string): string | undefined {
+  const st = existing?.status as any;
+  if (!st) return undefined;
+  const { components, integrations } = st;
+  switch (suffix) {
+    case 'EBPFAgents':
+      return components?.agent?.state;
+    case 'WebConsole':
+      return components?.plugin?.state;
+    case 'FLPMonolith':
+    case 'FLPParent':
+    case 'FLPTransformer':
+      return components?.processor?.state;
+    case 'Monitoring':
+      return integrations?.monitoring?.state;
+    case 'LokiStack':
+    case 'DemoLoki':
+      return integrations?.loki?.state;
+    default:
+      return undefined;
+  }
+}
+
+/** One tone per row: drives icon and message color. */
+function conditionTone(c: K8sResourceCondition, existing: K8sResourceKind | null): ConditionTone {
+  const { type, status, reason } = c;
+
+  if (type === 'ConfigurationIssue') {
+    if (status === 'True' && reason === 'Error') return 'error';
+    if (status === 'True' && reason === 'Warnings') return 'warning';
+    return 'unknown';
+  }
+
+  if (type.startsWith('Waiting')) {
+    const suffix = type.slice('Waiting'.length);
+    if (status === 'False' && reason === 'Ready') return 'success';
+    if (status === 'Unknown' && reason === 'Unused') return 'unused';
+    if (status !== 'True') return 'unknown';
+
+    const st = waitingComponentState(existing, suffix);
+    if (st === 'Failure') return 'error';
+    if (st === 'Degraded') return 'warning';
+    if (st === 'InProgress') return 'progress';
+    if (st === 'Ready') return 'success';
+    return WAITING_NO_STATUS_FIELD.has(suffix) ? 'error' : 'progress';
+  }
+
+  if (status === 'True') return 'success';
+  if (status === 'False' && reason === 'Pending') return 'progress';
+  if (status === 'False' && reason !== 'Valid') return 'error';
+  return 'unknown';
+}
+
 export const ResourceStatus: FC<ResourceStatusProps> = ({
   group,
   version,
@@ -232,16 +293,7 @@ export const ResourceStatus: FC<ResourceStatusProps> = ({
         </Thead>
         <Tbody>
           {conditions.map((condition, i) => {
-            const isWarning =
-              condition.type === 'ConfigurationIssue' && condition.status === 'True' && condition.reason === 'Warnings';
-            const isError =
-              (condition.type === 'ConfigurationIssue' &&
-                condition.status === 'True' &&
-                condition.reason === 'Error') ||
-              (condition.type !== 'ConfigurationIssue' &&
-                condition.status === 'False' &&
-                condition.reason !== 'Pending' &&
-                condition.reason !== 'Valid');
+            const tone = conditionTone(condition, existing);
             return (
               <Tr
                 id={`${condition.type}-row`}
@@ -250,14 +302,16 @@ export const ResourceStatus: FC<ResourceStatusProps> = ({
                 key={i}
               >
                 <Td>
-                  {isError ? (
+                  {tone === 'error' ? (
                     <ExclamationCircleIcon color="var(--pf-v5-global--danger-color--100)" />
-                  ) : isWarning ? (
+                  ) : tone === 'warning' ? (
                     <ExclamationTriangleIcon color="var(--pf-v5-global--warning-color--100)" />
-                  ) : condition.status === 'True' && condition.type !== 'ConfigurationIssue' ? (
-                    <CheckCircleIcon color="var(--pf-v5-global--success-color--100)" />
-                  ) : condition.status === 'False' && condition.reason === 'Pending' ? (
+                  ) : tone === 'progress' ? (
                     <HourglassHalfIcon color="var(--pf-v5-global--info-color--100)" />
+                  ) : tone === 'unused' ? (
+                    <BanIcon color="var(--pf-v5-global--disabled-color--100)" />
+                  ) : tone === 'success' ? (
+                    <CheckCircleIcon color="var(--pf-v5-global--success-color--100)" />
                   ) : (
                     <UnknownIcon color="var(--pf-v5-global--disabled-color--100)" />
                   )}{' '}
@@ -267,9 +321,9 @@ export const ResourceStatus: FC<ResourceStatusProps> = ({
                 <Td>{condition.reason}</Td>
                 <Td
                   style={
-                    isWarning
+                    tone === 'warning'
                       ? { color: 'var(--pf-v5-global--warning-color--200)' }
-                      : isError
+                      : tone === 'error'
                       ? { color: 'var(--pf-v5-global--danger-color--100)' }
                       : undefined
                   }

--- a/web/src/components/status/flowcollector-status-icon.tsx
+++ b/web/src/components/status/flowcollector-status-icon.tsx
@@ -51,7 +51,7 @@ export const FlowCollectorStatusIcon: React.FC<FlowCollectorStatusIconProps> = (
   }, [status]);
 
   return (
-    <Tooltip content={tooltipContent} position="bottom">
+    <Tooltip id="flowcollector-status-tooltip" content={tooltipContent} position="bottom">
       <span style={{ display: 'inline-flex', verticalAlign: 'middle' }}>{icon}</span>
     </Tooltip>
   );

--- a/web/src/components/status/flowcollector-status-icon.tsx
+++ b/web/src/components/status/flowcollector-status-icon.tsx
@@ -36,15 +36,15 @@ export const FlowCollectorStatusIcon: React.FC<FlowCollectorStatusIconProps> = (
   const icon = React.useMemo(() => {
     switch (status) {
       case 'ready':
-        return <ConnectedIcon color="var(--pf-v5-global--success-color--100)" />;
+        return <ConnectedIcon color="var(--pf-t--global--icon--color--status--success--default)" />;
       case 'degraded':
-        return <ExclamationTriangleIcon color="var(--pf-v5-global--warning-color--100)" />;
+        return <ExclamationTriangleIcon color="var(--pf-t--global--icon--color--status--warning--default)" />;
       case 'pending':
-        return <ExclamationTriangleIcon color="var(--pf-v5-global--warning-color--100)" />;
+        return <ExclamationTriangleIcon color="var(--pf-t--global--icon--color--status--warning--default)" />;
       case 'error':
-        return <ExclamationCircleIcon color="var(--pf-v5-global--danger-color--100)" />;
+        return <ExclamationCircleIcon color="var(--pf-t--global--icon--color--status--danger--default)" />;
       case 'onHold':
-        return <PauseCircleIcon color="var(--pf-v5-global--info-color--100)" />;
+        return <PauseCircleIcon color="var(--pf-t--global--icon--color--status--info--default)" />;
       case 'loading':
         return <Spinner size="md" />;
     }


### PR DESCRIPTION
## Description

Followup on [NETOBSERV-2376](https://redhat.atlassian.net/browse/NETOBSERV-2376) to fix conditions icons and colors since we [reverted the logic in operator](https://github.com/netobserv/netobserv-operator/pull/2610#discussion_r3057884500).

Also see https://github.com/netobserv/netobserv-operator/pull/2677 for onHold and kafka condition fixes

## Dependencies

n/a

## Checklist

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced status condition display with more granular visual indicators (error, warning, progress, success, unused, unknown) for clearer status information.
  * Updated status icon styling and colors using modern design tokens for improved visual consistency.
  * Refined component and integration status reporting logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->