### PR TITLE
Hide OpenShift-only links in standalone mode

### DIFF
--- a/web/locales/en/plugin__netobserv-plugin.json
+++ b/web/locales/en/plugin__netobserv-plugin.json
@@ -377,6 +377,7 @@
   "Description": "Description",
   "No results found": "No results found",
   "Clear or reset filters and try again.": "Clear or reset filters and try again.",
+  "Status endpoint is returning: {{statusError}}": "Status endpoint is returning: {{statusError}}",
   "Check for errors in health dashboard. Status endpoint is returning: {{statusError}}": "Check for errors in health dashboard. Status endpoint is returning: {{statusError}}",
   "Suggestions to avoid this error:": "Suggestions to avoid this error:",
   "Reduce the Query Options -> limit to reduce the number of results": "Reduce the Query Options -> limit to reduce the number of results",

--- a/web/src/components/messages/__tests__/secondary-action.spec.tsx
+++ b/web/src/components/messages/__tests__/secondary-action.spec.tsx
@@ -29,7 +29,7 @@ describe('<SecondaryAction />', () => {
     jest.spyOn(ContextSingleton, 'isStandalone').mockReturnValue(false);
     ContextSingleton.setFlowCollectorK8SModel(flowCollectorModel);
 
-    render(<SecondaryAction />);
+    const { rerender } = render(<SecondaryAction />);
 
     const flowCollectorLink = screen.getByRole('link', { name: 'Show FlowCollector CR' });
     expect(flowCollectorLink).toHaveAttribute(
@@ -37,10 +37,19 @@ describe('<SecondaryAction />', () => {
       '/k8s/cluster/flows.netobserv.io~v1beta2~FlowCollector/cluster'
     );
     expect(flowCollectorLink).toHaveAttribute('target', '_blank');
+    expect(flowCollectorLink).toHaveAttribute('data-test', 'flowcollector-link');
 
     const healthDashboardLink = screen.getByRole('link', { name: 'Show health dashboard' });
     expect(healthDashboardLink).toHaveAttribute('href', '/monitoring/dashboards/grafana-dashboard-netobserv-health');
     expect(healthDashboardLink).toHaveAttribute('target', '_blank');
+    expect(healthDashboardLink).toHaveAttribute('data-test', 'health-dashboard-link');
+
+    healthDashboardLink.focus();
+    rerender(<SecondaryAction />);
+
+    expect(screen.getByRole('link', { name: 'Show FlowCollector CR' })).toBe(flowCollectorLink);
+    expect(screen.getByRole('link', { name: 'Show health dashboard' })).toBe(healthDashboardLink);
+    expect(healthDashboardLink).toHaveFocus();
   });
 
   it('hides OpenShift console links in standalone mode and preserves other actions', () => {

--- a/web/src/components/messages/__tests__/secondary-action.spec.tsx
+++ b/web/src/components/messages/__tests__/secondary-action.spec.tsx
@@ -32,10 +32,7 @@ describe('<SecondaryAction />', () => {
     const { rerender } = render(<SecondaryAction />);
 
     const flowCollectorLink = screen.getByRole('link', { name: 'Show FlowCollector CR' });
-    expect(flowCollectorLink).toHaveAttribute(
-      'href',
-      '/k8s/cluster/flows.netobserv.io~v1beta2~FlowCollector/cluster'
-    );
+    expect(flowCollectorLink).toHaveAttribute('href', '/k8s/cluster/flows.netobserv.io~v1beta2~FlowCollector/cluster');
     expect(flowCollectorLink).toHaveAttribute('target', '_blank');
     expect(flowCollectorLink).toHaveAttribute('data-test', 'flowcollector-link');
 

--- a/web/src/components/messages/__tests__/secondary-action.spec.tsx
+++ b/web/src/components/messages/__tests__/secondary-action.spec.tsx
@@ -1,0 +1,59 @@
+import { K8sModel } from '@openshift-console/dynamic-plugin-sdk';
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { ContextSingleton } from '../../../utils/context';
+import { SecondaryAction } from '../secondary-action';
+
+jest.mock('../../../utils/url', () => ({
+  Link: ({
+    to,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    to: { pathname: string };
+  }) => <a {...props} href={to.pathname} />
+}));
+
+const flowCollectorModel = {
+  apiGroup: 'flows.netobserv.io',
+  apiVersion: 'v1beta2',
+  kind: 'FlowCollector'
+} as K8sModel;
+
+describe('<SecondaryAction />', () => {
+  afterEach(() => {
+    ContextSingleton.setFlowCollectorK8SModel(undefined);
+    jest.restoreAllMocks();
+  });
+
+  it('shows OpenShift console links in plugin mode', () => {
+    jest.spyOn(ContextSingleton, 'isStandalone').mockReturnValue(false);
+    ContextSingleton.setFlowCollectorK8SModel(flowCollectorModel);
+
+    render(<SecondaryAction />);
+
+    const flowCollectorLink = screen.getByRole('link', { name: 'Show FlowCollector CR' });
+    expect(flowCollectorLink).toHaveAttribute(
+      'href',
+      '/k8s/cluster/flows.netobserv.io~v1beta2~FlowCollector/cluster'
+    );
+    expect(flowCollectorLink).toHaveAttribute('target', '_blank');
+
+    const healthDashboardLink = screen.getByRole('link', { name: 'Show health dashboard' });
+    expect(healthDashboardLink).toHaveAttribute('href', '/monitoring/dashboards/grafana-dashboard-netobserv-health');
+    expect(healthDashboardLink).toHaveAttribute('target', '_blank');
+  });
+
+  it('hides OpenShift console links in standalone mode and preserves other actions', () => {
+    jest.spyOn(ContextSingleton, 'isStandalone').mockReturnValue(true);
+    ContextSingleton.setFlowCollectorK8SModel(flowCollectorModel);
+    const clearFilters = jest.fn();
+
+    render(<SecondaryAction clearFilters={clearFilters} />);
+
+    expect(screen.queryByRole('link', { name: 'Show FlowCollector CR' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Show health dashboard' })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear all filters' }));
+    expect(clearFilters).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/components/messages/empty.tsx
+++ b/web/src/components/messages/empty.tsx
@@ -82,9 +82,11 @@ export const Empty: React.FC<EmptyProps> = ({ showDetails, resetDefaultFilters, 
           )}
           {statusError !== undefined && (
             <Content className="netobserv-error-message" component={ContentVariants.p}>
-              {t('Check for errors in health dashboard. Status endpoint is returning: {{statusError}}', {
-                statusError
-              })}
+              {ContextSingleton.isStandalone()
+                ? t('Status endpoint is returning: {{statusError}}', { statusError })
+                : t('Check for errors in health dashboard. Status endpoint is returning: {{statusError}}', {
+                    statusError
+                  })}
             </Content>
           )}
           <Content className="empty-text-content">

--- a/web/src/components/messages/error.tsx
+++ b/web/src/components/messages/error.tsx
@@ -145,9 +145,11 @@ export const ErrorComponent: React.FC<ErrorProps> = ({ title, error }) => {
             {status && <StatusTexts status={status} />}
             {statusError && (
               <Content component={ContentVariants.blockquote}>
-                {t('Check for errors in health dashboard. Status endpoint is returning: {{statusError}}', {
-                  statusError
-                })}
+                {ContextSingleton.isStandalone()
+                  ? t('Status endpoint is returning: {{statusError}}', { statusError })
+                  : t('Check for errors in health dashboard. Status endpoint is returning: {{statusError}}', {
+                      statusError
+                    })}
               </Content>
             )}
           </Content>

--- a/web/src/components/messages/secondary-action.tsx
+++ b/web/src/components/messages/secondary-action.tsx
@@ -5,6 +5,29 @@ import { Config } from '../../model/config';
 import { ContextSingleton } from '../../utils/context';
 import { Link } from '../../utils/url';
 
+type ButtonLinkProps = Omit<React.ComponentProps<typeof Link>, 'to'>;
+
+const FlowCollectorLink: React.FC<ButtonLinkProps> = props => {
+  const flowCollectorK8SModel = ContextSingleton.getFlowCollectorK8SModel()!;
+  return (
+    <Link
+      {...props}
+      target="_blank"
+      to={{
+        pathname: `/k8s/cluster/${flowCollectorK8SModel.apiGroup}~${flowCollectorK8SModel.apiVersion}~${flowCollectorK8SModel.kind}/cluster`
+      }}
+    />
+  );
+};
+
+const HealthDashboardLink: React.FC<ButtonLinkProps> = props => (
+  <Link
+    {...props}
+    target="_blank"
+    to={{ pathname: '/monitoring/dashboards/grafana-dashboard-netobserv-health' }}
+  />
+);
+
 export interface EmptyProps {
   resetDefaultFilters?: (c?: Config) => void;
   clearFilters?: () => void;
@@ -28,32 +51,12 @@ export const SecondaryAction: React.FC<EmptyProps> = ({
     <>
       <EmptyStateActions>
         {!isStandalone && flowCollectorK8SModel && (
-          <Button
-            variant="link"
-            component={(props: React.FunctionComponent) => (
-              <Link
-                {...props}
-                target="_blank"
-                to={{
-                  pathname: `/k8s/cluster/${flowCollectorK8SModel.apiGroup}~${flowCollectorK8SModel.apiVersion}~${flowCollectorK8SModel.kind}/cluster`
-                }}
-              />
-            )}
-          >
+          <Button variant="link" component={FlowCollectorLink} data-test="flowcollector-link">
             {t('Show FlowCollector CR')}
           </Button>
         )}
         {!isStandalone && (
-          <Button
-            variant="link"
-            component={(props: React.FunctionComponent) => (
-              <Link
-                {...props}
-                target="_blank"
-                to={{ pathname: '/monitoring/dashboards/grafana-dashboard-netobserv-health' }}
-              />
-            )}
-          >
+          <Button variant="link" component={HealthDashboardLink} data-test="health-dashboard-link">
             {t('Show health dashboard')}
           </Button>
         )}

--- a/web/src/components/messages/secondary-action.tsx
+++ b/web/src/components/messages/secondary-action.tsx
@@ -21,11 +21,7 @@ const FlowCollectorLink: React.FC<ButtonLinkProps> = props => {
 };
 
 const HealthDashboardLink: React.FC<ButtonLinkProps> = props => (
-  <Link
-    {...props}
-    target="_blank"
-    to={{ pathname: '/monitoring/dashboards/grafana-dashboard-netobserv-health' }}
-  />
+  <Link {...props} target="_blank" to={{ pathname: '/monitoring/dashboards/grafana-dashboard-netobserv-health' }} />
 );
 
 export interface EmptyProps {

--- a/web/src/components/messages/secondary-action.tsx
+++ b/web/src/components/messages/secondary-action.tsx
@@ -22,11 +22,12 @@ export const SecondaryAction: React.FC<EmptyProps> = ({
 }) => {
   const { t } = useTranslation('plugin__netobserv-plugin');
   const flowCollectorK8SModel = ContextSingleton.getFlowCollectorK8SModel();
+  const isStandalone = ContextSingleton.isStandalone();
 
   return (
     <>
       <EmptyStateActions>
-        {flowCollectorK8SModel && (
+        {!isStandalone && flowCollectorK8SModel && (
           <Button
             variant="link"
             component={(props: React.FunctionComponent) => (
@@ -42,18 +43,20 @@ export const SecondaryAction: React.FC<EmptyProps> = ({
             {t('Show FlowCollector CR')}
           </Button>
         )}
-        <Button
-          variant="link"
-          component={(props: React.FunctionComponent) => (
-            <Link
-              {...props}
-              target="_blank"
-              to={{ pathname: '/monitoring/dashboards/grafana-dashboard-netobserv-health' }}
-            />
-          )}
-        >
-          {t('Show health dashboard')}
-        </Button>
+        {!isStandalone && (
+          <Button
+            variant="link"
+            component={(props: React.FunctionComponent) => (
+              <Link
+                {...props}
+                target="_blank"
+                to={{ pathname: '/monitoring/dashboards/grafana-dashboard-netobserv-health' }}
+              />
+            )}
+          >
+            {t('Show health dashboard')}
+          </Button>
+        )}
         {clearFilters && (
           <Button id="clear-all-filters" onClick={() => clearFilters()} variant="link">
             {t('Clear all filters')}


### PR DESCRIPTION
## Description

Hide the FlowCollector CR and OpenShift monitoring dashboard actions when the web console runs in standalone mode. Those routes only exist inside the OpenShift console and currently lead standalone users to not-found pages.

Plugin mode keeps both actions unchanged. Other empty-state actions, including clearing filters, remain available in standalone mode.

Closes #1593

Assisted-by: OpenAI Codex (GPT-5)

## Dependencies

n/a

## Checklist

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ] if so please describe it in PR description.
* [x] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).

## Testing

- `npm test -- --runInBand` (66 suites, 384 tests)
- `npm run build`
- `npm run build:standalone`
- `npx eslint './src/**/*.{ts,tsx}'`
- `npx tsc --noEmit`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standalone mode now displays concise status endpoint error messages.
  * Console links are hidden when running in standalone mode.
  * Health dashboard and FlowCollector links remain available in plugin mode.

* **Bug Fixes**
  * Improved error messaging based on the application’s operating mode.
  * Preserved link focus after message updates.

* **Tests**
  * Added coverage for standalone and plugin-mode actions, links, focus behavior, and filter clearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->