### PR TITLE
[upstream] Add standalone builds to PR image workflow

### DIFF
--- a/.github/workflows/build_image_pr.yml
+++ b/.github/workflows/build_image_pr.yml
@@ -4,8 +4,7 @@ on:
     types: [labeled]
 
 env:
-  WF_REGISTRY: quay.io/netobserv
-  WF_IMAGE: network-observability-console-plugin
+  WF_ORG: netobserv
 
 permissions:
   contents: read
@@ -24,7 +23,9 @@ jobs:
       - name: get short sha
         run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       - name: build and save image
-        run: OCI_BUILD_OPTS="--label quay.expires-after=2w" IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.short_sha }} CLEAN_BUILD=1 make tar-image
+        run: OCI_BUILD_OPTS="--label quay.expires-after=2w" IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.short_sha }} CLEAN_BUILD=1 make tar-image
+      - name: build and save standalone image
+        run: OCI_BUILD_OPTS="--label quay.expires-after=2w" IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.short_sha }} CLEAN_BUILD=1 STANDALONE=true make tar-image
       - name: save PR number
         run: |
           echo ${{ github.event.number }} > ./out/pr-id

--- a/.github/workflows/push_image_pr.yml
+++ b/.github/workflows/push_image_pr.yml
@@ -25,6 +25,7 @@ jobs:
       - name: load images
         run: |
           docker load --input ./image.tar
+          docker load --input ./image-standalone.tar
       - name: docker login to quay.io
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
@@ -34,6 +35,7 @@ jobs:
       - name: push images
         run: |
           DOCKER_BUILDKIT=1 docker push $(cat ./name)
+          DOCKER_BUILDKIT=1 docker push $(cat ./name-standalone)
       - uses: actions/github-script@v9
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -42,16 +44,18 @@ jobs:
             var issueNumber = Number(fs.readFileSync('./pr-id'));
             var shortSha = String(fs.readFileSync('./short-sha')).trim();
             var mainImage = fs.readFileSync('./name');
+            var standaloneImage = fs.readFileSync('./name-standalone');
             github.rest.issues.createComment({
               issue_number: issueNumber,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `New image:
+              body: `New images:
             \`\`\`bash
             ${mainImage}
+            ${standaloneImage}
             \`\`\`
 
-            It will expire in two weeks.
+            They will expire in two weeks.
 
             To deploy this build, run from the operator repo, assuming the operator is running:
             \`\`\`bash

--- a/Makefile
+++ b/Makefile
@@ -284,8 +284,13 @@ tar-image: MULTIARCH_TARGETS=amd64
 tar-image: image-build ## Build single arch (amd64) and save as a tar
 	$(OCI_BIN) tag $(IMAGE)-amd64 $(IMAGE)
 	mkdir -p ./out
+ifeq (${STANDALONE}, true)
+	$(OCI_BIN) save -o out/image-standalone.tar $(IMAGE)
+	echo $(IMAGE) > ./out/name-standalone
+else
 	$(OCI_BIN) save -o out/image.tar $(IMAGE)
 	echo $(IMAGE) > ./out/name
+endif
 
 include .mk/cypress.mk
 include .mk/shortcuts.mk


### PR DESCRIPTION
so that "ok-to-test" also builds images for upstream

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New standalone image variant now available alongside the standard image release.

* **Chores**
  * Updated build and deployment workflows to support building and pushing multiple image variants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netobserv/netobserv-web-console/pull/1555?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->