### PR TITLE
Minor security hardening, improve upstream releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,3 +35,8 @@ updates:
         applies-to: version-updates
         patterns:
           - "cypress/*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/.github"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/build_image_pr.yml
+++ b/.github/workflows/build_image_pr.yml
@@ -15,7 +15,7 @@ jobs:
     name: Build PR image and upload artifact
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       - name: Install make
@@ -25,7 +25,7 @@ jobs:
       - name: build and save standalone image
         run: OCI_BUILD_OPTS="--label quay.expires-after=2w" IMAGE_ORG=${{ env.WF_ORG }} VERSION=tmp CLEAN_BUILD=1 STANDALONE=true make tar-image
       - name: upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pr
           path: out/

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,11 +16,11 @@ jobs:
     - name: install make
       run: sudo apt-get install make
     - name: set up go 1.x
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version: '1.26'
     - name: checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         persist-credentials: false
     - name: build, lint, test
@@ -42,11 +42,11 @@ jobs:
     - name: install make
       run: sudo apt-get install make
     - name: set up node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6
       with:
         node-version: 22
     - name: checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         persist-credentials: false
     - name: build and test
@@ -66,18 +66,18 @@ jobs:
     - name: install make
       run: sudo apt-get install make
     - name: set up go 1.x
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version: '1.26'
     - name: checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         persist-credentials: false
     - name: run benchmark comparison
       run: make benchmark-server-compare
     - name: upload benchmark results
       if: always()
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       with:
         name: benchmark-results
         path: pkg/server/benchmark-current.txt

--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -20,7 +20,7 @@ jobs:
       - name: install make
         run: sudo apt-get install make
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       - name: docker login to quay.io
@@ -49,11 +49,12 @@ jobs:
     - name: install make
       run: sudo apt-get install make
     - name: set up go 1.x
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version: '1.26'
+        cache: false
     - name: checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         persist-credentials: false
     - name: Test
@@ -75,11 +76,11 @@ jobs:
     - name: install make
       run: sudo apt-get install make
     - name: set up node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6
       with:
         node-version: 22
     - name: checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         persist-credentials: false
     - name: Test

--- a/.github/workflows/push_image_pr.yml
+++ b/.github/workflows/push_image_pr.yml
@@ -43,7 +43,7 @@ jobs:
           echo "main_image=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${head_sha::8}" >> $GITHUB_ENV
           echo "sa_image=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE_SA }}:${head_sha::8}" >> $GITHUB_ENV
       - name: download artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: pr
           run-id: ${{github.event.workflow_run.id }}
@@ -64,7 +64,7 @@ jobs:
         run: |
           DOCKER_BUILDKIT=1 docker push ${{ env.main_image }}
           DOCKER_BUILDKIT=1 docker push ${{ env.sa_image }}
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       - name: validate tag
@@ -45,12 +45,9 @@ jobs:
         run: |
           MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.tag }} CLEAN_BUILD=1 STANDALONE=true make images
       - name: create draft release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           tag_name: ${{ env.tag }}
-          release_name: ${{ env.tag }}
+          name: ${{ env.tag }}
           draft: true
           prerelease: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,21 +5,29 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
+  artifact-metadata: write
 
 env:
   WF_REGISTRY_USER: netobserv+github_ci
   WF_ORG: netobserv
   WF_MULTIARCH_TARGETS: amd64 arm64 ppc64le s390x
+  WF_REGISTRY_NAME: quay.io
+  WF_IMAGE_NAME: quay.io/netobserv/network-observability-console-plugin
+  WF_STANDALONE_IMAGE_NAME: quay.io/netobserv/network-observability-standalone-frontend
 
 jobs:
   push-image:
     name: build and push release
     runs-on: ubuntu-latest
+
     steps:
       - name: checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
+
       - name: validate tag
         run: |
           tag=`git describe --exact-match --tags 2> /dev/null`
@@ -31,23 +39,104 @@ jobs:
               echo "$tag is NOT a valid release tag"
               exit 1
           fi
+
       - name: install make
         run: sudo apt-get install make
+
       - name: docker login to quay.io
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ env.WF_REGISTRY_USER }}
           password: ${{ secrets.QUAY_SECRET }}
-          registry: quay.io
+          registry: ${{ env.WF_REGISTRY_NAME }}
+
       - name: build and push manifest with images
         run: MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.tag }} CLEAN_BUILD=1 make images
+
       - name: build and push manifest with images for standalone build
         run: |
           MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.tag }} CLEAN_BUILD=1 STANDALONE=true make images
