### PR TITLE
Dockerfile.e2e remove repo files for chrome and edge

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -5,7 +5,10 @@ FROM cypress/included:13.6.5
 
 # Install additional dependencies
 USER root
-RUN apt-get update && apt-get install -y \
+RUN rm -f /etc/apt/sources.list.d/google-chrome.list \
+          /etc/apt/sources.list.d/microsoft-edge.list \
+          /etc/apt/sources.list.d/microsoft-edge-stable.list && \
+    apt-get update && apt-get install -y \
     curl \
     jq \
     apache2-utils \


### PR DESCRIPTION
## Description

Fix removes the broken Chrome and duplicate Microsoft Edge apt source lists before running apt-get update. The cypress/included base image adds these repos for browser installation, but the Chrome GPG key has rotated
  and causes the failure.

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [X] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
