### PR TITLE
NetObserv-2389  update to e2e Dockerfile and scripts

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -44,20 +44,14 @@ RUN mkdir -p gui_test_screenshots/cypress/screenshots \
     chmod -R 777 gui_test_screenshots cypress/results
 
 # Set environment variables
-ENV CYPRESS_CACHE_FOLDER=/tmp/.cache/Cypress
 ENV HOME=/tmp
 ENV NO_COLOR=1
+ENV WEB_DIR=/opt/app-root/web
 
-# Make cache directory writable for OpenShift arbitrary UIDs
-RUN mkdir -p /tmp/.cache/Cypress && chmod -R 777 /tmp
+RUN chmod -R 777 /root/.cache/Cypress /tmp
 
-# Create a non-root user for OpenShift compatibility
-RUN useradd -u 1001 -r -g 0 -m -d /tmp -s /sbin/nologin \
-    -c "Default Application User" default && \
-    chown -R 1001:0 /opt/app-root && \
-    chmod -R g+rwX /opt/app-root /tmp
-
-USER 1001
+# Make directories writable for OpenShift arbitrary UIDs (group 0)
+RUN chmod -R g+rwX /opt/app-root
 
 WORKDIR /opt/app-root
 

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -48,7 +48,9 @@ ENV HOME=/tmp
 ENV NO_COLOR=1
 ENV WEB_DIR=/opt/app-root/web
 
-RUN chmod -R 777 /root/.cache/Cypress /tmp
+RUN mkdir -p /root/.cache/Cypress /tmp && \
+    chmod 1777 /tmp && \
+    chmod -R g+rwX /root/.cache/Cypress
 
 # Make directories writable for OpenShift arbitrary UIDs (group 0)
 RUN chmod -R g+rwX /opt/app-root

--- a/scripts/run-e2e-tests.sh
+++ b/scripts/run-e2e-tests.sh
@@ -237,18 +237,13 @@ BROWSER="${CYPRESS_BROWSER:-chrome}"
 
 # Build cypress run command arguments
 CYPRESS_ARGS=(
-    --spec "cypress/integration-tests/**/*.cy.ts"
+    --spec "${SPEC_FILES:-cypress/integration-tests/**/*.cy.ts}"
     --env "grepTags=${GREP_TAGS}"
     --browser "${BROWSER}"
     --headless
     --reporter cypress-multi-reporters
     --reporter-options configFile=reporter-config.json
 )
-
-# Add --spec option if spec files are provided
-if [ -n "${SPEC_FILES}" ]; then
-    CYPRESS_ARGS+=(--spec "${SPEC_FILES}")
-fi
 
 # Run tests and capture exit code
 set +e

--- a/scripts/run-e2e-tests.sh
+++ b/scripts/run-e2e-tests.sh
@@ -31,9 +31,11 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# Configuration
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-WEB_DIR="${SCRIPT_DIR}/../web"
+# Configuration — use WEB_DIR env var if set, otherwise detect from script location
+if [ -z "${WEB_DIR:-}" ]; then
+    SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+    WEB_DIR="${SCRIPT_DIR}/../web"
+fi
 RESULTS_DIR="${WEB_DIR}/cypress/results"
 SCREENSHOTS_DIR="${WEB_DIR}/gui_test_screenshots"
 
@@ -235,6 +237,7 @@ BROWSER="${CYPRESS_BROWSER:-chrome}"
 
 # Build cypress run command arguments
 CYPRESS_ARGS=(
+    --spec "cypress/integration-tests/**/*.cy.ts"
     --env "grepTags=${GREP_TAGS}"
     --browser "${BROWSER}"
     --headless

--- a/web/cypress/support/commands.ts
+++ b/web/cypress/support/commands.ts
@@ -192,7 +192,7 @@ Cypress.Commands.add('changeMetricType', (name) => {
 
   cy.get('#metricType-dropdown').click();
   cy.get('.pf-v6-c-menu__content').filter(':visible').contains(name).click();
-  
+
   // For Packets metric, we expect a full page error due to mock timeout
   if (name === 'Packets') {
     cy.get('[data-test="error-state"]').should('exist');
@@ -294,8 +294,8 @@ Cypress.Commands.add('uiLogin', (provider: string, username: string, password: s
   cy.clearAllCookies();
   cy.visit('/');
 
-  // Wait a moment for potential redirect to OAuth server
-  cy.url({ timeout: 30000 }).should('include', '/oauth/authorize').then((url) => {
+  // Wait for redirect to OAuth login page
+  cy.url({ timeout: 30000 }).should('match', /\/login|\/oauth\/authorize/).then((url) => {
     const currentUrl = new URL(url);
 
     cy.log(`Current URL: ${url}`);


### PR DESCRIPTION
## Description

[NetObserv-2389](https://redhat.atlassian.net/browse/NetObserv-2389)  update to e2e Dockerfile and scripts for CI

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [X] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Test runner allows overriding the detected web directory via WEB_DIR (falls back to a derived path).
  * Test invocation always supplies a test-spec argument, using a provided pattern or a sensible default.
  * Container test runtime updated: environment variables set earlier and directory permissions adjusted to better support non-root/arbitrary UIDs.

* **Tests**
  * Login check widened to accept alternate pre-OAuth redirect URLs to reduce flaky test failures.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netobserv/netobserv-web-console/pull/1505)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->