### PR TITLE
NETOBSERV-2716 fix udn tab

### DIFF
--- a/web/src/components/netflow-traffic-tab.tsx
+++ b/web/src/components/netflow-traffic-tab.tsx
@@ -231,6 +231,34 @@ export const NetflowTrafficTab: React.FC<NetflowTrafficTabProps> = ({ match, obj
           match: 'bidirectional'
         });
         break;
+      case 'ClusterUserDefinedNetwork':
+        setForcedFilters({
+          list: [
+            {
+              def: findFilter(filterDefinitions, 'udns')!,
+              compare: FilterCompare.equal,
+              values: [{ v: obj!.metadata!.name as string }]
+            }
+          ],
+          match: 'bidirectional'
+        });
+        break;
+      case 'UserDefinedNetwork':
+        setForcedFilters({
+          list: [
+            {
+              def: findFilter(filterDefinitions, 'udns')!,
+              compare: FilterCompare.equal,
+              values: [
+                {
+                  v: `${obj!.metadata!.namespace!}.${obj!.metadata!.name!}`
+                }
+              ]
+            }
+          ],
+          match: 'bidirectional'
+        });
+        break;
     }
   }, [config, obj, previous, t]);
 


### PR DESCRIPTION
## Description

Fix CUDN / UDN tab not handled (crashing)

## Dependencies

n/a

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Network traffic tab now supports ClusterUserDefinedNetwork and UserDefinedNetwork resources. When viewing those resources, the tab automatically applies appropriate filters to show bidirectional traffic for the selected network (namespace-aware where applicable), simplifying monitoring of user-defined networks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netobserv/netobserv-web-console/pull/1504?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->