### PR TITLE
NETOBSERV-2774 fix topology export styling

### DIFF
--- a/web/src/components/toolbar/view-options-toolbar.tsx
+++ b/web/src/components/toolbar/view-options-toolbar.tsx
@@ -19,7 +19,7 @@ import { useTranslation } from 'react-i18next';
 import { FlowScope, MetricType, StatFunction } from '../../model/flow-query';
 import { useNetflowContext } from '../../model/netflow-context';
 import { TopologyOptions } from '../../model/topology';
-import { exportToPng } from '../../utils/export';
+import { areChartsSizedForExport, exportToPng, waitForExportLayout } from '../../utils/export';
 import { useTheme } from '../../utils/theme-hook';
 import OverviewDisplayDropdown, { Size } from '../dropdowns/overview-display-dropdown';
 import TableDisplayDropdown from '../dropdowns/table-display-dropdown';
@@ -62,21 +62,30 @@ export const ViewOptionsToolbar = React.forwardRef<SearchHandle, ViewOptionsTool
   const { caps } = useNetflowContext();
 
   const onTopologyExport = React.useCallback(() => {
-    const topology_flex = document.getElementsByClassName('pf-topology-visualization-surface__svg')[0];
-    exportToPng('topology', topology_flex as HTMLElement, isDarkTheme);
+    const topology_svg = document.querySelector<SVGSVGElement>('.pf-topology-visualization-surface__svg');
+    exportToPng('topology', topology_svg ?? undefined, isDarkTheme);
   }, [isDarkTheme]);
 
   const onOverviewExport = React.useCallback(() => {
     const prevFocusState = props.overviewFocus;
-    props.setOverviewFocus(false);
-    setTimeout(() => {
-      const overview_flex = document.getElementById('overview-flex');
-      exportToPng('overview_page', overview_flex as HTMLElement, isDarkTheme, undefined, () =>
+    const overviewRoot = document.getElementById('overview-flex');
+    const layoutRoot = document.getElementById('overview-graph-list') ?? overviewRoot;
+
+    const runExport = async () => {
+      if (prevFocusState) {
+        props.setOverviewFocus(false);
+        await waitForExportLayout(layoutRoot, { requireResize: true });
+      } else if (!areChartsSizedForExport(layoutRoot ?? document.body)) {
+        await waitForExportLayout(layoutRoot);
+      }
+      exportToPng('overview_page', overviewRoot ?? undefined, isDarkTheme, undefined, () =>
         props.setOverviewFocus(prevFocusState)
       );
-    }, 500);
+    };
+
+    void runExport();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isDarkTheme, props.setOverviewFocus]);
+  }, [isDarkTheme, props.overviewFocus, props.setOverviewFocus]);
 
   const viewOptionsContent = () => {
     const items: JSX.Element[] = [];

--- a/web/src/components/toolbar/view-options-toolbar.tsx
+++ b/web/src/components/toolbar/view-options-toolbar.tsx
@@ -72,15 +72,17 @@ export const ViewOptionsToolbar = React.forwardRef<SearchHandle, ViewOptionsTool
     const layoutRoot = document.getElementById('overview-graph-list') ?? overviewRoot;
 
     const runExport = async () => {
-      if (prevFocusState) {
-        props.setOverviewFocus(false);
-        await waitForExportLayout(layoutRoot, { requireResize: true });
-      } else if (!areChartsSizedForExport(layoutRoot ?? document.body)) {
-        await waitForExportLayout(layoutRoot);
+      try {
+        if (prevFocusState) {
+          props.setOverviewFocus(false);
+          await waitForExportLayout(layoutRoot, { requireResize: true });
+        } else if (!areChartsSizedForExport(layoutRoot ?? document.body)) {
+          await waitForExportLayout(layoutRoot);
+        }
+        await exportToPng('overview_page', overviewRoot ?? undefined, isDarkTheme);
+      } finally {
+        props.setOverviewFocus(prevFocusState);
       }
-      exportToPng('overview_page', overviewRoot ?? undefined, isDarkTheme, undefined, () =>
-        props.setOverviewFocus(prevFocusState)
-      );
     };
 
     void runExport();

--- a/web/src/utils/__tests__/export.spec.ts
+++ b/web/src/utils/__tests__/export.spec.ts
@@ -158,6 +158,12 @@ describe('saveAndInlineSvgStyles', () => {
 
     restoreSvgStyles(saved);
   });
+});
+
+describe('chart layout readiness', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
 
   it('detects when chart svg dimensions match their containers', () => {
     document.body.innerHTML = `

--- a/web/src/utils/__tests__/export.spec.ts
+++ b/web/src/utils/__tests__/export.spec.ts
@@ -1,0 +1,214 @@
+import { areChartsSizedForExport, restoreSvgStyles, saveAndInlineSvgStyles, waitForExportLayout } from '../export';
+
+describe('saveAndInlineSvgStyles', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('inlines computed fill and stroke on SVG elements and restores them', () => {
+    document.body.innerHTML = `
+      <style>
+        .label-bg { fill: rgb(255, 255, 255); stroke: rgb(106, 110, 115); }
+        .label-text { fill: rgb(21, 21, 21); font-size: 14px; }
+      </style>
+      <svg id="topology" width="200" height="100">
+        <rect class="label-bg" width="80" height="20" />
+        <text class="label-text" x="4" y="14">node-a</text>
+      </svg>
+    `;
+
+    const svg = document.getElementById('topology')!;
+    const rect = svg.querySelector('rect')!;
+    const text = svg.querySelector('text')!;
+
+    expect(rect.getAttribute('fill')).toBeNull();
+    expect(text.getAttribute('fill')).toBeNull();
+
+    const saved = saveAndInlineSvgStyles(svg);
+
+    expect(rect.getAttribute('fill')).toBe('rgb(255, 255, 255)');
+    expect(rect.getAttribute('stroke')).toBe('rgb(106, 110, 115)');
+    expect(text.getAttribute('fill')).toBe('rgb(21, 21, 21)');
+    expect(text.style.fontSize).toBe('14px');
+
+    restoreSvgStyles(saved);
+
+    expect(rect.getAttribute('fill')).toBeNull();
+    expect(rect.style.fill).toBe('');
+    expect(text.getAttribute('fill')).toBeNull();
+    expect(text.style.fontSize).toBe('');
+  });
+
+  it('walks nested svg icons inside the topology surface', () => {
+    document.body.innerHTML = `
+      <style>
+        .icon { color: rgb(57, 63, 68); }
+        .icon path { fill: currentColor; }
+      </style>
+      <svg id="topology" width="100" height="100">
+        <g class="icon">
+          <svg width="24" height="24">
+            <path d="M0 0" />
+          </svg>
+        </g>
+      </svg>
+    `;
+
+    const svg = document.getElementById('topology')!;
+    const iconPath = svg.querySelector('path')!;
+    const saved = saveAndInlineSvgStyles(svg);
+
+    expect(iconPath.getAttribute('fill')).toBe('rgb(57, 63, 68)');
+
+    restoreSvgStyles(saved);
+    expect(iconPath.getAttribute('fill')).toBeNull();
+  });
+
+  it('does not inline invisible edge background hit areas', () => {
+    document.body.innerHTML = `
+      <style>
+        .pf-topology__edge__background {
+          stroke: transparent;
+          fill: none;
+          stroke-width: 10px;
+        }
+      </style>
+      <svg id="topology" width="100" height="100">
+        <path class="pf-topology__edge__background" d="M0 0 L50 50" />
+      </svg>
+    `;
+
+    const svg = document.getElementById('topology')!;
+    const background = svg.querySelector('path')!;
+    const saved = saveAndInlineSvgStyles(svg);
+
+    expect(saved.some(entry => entry.element === background)).toBe(false);
+    expect(background.style.strokeWidth).toBe('');
+    expect(background.getAttribute('stroke')).toBeNull();
+
+    restoreSvgStyles(saved);
+  });
+
+  it('inlines dotted edge dash styles', () => {
+    document.body.innerHTML = `
+      <style>
+        .pf-topology__edge__link.pf-m-dotted {
+          stroke: rgb(106, 110, 115);
+          stroke-width: 1px;
+          stroke-dasharray: 2;
+          stroke-dashoffset: 2;
+          fill-opacity: 0;
+        }
+      </style>
+      <svg id="topology" width="100" height="100">
+        <path class="pf-topology__edge__link pf-m-dotted" d="M0 0 L50 50" />
+      </svg>
+    `;
+
+    const svg = document.getElementById('topology')!;
+    const link = svg.querySelector('path')!;
+    const saved = saveAndInlineSvgStyles(svg);
+
+    expect(link.getAttribute('stroke')).toBe('rgb(106, 110, 115)');
+    expect(link.style.strokeDasharray).toBe('2');
+    expect(link.getAttribute('stroke-dasharray')).toBe('2');
+    expect(link.style.strokeDashoffset).toBe('2');
+    expect(link.getAttribute('stroke-dashoffset')).toBe('2');
+    expect(link.getAttribute('fill')).toBe('none');
+
+    restoreSvgStyles(saved);
+    expect(link.getAttribute('stroke-dasharray')).toBeNull();
+  });
+
+  it('clears inherited fill on light-theme edge links and applies dotted dash pattern', () => {
+    document.body.innerHTML = `
+      <style>
+        .pf-topology__edge {
+          fill: rgb(106, 110, 115);
+          stroke: rgb(106, 110, 115);
+        }
+        .pf-topology__edge__link {
+          fill-opacity: 0;
+          stroke: rgb(106, 110, 115);
+          stroke-width: 1px;
+          stroke-dasharray: 0;
+        }
+        .pf-topology__edge__link.pf-m-dotted {
+          stroke-dasharray: 2;
+          stroke-dashoffset: 2;
+        }
+      </style>
+      <svg id="topology" width="100" height="100">
+        <g class="pf-topology__edge">
+          <path class="pf-topology__edge__link pf-m-dotted" d="M0 0 L50 50" />
+        </g>
+      </svg>
+    `;
+
+    const svg = document.getElementById('topology')!;
+    const edgeGroup = svg.querySelector('.pf-topology__edge') as SVGGElement;
+    const link = svg.querySelector('.pf-topology__edge__link') as SVGPathElement;
+    const saved = saveAndInlineSvgStyles(svg);
+
+    expect(edgeGroup.style.fill).toBe('');
+    expect(link.getAttribute('fill')).toBe('none');
+    expect(link.style.fill).toBe('none');
+    expect(link.getAttribute('stroke-dasharray')).toBe('2');
+    expect(link.getAttribute('stroke-dashoffset')).toBe('2');
+
+    restoreSvgStyles(saved);
+  });
+
+  it('detects when chart svg dimensions match their containers', () => {
+    document.body.innerHTML = `
+      <div id="overview-graph-list">
+        <div class="metrics-content-div" style="width: 400px; height: 300px">
+          <svg width="400" height="300"></svg>
+        </div>
+      </div>
+    `;
+
+    const root = document.getElementById('overview-graph-list')!;
+    expect(areChartsSizedForExport(root)).toBe(true);
+  });
+
+  it('waits until chart svg dimensions match their containers', async () => {
+    document.body.innerHTML = `
+      <div id="overview-graph-list">
+        <div class="metrics-content-div" style="width: 400px; height: 300px">
+          <svg width="120" height="80"></svg>
+        </div>
+      </div>
+    `;
+
+    const root = document.getElementById('overview-graph-list')!;
+    const chart = root.querySelector('.metrics-content-div') as HTMLElement;
+    const svg = chart.querySelector('svg') as SVGSVGElement;
+
+    expect(areChartsSizedForExport(root)).toBe(false);
+
+    const layoutReady = waitForExportLayout(root, { quietMs: 50, timeoutMs: 1000 });
+    setTimeout(() => {
+      svg.setAttribute('width', '400');
+      svg.setAttribute('height', '300');
+    }, 100);
+
+    await layoutReady;
+    expect(areChartsSizedForExport(root)).toBe(true);
+  });
+
+  it('resolves quickly when charts are already sized', async () => {
+    document.body.innerHTML = `
+      <div id="overview-graph-list">
+        <div class="metrics-content-div" style="width: 400px; height: 300px">
+          <svg width="400" height="300"></svg>
+        </div>
+      </div>
+    `;
+
+    const root = document.getElementById('overview-graph-list')!;
+    const startedAt = performance.now();
+    await waitForExportLayout(root);
+    expect(performance.now() - startedAt).toBeLessThan(100);
+  });
+});

--- a/web/src/utils/export.ts
+++ b/web/src/utils/export.ts
@@ -1,14 +1,434 @@
 import { toPng } from '@jpinsonneau/html-to-image'; // slightly modified from 'html-to-image' to fix a browser freeze. See NETOBSERV-2314.
 
+const EXPORT_BACKGROUND = {
+  dark: '#0f1214',
+  light: '#f0f0f0'
+} as const;
+
+const SVG_GRAPHICAL_TAGS = new Set([
+  'circle',
+  'ellipse',
+  'line',
+  'path',
+  'polygon',
+  'polyline',
+  'rect',
+  'stop',
+  'text',
+  'tspan',
+  'use'
+]);
+
+const INLINE_STYLE_PROPS = [
+  'fill',
+  'stroke',
+  'stroke-width',
+  'stroke-opacity',
+  'stroke-dasharray',
+  'stroke-dashoffset',
+  'fill-opacity',
+  'opacity',
+  'color',
+  'font-family',
+  'font-size',
+  'font-weight',
+  'stop-color'
+] as const;
+
+const PRESENTATION_ATTRS = new Set(['fill', 'stroke', 'stop-color', 'stroke-dasharray', 'stroke-dashoffset']);
+
+// Hit-area paths: inlining stroke-width without a visible stroke renders as a solid highlight band.
+const SKIP_INLINE_CLASSES = ['pf-topology__edge__background'];
+
+const EDGE_GROUP_CLASS = 'pf-topology__edge';
+const EDGE_LINK_CLASS = 'pf-topology__edge__link';
+
+// PatternFly edge modifiers; used when animation resets computed dash styles to 0.
+const EDGE_DASH_STYLES: Record<string, { strokeDasharray: string; strokeDashoffset: string }> = {
+  'pf-m-dotted': { strokeDasharray: '2', strokeDashoffset: '2' },
+  'pf-m-dashed': { strokeDasharray: '4 2', strokeDashoffset: '6' },
+  'pf-m-dashed-md': { strokeDasharray: '8 2', strokeDashoffset: '10' },
+  'pf-m-dashed-lg': { strokeDasharray: '16 2', strokeDashoffset: '18' },
+  'pf-m-dashed-xl': { strokeDasharray: '32 2', strokeDashoffset: '34' }
+};
+
+type SavedSvgStyle = {
+  element: SVGElement;
+  attrs: Map<string, string | null>;
+  styles: Map<string, string>;
+};
+
+type ExportableElement = HTMLElement | SVGSVGElement;
+
+const isVisibleValue = (value: string): boolean =>
+  !!value && value !== 'none' && value !== 'transparent' && value !== 'rgba(0, 0, 0, 0)';
+
+const shouldSkipElement = (element: SVGElement): boolean =>
+  SKIP_INLINE_CLASSES.some(className => element.classList.contains(className));
+
+const shouldSkipPropertyOnElement = (element: Element, prop: string): boolean => {
+  // Group-level fill/stroke is inherited by children and breaks edge link dashes in export.
+  if (element.classList.contains(EDGE_GROUP_CLASS) && (prop === 'fill' || prop === 'stroke' || prop === 'color')) {
+    return true;
+  }
+  return false;
+};
+
+const getEdgeDashStyles = (element: Element): { strokeDasharray: string; strokeDashoffset: string } | null => {
+  for (const [className, styles] of Object.entries(EDGE_DASH_STYLES)) {
+    if (element.classList.contains(className)) {
+      return styles;
+    }
+  }
+  return null;
+};
+
+const isZeroDashValue = (value: string): boolean => value === 'none' || value === '0' || value === '0px';
+
+const hasVisibleStroke = (element: Element, computed: CSSStyleDeclaration): boolean =>
+  isVisibleValue(resolveStyleValue(element, computed, 'stroke'));
+
+const shouldInlineProperty = (
+  element: Element,
+  computed: CSSStyleDeclaration,
+  prop: string,
+  value: string
+): boolean => {
+  if (!value || value === 'initial' || value === 'inherit') {
+    return false;
+  }
+
+  if (shouldSkipPropertyOnElement(element, prop)) {
+    return false;
+  }
+
+  const isPresentationAttr = PRESENTATION_ATTRS.has(prop);
+
+  if (prop === 'fill' && computed.getPropertyValue('fill-opacity') === '0') {
+    return false;
+  }
+
+  if ((prop === 'stroke-width' || prop === 'stroke-opacity') && !hasVisibleStroke(element, computed)) {
+    return false;
+  }
+
+  if (prop === 'stroke-dasharray' || prop === 'stroke-dashoffset') {
+    return !isZeroDashValue(value);
+  }
+
+  return (
+    prop === 'opacity' ||
+    prop === 'color' ||
+    prop === 'fill-opacity' ||
+    prop.startsWith('font-') ||
+    (isPresentationAttr && isVisibleValue(value)) ||
+    (!isPresentationAttr && value !== 'none')
+  );
+};
+
+const resolveStyleValue = (element: Element, computed: CSSStyleDeclaration, prop: string): string => {
+  let value = computed.getPropertyValue(prop);
+  if (prop === 'fill' && value.toLowerCase() === 'currentcolor') {
+    value = computed.getPropertyValue('color');
+    if (value.toLowerCase() === 'currentcolor' && element.parentElement) {
+      value = window.getComputedStyle(element.parentElement).getPropertyValue('color');
+    }
+  }
+  return value;
+};
+
+const applyEdgeLinkExportStyles = (element: SVGElement, entry: SavedSvgStyle): void => {
+  if (!element.classList.contains(EDGE_LINK_CLASS)) {
+    return;
+  }
+
+  if (!entry.attrs.has('fill')) {
+    entry.attrs.set('fill', element.getAttribute('fill'));
+  }
+  element.setAttribute('fill', 'none');
+  if (!entry.styles.has('fill')) {
+    entry.styles.set('fill', element.style.getPropertyValue('fill'));
+  }
+  element.style.setProperty('fill', 'none');
+
+  if (!entry.styles.has('fill-opacity')) {
+    entry.styles.set('fill-opacity', element.style.getPropertyValue('fill-opacity'));
+  }
+  element.style.setProperty('fill-opacity', '0');
+
+  const dashStyles = getEdgeDashStyles(element);
+  if (!dashStyles) {
+    return;
+  }
+
+  if (!entry.attrs.has('stroke-dasharray')) {
+    entry.attrs.set('stroke-dasharray', element.getAttribute('stroke-dasharray'));
+  }
+  element.setAttribute('stroke-dasharray', dashStyles.strokeDasharray);
+  if (!entry.styles.has('stroke-dasharray')) {
+    entry.styles.set('stroke-dasharray', element.style.getPropertyValue('stroke-dasharray'));
+  }
+  element.style.setProperty('stroke-dasharray', dashStyles.strokeDasharray);
+
+  if (!entry.attrs.has('stroke-dashoffset')) {
+    entry.attrs.set('stroke-dashoffset', element.getAttribute('stroke-dashoffset'));
+  }
+  element.setAttribute('stroke-dashoffset', dashStyles.strokeDashoffset);
+  if (!entry.styles.has('stroke-dashoffset')) {
+    entry.styles.set('stroke-dashoffset', element.style.getPropertyValue('stroke-dashoffset'));
+  }
+  element.style.setProperty('stroke-dashoffset', dashStyles.strokeDashoffset);
+};
+
+const collectSvgElements = (root: Element): Element[] => {
+  const elements = root instanceof SVGSVGElement || root.tagName.toLowerCase() === 'svg' ? [root] : [];
+  return elements.concat(Array.from(root.querySelectorAll('svg, svg *')));
+};
+
+/**
+ * html-to-image does not inline computed styles on SVG descendants, so CSS variables
+ * (PatternFly theme tokens) are lost in exports. Inline resolved values temporarily.
+ */
+export const saveAndInlineSvgStyles = (root: Element): SavedSvgStyle[] => {
+  const saved: SavedSvgStyle[] = [];
+
+  for (const element of collectSvgElements(root)) {
+    if (!(element instanceof SVGElement) || shouldSkipElement(element)) {
+      continue;
+    }
+
+    const computed = window.getComputedStyle(element);
+    const entry: SavedSvgStyle = { element, attrs: new Map(), styles: new Map() };
+    let modified = false;
+    const tag = element.tagName.toLowerCase();
+
+    for (const prop of INLINE_STYLE_PROPS) {
+      const value = resolveStyleValue(element, computed, prop);
+      if (!shouldInlineProperty(element, computed, prop, value)) {
+        continue;
+      }
+
+      const isPresentationAttr = PRESENTATION_ATTRS.has(prop);
+
+      entry.styles.set(prop, element.style.getPropertyValue(prop));
+      element.style.setProperty(prop, value);
+      modified = true;
+
+      if (isPresentationAttr && (SVG_GRAPHICAL_TAGS.has(tag) || tag === 'svg')) {
+        entry.attrs.set(prop, element.getAttribute(prop));
+        element.setAttribute(prop, value);
+      }
+    }
+
+    if (element.classList.contains(EDGE_LINK_CLASS)) {
+      applyEdgeLinkExportStyles(element, entry);
+    }
+
+    if (modified || entry.attrs.size > 0 || entry.styles.size > 0) {
+      saved.push(entry);
+    }
+  }
+
+  return saved;
+};
+
+export const restoreSvgStyles = (saved: SavedSvgStyle[]): void => {
+  for (const { element, attrs, styles } of saved) {
+    for (const [prop, value] of styles) {
+      if (value) {
+        element.style.setProperty(prop, value);
+      } else {
+        element.style.removeProperty(prop);
+      }
+    }
+    for (const [attr, value] of attrs) {
+      if (value === null) {
+        element.removeAttribute(attr);
+      } else {
+        element.setAttribute(attr, value);
+      }
+    }
+  }
+};
+
+const getExportDimensions = (element: ExportableElement): { width?: number; height?: number } => {
+  const rect = element.getBoundingClientRect();
+  if (rect.width > 0 && rect.height > 0) {
+    return { width: rect.width, height: rect.height };
+  }
+  return {};
+};
+
+const CHART_CONTAINER_SELECTOR = '.metrics-content-div';
+const LAYOUT_SIZE_TOLERANCE_PX = 20;
+const DEFAULT_LAYOUT_QUIET_MS = 50;
+const DEFAULT_LAYOUT_TIMEOUT_MS = 3000;
+
+const getElementSize = (element: HTMLElement): { width: number; height: number } => {
+  let width = element.clientWidth;
+  let height = element.clientHeight;
+
+  if (width <= 0 || height <= 0) {
+    const rect = element.getBoundingClientRect();
+    width = rect.width;
+    height = rect.height;
+  }
+
+  if (width <= 0 || height <= 0) {
+    const style = window.getComputedStyle(element);
+    width = parseFloat(style.width) || 0;
+    height = parseFloat(style.height) || 0;
+  }
+
+  return { width, height };
+};
+
+const getSvgRenderedSize = (svg: SVGSVGElement): { width: number; height: number } => {
+  const rect = svg.getBoundingClientRect();
+  if (rect.width > 0 && rect.height > 0) {
+    return { width: rect.width, height: rect.height };
+  }
+
+  const attrWidth = Number(svg.getAttribute('width'));
+  const attrHeight = Number(svg.getAttribute('height'));
+  if (attrWidth > 0 && attrHeight > 0) {
+    return { width: attrWidth, height: attrHeight };
+  }
+
+  return { width: 0, height: 0 };
+};
+
+export const areChartsSizedForExport = (root: Element): boolean => {
+  const charts = root.querySelectorAll(CHART_CONTAINER_SELECTOR);
+  if (charts.length === 0) {
+    return true;
+  }
+
+  return Array.from(charts).every(chart => {
+    const container = chart as HTMLElement;
+    const containerSize = getElementSize(container);
+    if (containerSize.width <= 0 || containerSize.height <= 0) {
+      return false;
+    }
+
+    const svg = container.querySelector('svg');
+    if (!svg) {
+      return false;
+    }
+
+    const svgSize = getSvgRenderedSize(svg);
+    return (
+      Math.abs(svgSize.width - containerSize.width) <= LAYOUT_SIZE_TOLERANCE_PX &&
+      Math.abs(svgSize.height - containerSize.height) <= LAYOUT_SIZE_TOLERANCE_PX
+    );
+  });
+};
+
+export const waitForNextPaint = (): Promise<void> =>
+  new Promise(resolve => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => resolve());
+    });
+  });
+
+/**
+ * Wait for overview charts to finish resizing before capture.
+ * Victory charts update one frame after their container ResizeObserver fires.
+ */
+export const waitForExportLayout = (
+  root: Element | null | undefined,
+  options?: { quietMs?: number; timeoutMs?: number; requireResize?: boolean }
+): Promise<void> => {
+  if (!root) {
+    return Promise.resolve();
+  }
+
+  if (!options?.requireResize && areChartsSizedForExport(root)) {
+    return waitForNextPaint();
+  }
+
+  const quietMs = options?.quietMs ?? DEFAULT_LAYOUT_QUIET_MS;
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_LAYOUT_TIMEOUT_MS;
+
+  return new Promise(resolve => {
+    let finished = false;
+    let readySince: number | null = null;
+    let pollRaf = 0;
+
+    const targets = Array.from(
+      new Set([
+        root,
+        ...Array.from(root.querySelectorAll(`${CHART_CONTAINER_SELECTOR}, #overview-flex, #overview-graph-list`))
+      ])
+    );
+
+    const finish = async () => {
+      if (finished) {
+        return;
+      }
+      finished = true;
+      observers.forEach(observer => observer.disconnect());
+      clearTimeout(timeoutTimer);
+      cancelAnimationFrame(pollRaf);
+      await waitForNextPaint();
+      resolve();
+    };
+
+    const onLayoutChange = () => {
+      readySince = null;
+    };
+
+    const poll = () => {
+      if (finished) {
+        return;
+      }
+
+      if (areChartsSizedForExport(root)) {
+        if (readySince === null) {
+          readySince = performance.now();
+        }
+        if (performance.now() - readySince >= quietMs) {
+          void finish();
+          return;
+        }
+      } else {
+        readySince = null;
+      }
+
+      pollRaf = requestAnimationFrame(poll);
+    };
+
+    const observers = targets.map(target => {
+      const observer = new ResizeObserver(onLayoutChange);
+      observer.observe(target);
+      return observer;
+    });
+
+    const timeoutTimer = setTimeout(() => {
+      void finish();
+    }, timeoutMs);
+
+    pollRaf = requestAnimationFrame(poll);
+  });
+};
+
 export const exportToPng = (
   name: string,
-  element: HTMLElement | undefined,
+  element: ExportableElement | undefined,
   isDark?: boolean,
   id?: string,
   callback?: () => void
 ) => {
   if (element) {
-    toPng(element, { cacheBust: true, backgroundColor: isDark ? '#0f1214' : '#f0f0f0' })
+    const savedStyles = saveAndInlineSvgStyles(element);
+    const dimensions = getExportDimensions(element);
+
+    // html-to-image typings only list HTMLElement, but SVGSVGElement is supported at runtime.
+    toPng(element as unknown as HTMLElement, {
+      cacheBust: true,
+      backgroundColor: isDark ? EXPORT_BACKGROUND.dark : EXPORT_BACKGROUND.light,
+      ...dimensions
+    })
       .then(dataUrl => {
         const link = document.createElement('a');
         if (id) {
@@ -24,6 +444,9 @@ export const exportToPng = (
       })
       .catch(err => {
         console.error(err);
+      })
+      .finally(() => {
+        restoreSvgStyles(savedStyles);
       });
   } else {
     console.error('exportToPng called but element is undefined');

--- a/web/src/utils/export.ts
+++ b/web/src/utils/export.ts
@@ -418,13 +418,13 @@ export const exportToPng = (
   isDark?: boolean,
   id?: string,
   callback?: () => void
-) => {
+): Promise<void> => {
   if (element) {
     const savedStyles = saveAndInlineSvgStyles(element);
     const dimensions = getExportDimensions(element);
 
     // html-to-image typings only list HTMLElement, but SVGSVGElement is supported at runtime.
-    toPng(element as unknown as HTMLElement, {
+    return toPng(element as unknown as HTMLElement, {
       cacheBust: true,
       backgroundColor: isDark ? EXPORT_BACKGROUND.dark : EXPORT_BACKGROUND.light,
       ...dimensions
@@ -438,17 +438,17 @@ export const exportToPng = (
         }
         link.href = dataUrl;
         link.click();
-        if (callback) {
-          callback();
-        }
       })
       .catch(err => {
         console.error(err);
       })
       .finally(() => {
         restoreSvgStyles(savedStyles);
+        callback?.();
       });
-  } else {
-    console.error('exportToPng called but element is undefined');
   }
+
+  console.error('exportToPng called but element is undefined');
+  callback?.();
+  return Promise.resolve();
 };


### PR DESCRIPTION
## Description

- fix topology export styling
- also took the opportunity to improve overview export when focused on a single graph

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved topology and overview diagram exports to PNG.
  * Exports now wait for chart layouts to stabilize, producing more accurate dimensions and rendering.
  * SVG styling, including icons, patterns, and dashed links, is preserved more reliably in exported images.

* **Bug Fixes**
  * Restored diagram styling after exports, including when an export fails.
  * Preserved overview focus state after completing an export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->