### PR TITLE
NETOBSERV-2817: Frontend test fixes

### DIFF
--- a/web/cypress/views/netflow-page.ts
+++ b/web/cypress/views/netflow-page.ts
@@ -73,10 +73,18 @@ export const netflowPage = {
         })
     },
     resetClearFilters: () => {
-        cy.byTestID("reset-filters-button").should('exist').click({ force: true })
+        cy.get('body').then($body => {
+            if ($body.find('[data-test="reset-filters-button"]').length > 0) {
+                cy.byTestID("reset-filters-button").click({ force: true })
+            }
+        })
     },
     clearAllFilters: () => {
-        cy.byTestID("clear-all-filters-button").should('exist').click()
+        cy.get('body').then($body => {
+            if ($body.find('[data-test="clear-all-filters-button"]').length > 0) {
+                cy.byTestID("clear-all-filters-button").click()
+            }
+        })
     },
     waitForLokiQuery: () => {
         cy.get("#refresh-button > span > svg").invoke('attr', 'style').should('contain', '0s linear 0s')


### PR DESCRIPTION
## Description

Fixes for frontend tests failing in run [noo-frontend-tests#133](https://jenkins-csb-openshift-qe-mastern.dno.corp.redhat.com/job/netobserv/job/noo-frontend-tests/133/)

## Dependencies
n/a

## Test Results
`
  ✔  netflow_external_subnet.cy.ts            02:07        1        1        -        -        -
`
`
  ✔  netflow_zone_multiCluster.cy.ts          01:52        2        2        -        -        -
`
`
  ✔  packet_drop.cy.ts                        01:45        2        2        -        -        -
`
`
  ✔  topology_edges_labels.cy.ts              02:43        5        5        -        -        -
`
`
  ✔  topology_view.cy.ts                      01:14        3        3        -        -        -
`

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [x] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