-      - name: create draft release
+
+      - name: capture image digest
+        id: image_digest
+        run: |
+          mkdir -p release-assets
+          digest=$(docker buildx imagetools inspect ${{ env.WF_IMAGE_NAME }}:${{ env.tag }} \
+            --format '{{json .Manifest.Digest}}' | tr -d '"')
+          echo "digest=$digest" >> "$GITHUB_ENV"
+          echo "${{ env.WF_IMAGE_NAME }}@$digest" >> ./release-assets/images
+
+          digest_standalone=$(docker buildx imagetools inspect ${{ env.WF_STANDALONE_IMAGE_NAME }}:${{ env.tag }} \
+            --format '{{json .Manifest.Digest}}' | tr -d '"')
+          echo "digest_standalone=$digest_standalone" >> "$GITHUB_ENV"
+          echo "${{ env.WF_STANDALONE_IMAGE_NAME }}@$digest_standalone" >> ./release-assets/images
+
+      - name: cosign-installer
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003
+
+      - name: Sign and verify the image with GitHub OIDC Token
+        run: |
+          cosign sign --yes ${{ env.WF_IMAGE_NAME }}@${{ env.digest }}
+
+          cosign verify ${{ env.WF_IMAGE_NAME }}@${{ env.digest }} \
+            --certificate-identity=https://github.com/netobserv/netobserv-web-console/.github/workflows/release.yml@refs/tags/${{ env.tag }} \
+            --certificate-oidc-issuer=https://token.actions.githubusercontent.com
+
+          cosign sign --yes ${{ env.WF_STANDALONE_IMAGE_NAME }}@${{ env.digest_standalone }}
+
+          cosign verify ${{ env.WF_STANDALONE_IMAGE_NAME }}@${{ env.digest_standalone }} \
+            --certificate-identity=https://github.com/netobserv/netobserv-web-console/.github/workflows/release.yml@refs/tags/${{ env.tag }} \
+            --certificate-oidc-issuer=https://token.actions.githubusercontent.com
+
+      - name: Attest Provenance attestations
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
+        with:
+          subject-name: ${{ env.WF_IMAGE_NAME }}
+          subject-digest: ${{ env.digest }}
+          push-to-registry: true
+
+      - name: Attest Provenance attestations (standalone)
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
+        with:
+          subject-name: ${{ env.WF_STANDALONE_IMAGE_NAME }}
+          subject-digest: ${{ env.digest_standalone }}
+          push-to-registry: true
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: ${{ env.WF_IMAGE_NAME }}@${{ env.digest }}
+          format: 'spdx-json'
+          output-file: './release-assets/sbom.spdx.json'
+
+      - name: Generate SBOM (standalone)
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: ${{ env.WF_STANDALONE_IMAGE_NAME }}@${{ env.digest_standalone }}
+          format: 'spdx-json'
+          output-file: './release-assets/sbom-standalone.spdx.json'
+
+      - name: Attest SBOM
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
+        with:
+          subject-name: ${{ env.WF_IMAGE_NAME }}
+          subject-digest: ${{ env.digest }}
+          sbom-path: './release-assets/sbom.spdx.json'
+          push-to-registry: true
+
+      - name: Attest SBOM (standalone)
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
+        with:
+          subject-name: ${{ env.WF_STANDALONE_IMAGE_NAME }}
+          subject-digest: ${{ env.digest_standalone }}
+          sbom-path: './release-assets/sbom-standalone.spdx.json'
+          push-to-registry: true
+
+      - name: create draft release and upload binaries
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           tag_name: ${{ env.tag }}
           name: ${{ env.tag }}
           draft: true
           prerelease: false
+          files: ./release-assets/*

--- a/pkg/httpclient/http_client.go
+++ b/pkg/httpclient/http_client.go
@@ -43,7 +43,7 @@ func NewTransport(timeout time.Duration, skipTLS bool, capath string, userCertPa
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 		slog.Warn("skipping TLS checks. SSL certificate verification is now disabled !")
 	} else if capath != "" || userCertPath != "" {
-		transport.TLSClientConfig = &tls.Config{}
+		transport.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS13}
 
 		if capath != "" {
 			caCert, err := os.ReadFile(capath)


### PR DESCRIPTION
## Description

Same as https://github.com/netobserv/netobserv-operator/pull/2815 and https://github.com/netobserv/flowlogs-pipeline/pull/1227

- sha pinning of the remaining github-owned actions
- dependabot setting for docker & actions
- force tls client minversion

Added new jobs in release.yml workflow,

-    cosign-installer
-    Sign and verify the image with GitHub OIDC Token
-    Attest Provenance attestations
-    Generate SBOM
-    Attest SBOM


## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [x] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
