### PR TITLE
NETOBSERV-2653: TLS topology automation

### DIFF
--- a/web/cypress/fixtures/test-tls-server-client.yaml
+++ b/web/cypress/fixtures/test-tls-server-client.yaml
@@ -1,0 +1,141 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-tls-server
+  labels:
+    name: test-tls-server
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-tls-config
+  namespace: test-tls-server
+data:
+  nginx.conf: |
+    events { worker_connections 1024; }
+    http {
+      server {
+        listen 8080;
+        location / { return 200 'HTTP\n'; }
+      }
+      server {
+        listen 8443 ssl;
+        ssl_certificate /etc/nginx/ssl/tls.crt;
+        ssl_certificate_key /etc/nginx/ssl/tls.key;
+        ssl_protocols TLSv1.2 TLSv1.3;
+        location / { return 200 'HTTPS\n'; }
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tls-server
+  namespace: test-tls-server
+  labels:
+    app: tls-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tls-server
+  template:
+    metadata:
+      labels:
+        app: tls-server
+    spec:
+      initContainers:
+        - name: cert-generator
+          image: registry.access.redhat.com/ubi9/ubi:latest
+          command:
+            - /bin/bash
+            - -c
+            - |
+              openssl req -x509 -nodes -days 1 -newkey rsa:2048 \
+                -keyout /etc/nginx/ssl/tls.key -out /etc/nginx/ssl/tls.crt \
+                -subj "/CN=tls-server"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: ssl-certs
+              mountPath: /etc/nginx/ssl
+      containers:
+        - name: nginx
+          image: quay.io/openshifttest/nginx-alpine:1.2.3
+          ports:
+            - containerPort: 8080
+            - containerPort: 8443
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: nginx-config
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+            - name: ssl-certs
+              mountPath: /etc/nginx/ssl
+      volumes:
+        - name: nginx-config
+          configMap:
+            name: nginx-tls-config
+        - name: ssl-certs
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tls-server-service
+  namespace: test-tls-server
+spec:
+  selector:
+    app: tls-server
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+    - name: https
+      port: 443
+      targetPort: 8443
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-tls-client
+  labels:
+    name: test-tls-client
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: tls-client
+  name: tls-client
+  namespace: test-tls-client
+spec:
+  containers:
+    - name: client
+      image: quay.io/openshifttest/hello-openshift:1.2.0
+      command:
+        - sh
+        - -c
+        - |
+          while : ; do
+            curl -sk --tlsv1.3 https://tls-server-service.test-tls-server.svc:443/ > /dev/null 2>&1
+            sleep 5
+            curl -sk --tlsv1.2 --tls-max 1.2 https://tls-server-service.test-tls-server.svc:443/ > /dev/null 2>&1
+            sleep 5
+            curl -s http://tls-server-service.test-tls-server.svc:80/ > /dev/null 2>&1
+            sleep 5
+          done
+      securityContext:
+        allowPrivilegeEscalation: false
+        runAsNonRoot: true
+        capabilities:
+          drop: ["ALL"]
+        seccompProfile:
+          type: RuntimeDefault

--- a/web/cypress/integration-tests/tls_dashboards.cy.ts
+++ b/web/cypress/integration-tests/tls_dashboards.cy.ts
@@ -1,5 +1,6 @@
 import { Operator } from "@views/netobserv"
 import { dashboard } from "@views/dashboards-page"
+import { filterSelectors, netflowPage, topologyPage } from "@views/netflow-page"
 
 const TLSPanels = [
     "flows-rate-per-tls-version-chart",
@@ -15,11 +16,96 @@ describe('(OCP-88966) TLSTracking test', { tags: ['Network_Observability'] }, fu
         Operator.install()
         cy.checkStorageClass(this)
         Operator.createFlowcollector("TLSTracking")
+
+        // Deploy TLS test server and client
+        cy.adminCLI('oc apply -f cypress/fixtures/test-tls-server-client.yaml')
+        cy.wait(10000)
+        cy.adminCLI('oc wait --for=condition=Available deployment/tls-server -n test-tls-server --timeout=180s')
+        cy.adminCLI('oc wait --for=condition=Ready pod -n test-tls-client -l app=tls-client --timeout=120s')
     })
 
-    // TODO: TLS in topology is still Dev InProgress. Will implement test here once its complete 
+    describe('TLS Topology tests', function () {
+        beforeEach('setup common topology filters', function () {
+            topologyPage.setupWithNamespaceFilter('test-tls-server')
+            cy.get(filterSelectors.filterInput).type("dst_namespace=test-tls-client{enter}")
+            cy.get(filterSelectors.filterInput).type("protocol=TCP{enter}")
+        })
+
+        it("(OCP-88966, aramesha) Verify TLS lock icons", function () {
+            // Add filters for TLS traffic (port 443)
+            cy.get(filterSelectors.filterInput).type("src_port=443{enter}")
+
+            netflowPage.waitForLokiQuery()
+
+            // Wait for topology to render with edges
+            cy.get('[data-kind="edge"]', { timeout: 60000 }).should('have.length.greaterThan', 0)
+
+            // Verify yellow/legacy lock appears (worst case: TLS 1.2 shown when both 1.2 and 1.3 present)
+            cy.byLegacyTestID('edge-handler').find('g.netobserv-topology-edge-lock--legacy').should('exist')
+
+            // Click on an edge to open side panel
+            cy.get('[data-kind="edge"]').first().click()
+            cy.get('#elementPanel').should('be.visible')
+
+            // Verify side panel shows TLS versions
+            cy.get('#elementPanel').should('contain', 'TLS versions')
+            cy.get('#elementPanel').should('contain', 'TLS 1.2')
+            cy.get('#elementPanel').should('contain', 'TLS 1.3')
+
+            // Click the TLS 1.3 quick filter
+            cy.get('[data-test="quick-filter-tls_version-TLS 1.3"]').click()
+
+            // Verify TLS 1.3 filter is applied
+            cy.get('[id^="tls_version-"]').should('contain.text', 'TLS 1.3')
+
+            netflowPage.waitForLokiQuery()
+
+            // Now verify green/modern lock appears
+            cy.byLegacyTestID('edge-handler').find('g.netobserv-topology-edge-lock--modern').should('exist')
+
+            // Clear filters for next test
+            netflowPage.clearAllFilters()
+        })
+
+        it("(OCP-88966, aramesha) Verify cleartext traffic display", function () {
+            // Add filters for HTTP cleartext traffic (port 80)
+            cy.get(filterSelectors.filterInput).type("src_port=80{enter}")
+
+            netflowPage.waitForLokiQuery()
+
+            // Verify edges with HTTP cleartext traffic
+            cy.get('[data-kind="edge"]', { timeout: 30000 }).should('have.length.greaterThan', 0)
+
+            // Verify no open lock appears before enabling cleartext display option
+            cy.byLegacyTestID('edge-handler').find('g.netobserv-topology-edge-lock--cleartext').should('not.exist')
+
+            // Open Display options and enable cleartext traffic display
+            cy.contains('Display options').should('exist').click()
+
+            // Verify "Cleartext traffic" checkbox exists
+            cy.get('#edges-cleartext-lock-switch').should('exist')
+
+            // Enable cleartext traffic display
+            cy.get('#edges-cleartext-lock-switch').check()
+
+            cy.contains('Display options').should('exist').click()
+            netflowPage.waitForLokiQuery()
+
+            // Verify open lock icons (cleartext) now appear on edges for HTTP traffic
+            cy.byLegacyTestID('edge-handler').find('g.netobserv-topology-edge-lock--cleartext').should('exist')
+
+            netflowPage.clearAllFilters()
+        })
+
+        afterEach('clear topology filters', function () {
+            netflowPage.resetClearFilters()
+        })
+    })
 
     it("(OCP-88966, aramesha) Validate TLSTracking dashboards", function () {
+        // Clear namespace context before navigating to dashboards
+        cy.visit('/monitoring')
+
         // navigate to 'NetObserv / Main' Dashboard page
         dashboard.visit()
         dashboard.visitDashboard("netobserv-main")
@@ -29,10 +115,12 @@ describe('(OCP-88966) TLSTracking test', { tags: ['Network_Observability'] }, fu
 
         cy.get('#content-scrollable').scrollTo('bottom')
 
+        // verify TLS dashboard panels
         cy.checkDashboards(TLSPanels)
     })
 
     after("all tests", function () {
+        cy.adminCLI('oc delete -f cypress/fixtures/test-tls-server-client.yaml --ignore-not-found')
         Operator.deleteFlowCollector()
         cy.adminCLI(`oc adm policy remove-cluster-role-from-user cluster-admin ${Cypress.env('LOGIN_USERNAME')}`)
     })


### PR DESCRIPTION
## Description

TLS Topology automation based on [NETOBSERV-2609](https://redhat.atlassian.net/browse/NETOBSERV-2609)

## Dependencies

n/a

Results:

         Spec                                              Tests  Passing  Failing  Pending  Skipped
    ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
    │ ✔  tls_dashboards.cy.ts                     03:39        3        3        -        -        - │
    └────────────────────────────────────────────────────────────────────────────────────────────────┘
      ✔  All specs passed!                        03:39        3        3        -        -        -


## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [x] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated test infrastructure for TLS server and client deployment to support comprehensive testing scenarios.
  * Enhanced TLS dashboard test validation, including lock icon rendering and cleartext traffic detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netobserv/netobserv-web-console/pull/1541?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->