### PR TITLE
NETOBSERV-2655 improve additionalIncludeList form behavior

### DIFF
--- a/web/moduleMapper/schemas.ts
+++ b/web/moduleMapper/schemas.ts
@@ -5531,7 +5531,7 @@ export const flowCollectorSchema: RJSFSchema | any = {
               "type": "string"
             },
             "metrics": {
-              "description": "`Metrics` define the processor configuration regarding metrics",
+              "description": "`Metrics` define the processor configuration regarding metrics.\n\nTo add optional metrics while keeping the built-in defaults, use `additionalIncludeList`.\nTo take full control and export only specific metrics, use `includeList` (which replaces the default set; `additionalIncludeList` is then ignored).",
               "properties": {
                 "disableAlerts": {
                   "description": "`disableAlerts` is a list of alert groups that should be disabled from the default set of alerts.\nPossible values are: `NetObservNoFlows`, `NetObservLokiError`, `PacketDropsByKernel`, `PacketDropsByDevice`, `IPsecErrors`, `NetpolDenied`,\n`LatencyHighTrend`, `DNSErrors`, `DNSNxDomain`, `ExternalEgressHighTrend`, `ExternalIngressHighTrend`, `Ingress5xxErrors`, `IngressHTTPLatencyTrend`.\nMore information on alerts: https://github.com/netobserv/netobserv-operator/blob/main/docs/HealthRules.md",
@@ -5640,7 +5640,51 @@ export const flowCollectorSchema: RJSFSchema | any = {
                   "type": "array"
                 },
                 "includeList": {
-                  "description": "`includeList` is a list of metric names to specify which ones to generate.\nThe names correspond to the names in Prometheus without the prefix. For example,\n`namespace_egress_packets_total` shows up as `netobserv_namespace_egress_packets_total` in Prometheus.\nNote that the more metrics you add, the bigger is the impact on Prometheus workload resources.\nMetrics enabled by default are:\n`namespace_flows_total`, `node_ingress_bytes_total`, `node_egress_bytes_total`, `workload_ingress_bytes_total`,\n`workload_egress_bytes_total`, `namespace_drop_packets_total` (when `PacketDrop` feature is enabled),\n`namespace_rtt_seconds` (when `FlowRTT` feature is enabled), `namespace_dns_latency_seconds` (when `DNSTracking` feature is enabled),\n`namespace_network_policy_events_total` (when `NetworkEvents` feature is enabled).\nMore information, with full list of available metrics: https://github.com/netobserv/netobserv-operator/blob/main/docs/Metrics.md",
+                  "description": "`includeList` replaces the default metric set entirely: only the metrics you list here are generated.\nOmit this field to keep the built-in defaults (they depend on enabled features). To add metrics on top of defaults instead, use `additionalIncludeList`.\n\nIf both are set, `includeList` wins and `additionalIncludeList` is ignored.\n\nNames match Prometheus without the `netobserv_` prefix; for example, `namespace_egress_packets_total` appears as `netobserv_namespace_egress_packets_total`.\nMore metrics increase load on Prometheus.\n\nWhen this field is omitted, defaults include: `namespace_flows_total`, `node_ingress_bytes_total`, `node_egress_bytes_total`, `workload_ingress_bytes_total`,\n`workload_egress_bytes_total`, `namespace_drop_packets_total` (when `PacketDrop` is enabled),\n`namespace_rtt_seconds` (when `FlowRTT` is enabled), `namespace_dns_latency_seconds` (when `DNSTracking` is enabled),\n`namespace_network_policy_events_total` (when `NetworkEvents` is enabled).\nFull list: https://github.com/netobserv/netobserv-operator/blob/main/docs/Metrics.md",
+                  "items": {
+                    "description": "Metric name. More information in https://github.com/netobserv/netobserv-operator/blob/main/docs/Metrics.md.",
+                    "enum": [
+                      "namespace_egress_bytes_total",
+                      "namespace_egress_packets_total",
+                      "namespace_ingress_bytes_total",
+                      "namespace_ingress_packets_total",
+                      "namespace_flows_total",
+                      "node_egress_bytes_total",
+                      "node_egress_packets_total",
+                      "node_ingress_bytes_total",
+                      "node_ingress_packets_total",
+                      "node_flows_total",
+                      "workload_egress_bytes_total",
+                      "workload_egress_packets_total",
+                      "workload_ingress_bytes_total",
+                      "workload_ingress_packets_total",
+                      "workload_flows_total",
+                      "namespace_drop_bytes_total",
+                      "namespace_drop_packets_total",
+                      "node_drop_bytes_total",
+                      "node_drop_packets_total",
+                      "workload_drop_bytes_total",
+                      "workload_drop_packets_total",
+                      "namespace_rtt_seconds",
+                      "node_rtt_seconds",
+                      "workload_rtt_seconds",
+                      "namespace_dns_latency_seconds",
+                      "node_dns_latency_seconds",
+                      "workload_dns_latency_seconds",
+                      "node_network_policy_events_total",
+                      "namespace_network_policy_events_total",
+                      "workload_network_policy_events_total",
+                      "node_ipsec_flows_total",
+                      "namespace_ipsec_flows_total",
+                      "workload_ipsec_flows_total",
+                      "node_to_node_ingress_flows_total"
+                    ],
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "additionalIncludeList": {
+                  "description": "`additionalIncludeList` adds extra metrics on top of the default set. It does not remove or replace defaults.\nOmit `includeList` when using this field: if `includeList` is set, it replaces all defaults and `additionalIncludeList` is ignored.\n\nNames match Prometheus without the `netobserv_` prefix; for example, `namespace_egress_packets_total` appears as `netobserv_namespace_egress_packets_total`.\nMore metrics increase load on Prometheus.\nFull list: https://github.com/netobserv/netobserv-operator/blob/main/docs/Metrics.md",
                   "items": {
                     "description": "Metric name. More information in https://github.com/netobserv/netobserv-operator/blob/main/docs/Metrics.md.",
                     "enum": [

--- a/web/src/components/forms/config/uiSchema.ts
+++ b/web/src/components/forms/config/uiSchema.ts
@@ -595,7 +595,20 @@ export const flowCollectorUISchema: UiSchema = {
           'ui:order': ['tls', 'port', '*']
         },
         includeList: {
-          'ui:title': 'Include list'
+          'ui:title': 'Metric include list (replaces defaults)'
+        },
+        additionalIncludeList: {
+          'ui:title': 'Additional metrics (on top of defaults)',
+          'ui:options': {
+            addDisabledTooltip:
+              'Cannot add metrics while "Metric include list (replaces defaults)" is set. Clear that list first.'
+          },
+          'ui:dependency': {
+            controlFieldPath: ['processor', 'metrics', 'includeList'],
+            controlFieldValue: '',
+            controlFieldName: 'includeList',
+            matchMode: 'controlUnset'
+          }
         },
         alerts: {
           'ui:title': 'Alerts'
@@ -603,7 +616,7 @@ export const flowCollectorUISchema: UiSchema = {
         disableAlerts: {
           'ui:title': 'Disable alerts'
         },
-        'ui:order': ['server', 'includeList', 'alerts', 'disableAlerts', '*']
+        'ui:order': ['server', 'includeList', 'additionalIncludeList', 'alerts', 'disableAlerts', '*']
       },
       resources: {
         'ui:title': 'Resource Requirements',

--- a/web/src/components/forms/dynamic-form/fields.tsx
+++ b/web/src/components/forms/dynamic-form/fields.tsx
@@ -132,13 +132,16 @@ export const FormField: React.FC<FormFieldProps> = ({ children, id, defaultLabel
 export type FieldSetProps = Pick<FieldProps, 'idSchema' | 'required' | 'schema' | 'uiSchema'> & {
   children?: React.ReactNode;
   defaultLabel?: string;
+  /** When true, the schema description block under the accordion title is omitted (e.g. full text only in a tooltip). */
+  suppressDescription?: boolean;
 };
 
 export const FieldSet: React.FC<FieldSetProps> = props => {
-  const { children, defaultLabel, idSchema, required = false, schema, uiSchema } = props;
+  const { children, defaultLabel, idSchema, required = false, schema, suppressDescription, uiSchema } = props;
   const [expanded, setExpanded] = React.useState(idSchema['$id'] === 'root'); // root is expanded by default
   const [showLabel, label] = useSchemaLabel(schema, uiSchema || {}, defaultLabel);
-  const description = useSchemaDescription(schema, uiSchema || {});
+  const schemaDescription = useSchemaDescription(schema, uiSchema || {});
+  const description = suppressDescription ? '' : schemaDescription;
   return showLabel && label ? (
     <div id={`${idSchema.$id}_field-group`} className="form-group co-dynamic-form__field-group">
       <AccordionItem isExpanded={expanded}>

--- a/web/src/components/forms/dynamic-form/templates.tsx
+++ b/web/src/components/forms/dynamic-form/templates.tsx
@@ -12,10 +12,11 @@ import {
 import * as _ from 'lodash';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
+import { MaybeTooltip } from '../../tooltip/maybe-tooltip';
 import { jsonSchemaGroupTypes } from './const';
 import { DescriptionField, FieldSet, FormField } from './fields';
 import { UiSchemaOptionsWithDependency } from './types';
-import { useSchemaLabel } from './utils';
+import { isDependencyControlUnset, useSchemaLabel } from './utils';
 
 export const AtomicFieldTemplate: React.FC<FieldTemplateProps> = ({
   children,
@@ -57,6 +58,11 @@ export const FieldTemplate: React.FC<FieldTemplateProps> = props => {
     const { dependency } = getUiOptions(uiSchema ?? {}) as UiSchemaOptionsWithDependency; // Type defs for this function are awful
     if (dependency) {
       setDependencyMet(() => {
+        if (dependency.matchMode === 'controlUnset') {
+          const spec = _.get(formContext.formData ?? {}, ['spec'], {});
+          return isDependencyControlUnset(spec, dependency.controlFieldPath);
+        }
+
         let val = _.get(formContext.formData ?? {}, ['spec'], '');
         dependency.controlFieldPath.forEach(path => {
           val = _.get(val, [path], '');
@@ -72,11 +78,21 @@ export const FieldTemplate: React.FC<FieldTemplateProps> = props => {
     }
   }, [uiSchema, formContext, id]);
 
-  if (hidden || !dependencyMet) {
+  if (hidden) {
     return null;
   }
+
+  const { dependency } = getUiOptions(uiSchema ?? {}) as UiSchemaOptionsWithDependency;
+  const disableBecauseControlUnset = dependency?.matchMode === 'controlUnset' && String(type) === 'array';
+
+  if (dependency && !dependencyMet && !disableBecauseControlUnset) {
+    return null;
+  }
+
   const isGroup = jsonSchemaGroupTypes.includes(String(type));
-  return isGroup ? children : <AtomicFieldTemplate {...props} />;
+  const inner = isGroup ? children : <AtomicFieldTemplate {...props} />;
+
+  return <>{inner}</>;
 };
 
 export const ObjectFieldTemplate: React.FC<ObjectFieldTemplateProps> = props => {
@@ -102,12 +118,20 @@ export const ArrayFieldTemplate: React.FC<ArrayFieldTemplateProps> = ({
   required,
   schema,
   title,
-  uiSchema
+  uiSchema,
+  formContext
 }) => {
   const { t } = useTranslation('plugin__netobserv-plugin');
   const [, label] = useSchemaLabel(schema, uiSchema || {}, title ?? 'Items');
-  return (
-    <FieldSet defaultLabel={label} idSchema={idSchema} required={required} schema={schema} uiSchema={uiSchema}>
+  const { addDisabledTooltip, dependency } = getUiOptions(uiSchema ?? {}) as UiSchemaOptionsWithDependency;
+  const spec = _.get(formContext?.formData, 'spec');
+  const pauseArrayEdit =
+    dependency?.matchMode === 'controlUnset' &&
+    Boolean(dependency.controlFieldPath?.length) &&
+    !isDependencyControlUnset(spec, dependency.controlFieldPath);
+  const addDisabledTooltipContent = pauseArrayEdit && addDisabledTooltip ? addDisabledTooltip : undefined;
+  const itemsBlock = (
+    <>
       {_.map(items ?? [], item => {
         return (
           <div className="co-dynamic-form__array-field-group-item" key={item.key}>
@@ -130,17 +154,40 @@ export const ArrayFieldTemplate: React.FC<ArrayFieldTemplateProps> = ({
           </div>
         );
       })}
+    </>
+  );
+  return (
+    <FieldSet
+      defaultLabel={label}
+      idSchema={idSchema}
+      required={required}
+      schema={schema}
+      suppressDescription={pauseArrayEdit}
+      uiSchema={uiSchema}
+    >
+      {pauseArrayEdit ? (
+        <fieldset disabled style={{ border: 'none', margin: 0, padding: 0, minWidth: 0 }}>
+          {itemsBlock}
+        </fieldset>
+      ) : (
+        itemsBlock
+      )}
       <div className="row">
-        <Button
-          icon={<PlusCircleIcon className="co-icon-space-r" />}
-          id={`${idSchema.$id}_add-btn`}
-          data-test-id={`${idSchema.$id}_add-btn`}
-          type="button"
-          onClick={onAddClick}
-          variant="link"
-        >
-          {t('Add {{singularLabel}}', { singularLabel: label })}
-        </Button>
+        <MaybeTooltip content={addDisabledTooltipContent}>
+          <span style={{ display: 'inline-block' }}>
+            <Button
+              icon={<PlusCircleIcon className="co-icon-space-r" />}
+              id={`${idSchema.$id}_add-btn`}
+              data-test-id={`${idSchema.$id}_add-btn`}
+              type="button"
+              isDisabled={pauseArrayEdit}
+              onClick={onAddClick}
+              variant="link"
+            >
+              {t('Add {{singularLabel}}', { singularLabel: label })}
+            </Button>
+          </span>
+        </MaybeTooltip>
       </div>
     </FieldSet>
   );

--- a/web/src/components/forms/dynamic-form/types.ts
+++ b/web/src/components/forms/dynamic-form/types.ts
@@ -2,10 +2,17 @@ export type DynamicFormFieldDependency = {
   controlFieldPath: string[];
   controlFieldValue: string;
   controlFieldName: string;
+  /**
+   * `equals` (default): show when the value at `controlFieldPath` (under spec) equals `controlFieldValue`.
+   * `controlUnset`: show when the control path is effectively unset (missing key, null, or empty array).
+   */
+  matchMode?: 'equals' | 'controlUnset';
 };
 
 export type UiSchemaOptionsWithDependency = {
   dependency?: DynamicFormFieldDependency;
+  /** When `matchMode: 'controlUnset'` pauses the array, tooltip for the disabled Add action. */
+  addDisabledTooltip?: string;
 };
 
 export type DynamicFormSchemaError = {

--- a/web/src/components/forms/dynamic-form/utils.ts
+++ b/web/src/components/forms/dynamic-form/utils.ts
@@ -33,6 +33,30 @@ export const getSchemaErrors = (schema: JSONSchema7): DynamicFormSchemaError[] =
   ];
 };
 
+/**
+ * For `ui:dependency` `matchMode: 'controlUnset'`: true when the control path under `spec` is
+ * effectively unset: property missing, `null`/`undefined`, or an empty array.
+ */
+export const isDependencyControlUnset = (spec: unknown, path: string[]): boolean => {
+  if (!path.length) {
+    return true;
+  }
+  const parentPath = path.slice(0, -1);
+  const fieldName = path[path.length - 1];
+  const parent = parentPath.length > 0 ? _.get(spec, parentPath) : spec;
+  if (!_.has(parent, fieldName)) {
+    return true;
+  }
+  const value = _.get(parent, fieldName);
+  if (value == null) {
+    return true;
+  }
+  if (Array.isArray(value) && value.length === 0) {
+    return true;
+  }
+  return false;
+};
+
 // Returns true if a value is not nil and is empty
 export const definedAndEmpty = (value: any): boolean => !_.isNil(value) && _.isEmpty(value);
 


### PR DESCRIPTION
## Description

Add helper texts
Disable additionnal metrics when include list is set

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to configure additional metrics on top of default metric set
  * New UI control for appending metrics without removing built-in defaults

* **Improvements**
  * Enhanced metric configuration with clearer labeling ("Metric include list" vs. "Additional metrics")
  * Form fields now intelligently disable/enable based on related configuration settings
  * Improved schema documentation for metric configuration options and precedence rules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->