### PR TITLE
NETOBSERV-428 aggregate topology edges between groups

### DIFF
--- a/web/cypress/e2e/topology/topology.spec.ts
+++ b/web/cypress/e2e/topology/topology.spec.ts
@@ -90,9 +90,12 @@ describe('netflow-topology', () => {
     cy.get('#group-collapsed-switch').should('be.disabled');
 
     cy.get('#edges-tag-switch').should('not.be.disabled');
+    cy.get('#group-edges-switch').should('not.be.disabled');
+    cy.get('#group-edges-switch').click();
     cy.get('#edges-tag-switch').click();
     cy.get('#edges-switch').click();
     cy.get('#edges-tag-switch').should('be.disabled');
+    cy.get('#group-edges-switch').should('be.disabled');
 
     cy.get('#badge-switch').click();
 

--- a/web/cypress/e2e/topology/topology.spec.ts
+++ b/web/cypress/e2e/topology/topology.spec.ts
@@ -84,14 +84,16 @@ describe('netflow-topology', () => {
     cy.dropdownSelect('group-dropdown', 'owners');
     cy.wait(c.waitTime);
 
-    //toggle switches
+    //toggle switches — exercise group-edges while a group type is still selected
+    cy.get('#group-edges-switch').should('not.be.disabled');
+    cy.get('#group-edges-switch').click();
+
     cy.get('#group-collapsed-switch').click();
     cy.dropdownSelect('group-dropdown', 'none');
     cy.get('#group-collapsed-switch').should('be.disabled');
+    cy.get('#group-edges-switch').should('be.disabled');
 
     cy.get('#edges-tag-switch').should('not.be.disabled');
-    cy.get('#group-edges-switch').should('not.be.disabled');
-    cy.get('#group-edges-switch').click();
     cy.get('#edges-tag-switch').click();
     cy.get('#edges-switch').click();
     cy.get('#edges-tag-switch').should('be.disabled');

--- a/web/locales/en/plugin__netobserv-plugin.json
+++ b/web/locales/en/plugin__netobserv-plugin.json
@@ -164,6 +164,8 @@
   "Show": "Show",
   "Edges": "Edges",
   "Edges label": "Edges label",
+  "Merge parallel connections between groups into shared bridges with exit and entry stubs. Reduces edge clutter when nodes are grouped.": "Merge parallel connections between groups into shared bridges with exit and entry stubs. Reduces edge clutter when nodes are grouped.",
+  "Group edges": "Group edges",
   "Marks volume edges as cleartext when aggregated logs show no TLS signals, using an open-lock icon. Can add many icons; use for focused troubleshooting.": "Marks volume edges as cleartext when aggregated logs show no TLS signals, using an open-lock icon. Can add many icons; use for focused troubleshooting.",
   "Cleartext traffic": "Cleartext traffic",
   "Badges": "Badges",

--- a/web/src/components/dropdowns/topology-display-options.tsx
+++ b/web/src/components/dropdowns/topology-display-options.tsx
@@ -180,6 +180,29 @@ export const TopologyDisplayOptions: React.FC<TopologyDisplayOptionsProps> = ({
               })
             }
           />
+          <Tooltip
+            content={t(
+              'Merge parallel connections between groups into shared bridges with exit and entry stubs. Reduces edge clutter when nodes are grouped.'
+            )}
+          >
+            <Checkbox
+              id="group-edges-switch"
+              data-test="group-edges-switch"
+              label={t('Group edges')}
+              isDisabled={!topologyOptions.edges || topologyOptions.groupTypes === 'none'}
+              isChecked={
+                Boolean(topologyOptions.edges) &&
+                topologyOptions.groupTypes !== 'none' &&
+                topologyOptions.groupEdges !== false
+              }
+              onChange={() =>
+                setTopologyOptions({
+                  ...topologyOptions,
+                  groupEdges: topologyOptions.groupEdges === false
+                })
+              }
+            />
+          </Tooltip>
           {isTLSTracking && (
             <Tooltip
               content={t(

--- a/web/src/components/tabs/netflow-topology/2d/aggregate-edge-snap-context.tsx
+++ b/web/src/components/tabs/netflow-topology/2d/aggregate-edge-snap-context.tsx
@@ -1,0 +1,4 @@
+import * as React from 'react';
+
+/** Bumped after layout end / collapse so aggregate edges force-resnap. */
+export const AggregateEdgeSnapContext = React.createContext(0);

--- a/web/src/components/tabs/netflow-topology/2d/componentFactories/componentFactory.ts
+++ b/web/src/components/tabs/netflow-topology/2d/componentFactories/componentFactory.ts
@@ -7,7 +7,7 @@ import {
   ModelKind
 } from '@patternfly/react-topology';
 import { ComponentType } from 'react';
-import { GraphElementPeer } from '../../../../../model/topology';
+import { AGGREGATE_EDGE_TYPE, GraphElementPeer } from '../../../../../model/topology';
 
 export const componentFactory: ComponentFactory = (
   kind: ModelKind,
@@ -16,7 +16,7 @@ export const componentFactory: ComponentFactory = (
   switch (type) {
     case 'group':
       return DefaultGroup;
-    case 'aggregate-edge':
+    case AGGREGATE_EDGE_TYPE:
       return DefaultEdge;
     default:
       switch (kind) {

--- a/web/src/components/tabs/netflow-topology/2d/componentFactories/componentFactory.ts
+++ b/web/src/components/tabs/netflow-topology/2d/componentFactories/componentFactory.ts
@@ -16,6 +16,8 @@ export const componentFactory: ComponentFactory = (
   switch (type) {
     case 'group':
       return DefaultGroup;
+    case 'aggregate-edge':
+      return DefaultEdge;
     default:
       switch (kind) {
         case ModelKind.graph:

--- a/web/src/components/tabs/netflow-topology/2d/componentFactories/stylesComponentFactory.tsx
+++ b/web/src/components/tabs/netflow-topology/2d/componentFactories/stylesComponentFactory.tsx
@@ -15,6 +15,7 @@ import * as React from 'react';
 import { GraphElementPeer } from '../../../../../model/topology';
 
 //keep default import here to use observers
+import StyleAggregateEdge from '../styles/styleAggregateEdge';
 import StyleEdge from '../styles/styleEdge';
 import StyleGroup from '../styles/styleGroup';
 import StyleNode from '../styles/styleNode';
@@ -33,6 +34,8 @@ export const stylesComponentFactory: ComponentFactory = (
       return withDndDrop(groupDropTargetSpec)(withDragNode(nodeDragSourceSpec('group'))(withSelection()(StyleGroup)));
     case 'edge':
       return withSelection()(StyleEdge);
+    case 'aggregate-edge':
+      return withSelection()(StyleAggregateEdge);
     default:
       return undefined;
   }

--- a/web/src/components/tabs/netflow-topology/2d/componentFactories/stylesComponentFactory.tsx
+++ b/web/src/components/tabs/netflow-topology/2d/componentFactories/stylesComponentFactory.tsx
@@ -12,7 +12,7 @@ import {
   withSelection
 } from '@patternfly/react-topology';
 import * as React from 'react';
-import { GraphElementPeer } from '../../../../../model/topology';
+import { AGGREGATE_EDGE_TYPE, GraphElementPeer } from '../../../../../model/topology';
 
 //keep default import here to use observers
 import StyleAggregateEdge from '../styles/styleAggregateEdge';
@@ -34,7 +34,7 @@ export const stylesComponentFactory: ComponentFactory = (
       return withDndDrop(groupDropTargetSpec)(withDragNode(nodeDragSourceSpec('group'))(withSelection()(StyleGroup)));
     case 'edge':
       return withSelection()(StyleEdge);
-    case 'aggregate-edge':
+    case AGGREGATE_EDGE_TYPE:
       return withSelection()(StyleAggregateEdge);
     default:
       return undefined;

--- a/web/src/components/tabs/netflow-topology/2d/components/edge.tsx
+++ b/web/src/components/tabs/netflow-topology/2d/components/edge.tsx
@@ -84,6 +84,8 @@ interface DefaultEdgeProps {
   onContextMenu?: (e: React.MouseEvent) => void;
   /** Flag indicating that the context menu for the edge is currently open  */
   contextMenuOpen?: boolean;
+  /** Test id for Cypress / RTL targeting */
+  'data-test'?: string;
   /** custom netobserv props */
   shadowed?: boolean;
   filtered?: boolean;
@@ -130,7 +132,8 @@ const DefaultEdgeInner: React.FunctionComponent<DefaultEdgeInnerProps> = observe
     filtered,
     drops,
     highlighted,
-    isDark
+    isDark,
+    'data-test': dataTest
   }) => {
     const [hover, hoverRef] = useHover();
     const startPoint = element.getStartPoint();
@@ -204,6 +207,7 @@ const DefaultEdgeInner: React.FunctionComponent<DefaultEdgeInnerProps> = observe
         <g
           ref={hoverRef as React.LegacyRef<SVGGElement> | undefined}
           data-test-id="edge-handler"
+          data-test={dataTest}
           className={groupClassName}
           onClick={onSelect}
           onContextMenu={onContextMenu}

--- a/web/src/components/tabs/netflow-topology/2d/components/topology-connector-tag.tsx
+++ b/web/src/components/tabs/netflow-topology/2d/components/topology-connector-tag.tsx
@@ -8,12 +8,29 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import type { TlsLockSeverity } from '../../../../../utils/tls-lock-severity';
 
-const LOCK_PATH = LockIconConfig.svgPath;
-const LOCK_ICON_W = LockIconConfig.width;
-const LOCK_ICON_H = LockIconConfig.height;
+/** PF icons ≤6.4 use flat svgPath/width/height; ≥6.6 nest under `.icon` with svgPathData. */
+type IconConfigShape = {
+  svgPath?: string;
+  width?: number;
+  height?: number;
+  icon?: { svgPathData: string; width: number; height: number };
+};
+
+const iconMetrics = (cfg: IconConfigShape) => {
+  if (cfg.icon) {
+    return { path: cfg.icon.svgPathData, width: cfg.icon.width, height: cfg.icon.height };
+  }
+  return { path: cfg.svgPath!, width: cfg.width!, height: cfg.height! };
+};
+
+const LOCK = iconMetrics(LockIconConfig as IconConfigShape);
+const OPEN_LOCK = iconMetrics(LockOpenIconConfig as IconConfigShape);
+const LOCK_PATH = LOCK.path;
+const LOCK_ICON_W = LOCK.width;
+const LOCK_ICON_H = LOCK.height;
 const LOCK_SCALE = 0.022;
 /** Match open-lock width to closed lock (PatternFly `LockOpenIcon` viewBox). */
-const OPEN_LOCK_SCALE = (LOCK_ICON_W * LOCK_SCALE) / LockOpenIconConfig.width;
+const OPEN_LOCK_SCALE = (LOCK_ICON_W * LOCK_SCALE) / OPEN_LOCK.width;
 const LOCK_GAP = 5;
 
 export type TopologyConnectorTagProps = {
@@ -74,8 +91,8 @@ const TopologyConnectorTag: React.FunctionComponent<TopologyConnectorTagProps> =
 
   const scaledLockW = LOCK_ICON_W * LOCK_SCALE;
   const scaledLockH = LOCK_ICON_H * LOCK_SCALE;
-  const scaledOpenW = LockOpenIconConfig.width * OPEN_LOCK_SCALE;
-  const scaledOpenH = LockOpenIconConfig.height * OPEN_LOCK_SCALE;
+  const scaledOpenW = OPEN_LOCK.width * OPEN_LOCK_SCALE;
+  const scaledOpenH = OPEN_LOCK.height * OPEN_LOCK_SCALE;
   const lockSlotW = showClosedLock ? scaledLockW : showOpenLock ? scaledOpenW : 0;
   const lockSlotH = showClosedLock ? scaledLockH : showOpenLock ? scaledOpenH : 0;
   const lockSlot = showAnyLock ? lockSlotW + LOCK_GAP : 0;
@@ -93,7 +110,7 @@ const TopologyConnectorTag: React.FunctionComponent<TopologyConnectorTagProps> =
         lockTranslateX: -width / 2 + paddingX,
         lockTranslateY: -lockSlotH / 2,
         lockScale: showClosedLock ? LOCK_SCALE : OPEN_LOCK_SCALE,
-        lockPath: showClosedLock ? LOCK_PATH : LockOpenIconConfig.svgPath
+        lockPath: showClosedLock ? LOCK_PATH : OPEN_LOCK.path
       };
     }
     if (!textSize) {
@@ -114,7 +131,7 @@ const TopologyConnectorTag: React.FunctionComponent<TopologyConnectorTagProps> =
       lockTranslateX: startX + paddingX,
       lockTranslateY: -lockSlotH / 2,
       lockScale: showClosedLock ? LOCK_SCALE : OPEN_LOCK_SCALE,
-      lockPath: showClosedLock ? LOCK_PATH : LockOpenIconConfig.svgPath
+      lockPath: showClosedLock ? LOCK_PATH : OPEN_LOCK.path
     };
   }, [tag, showAnyLock, showClosedLock, textSize, paddingX, paddingY, lockSlot, lockSlotH, lockSlotW]);
 

--- a/web/src/components/tabs/netflow-topology/2d/components/topology-connector-tag.tsx
+++ b/web/src/components/tabs/netflow-topology/2d/components/topology-connector-tag.tsx
@@ -8,29 +8,12 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import type { TlsLockSeverity } from '../../../../../utils/tls-lock-severity';
 
-/** PF icons ≤6.4 use flat svgPath/width/height; ≥6.6 nest under `.icon` with svgPathData. */
-type IconConfigShape = {
-  svgPath?: string;
-  width?: number;
-  height?: number;
-  icon?: { svgPathData: string; width: number; height: number };
-};
-
-const iconMetrics = (cfg: IconConfigShape) => {
-  if (cfg.icon) {
-    return { path: cfg.icon.svgPathData, width: cfg.icon.width, height: cfg.icon.height };
-  }
-  return { path: cfg.svgPath!, width: cfg.width!, height: cfg.height! };
-};
-
-const LOCK = iconMetrics(LockIconConfig as IconConfigShape);
-const OPEN_LOCK = iconMetrics(LockOpenIconConfig as IconConfigShape);
-const LOCK_PATH = LOCK.path;
-const LOCK_ICON_W = LOCK.width;
-const LOCK_ICON_H = LOCK.height;
+const LOCK_PATH = LockIconConfig.svgPath;
+const LOCK_ICON_W = LockIconConfig.width;
+const LOCK_ICON_H = LockIconConfig.height;
 const LOCK_SCALE = 0.022;
 /** Match open-lock width to closed lock (PatternFly `LockOpenIcon` viewBox). */
-const OPEN_LOCK_SCALE = (LOCK_ICON_W * LOCK_SCALE) / OPEN_LOCK.width;
+const OPEN_LOCK_SCALE = (LOCK_ICON_W * LOCK_SCALE) / LockOpenIconConfig.width;
 const LOCK_GAP = 5;
 
 export type TopologyConnectorTagProps = {
@@ -91,8 +74,8 @@ const TopologyConnectorTag: React.FunctionComponent<TopologyConnectorTagProps> =
 
   const scaledLockW = LOCK_ICON_W * LOCK_SCALE;
   const scaledLockH = LOCK_ICON_H * LOCK_SCALE;
-  const scaledOpenW = OPEN_LOCK.width * OPEN_LOCK_SCALE;
-  const scaledOpenH = OPEN_LOCK.height * OPEN_LOCK_SCALE;
+  const scaledOpenW = LockOpenIconConfig.width * OPEN_LOCK_SCALE;
+  const scaledOpenH = LockOpenIconConfig.height * OPEN_LOCK_SCALE;
   const lockSlotW = showClosedLock ? scaledLockW : showOpenLock ? scaledOpenW : 0;
   const lockSlotH = showClosedLock ? scaledLockH : showOpenLock ? scaledOpenH : 0;
   const lockSlot = showAnyLock ? lockSlotW + LOCK_GAP : 0;
@@ -110,7 +93,7 @@ const TopologyConnectorTag: React.FunctionComponent<TopologyConnectorTagProps> =
         lockTranslateX: -width / 2 + paddingX,
         lockTranslateY: -lockSlotH / 2,
         lockScale: showClosedLock ? LOCK_SCALE : OPEN_LOCK_SCALE,
-        lockPath: showClosedLock ? LOCK_PATH : OPEN_LOCK.path
+        lockPath: showClosedLock ? LOCK_PATH : LockOpenIconConfig.svgPath
       };
     }
     if (!textSize) {
@@ -131,7 +114,7 @@ const TopologyConnectorTag: React.FunctionComponent<TopologyConnectorTagProps> =
       lockTranslateX: startX + paddingX,
       lockTranslateY: -lockSlotH / 2,
       lockScale: showClosedLock ? LOCK_SCALE : OPEN_LOCK_SCALE,
-      lockPath: showClosedLock ? LOCK_PATH : OPEN_LOCK.path
+      lockPath: showClosedLock ? LOCK_PATH : LockOpenIconConfig.svgPath
     };
   }, [tag, showAnyLock, showClosedLock, textSize, paddingX, paddingY, lockSlot, lockSlotH, lockSlotW]);
 

--- a/web/src/components/tabs/netflow-topology/2d/layouts/__tests__/layout-edges.spec.ts
+++ b/web/src/components/tabs/netflow-topology/2d/layouts/__tests__/layout-edges.spec.ts
@@ -61,4 +61,32 @@ describe('collectLayoutLinks', () => {
     expect(initBendpoints).toHaveBeenCalledTimes(1);
     expect(initBendpoints).toHaveBeenCalledWith(edges[4]);
   });
+
+  it('skips distinct layout nodes that share the same id', () => {
+    const initBendpoints = jest.fn();
+    const createLink = jest.fn();
+    const dupA = { id: 'same' } as LayoutNode;
+    const dupB = { id: 'same' } as LayoutNode;
+    const getLayoutNode = jest.fn((_nodes: LayoutNode[], node: Node | null) => {
+      if (node === sourceNode) {
+        return dupA;
+      }
+      if (node === targetNode) {
+        return dupB;
+      }
+      return undefined;
+    });
+
+    const links = collectLayoutLinks(
+      [edgeWith({ role: 'bridge', source: sourceNode, target: targetNode })],
+      [dupA, dupB],
+      getLayoutNode,
+      createLink,
+      initBendpoints
+    );
+
+    expect(links).toHaveLength(0);
+    expect(createLink).not.toHaveBeenCalled();
+    expect(initBendpoints).not.toHaveBeenCalled();
+  });
 });

--- a/web/src/components/tabs/netflow-topology/2d/layouts/__tests__/layout-edges.spec.ts
+++ b/web/src/components/tabs/netflow-topology/2d/layouts/__tests__/layout-edges.spec.ts
@@ -1,0 +1,64 @@
+import { Edge, LayoutLink, LayoutNode, Node } from '@patternfly/react-topology';
+import { collectLayoutLinks, isLayoutRelevantEdge } from '../layout-edges';
+
+const edgeWith = (partial: { visible?: boolean; role?: string; source?: Node; target?: Node }): Edge =>
+  ({
+    isVisible: () => partial.visible !== false,
+    getData: () => (partial.role ? { role: partial.role } : {}),
+    getSource: () => partial.source ?? null,
+    getTarget: () => partial.target ?? null
+  } as unknown as Edge);
+
+describe('isLayoutRelevantEdge', () => {
+  it('rejects hidden edges', () => {
+    expect(isLayoutRelevantEdge(edgeWith({ visible: false, role: 'bridge' }))).toBe(false);
+  });
+
+  it('rejects exit and entry stubs', () => {
+    expect(isLayoutRelevantEdge(edgeWith({ role: 'exit' }))).toBe(false);
+    expect(isLayoutRelevantEdge(edgeWith({ role: 'entry' }))).toBe(false);
+  });
+
+  it('keeps bridges and plain edges', () => {
+    expect(isLayoutRelevantEdge(edgeWith({ role: 'bridge' }))).toBe(true);
+    expect(isLayoutRelevantEdge(edgeWith({}))).toBe(true);
+  });
+});
+
+describe('collectLayoutLinks', () => {
+  const sourceNode = { getId: () => 's' } as unknown as Node;
+  const targetNode = { getId: () => 't' } as unknown as Node;
+  const sourceLayout = { id: 's' } as LayoutNode;
+  const targetLayout = { id: 't' } as LayoutNode;
+
+  it('skips exit/entry, unresolved ends, and self-loops while initializing bendpoints', () => {
+    const initBendpoints = jest.fn();
+    const createLink = jest.fn(
+      (_edge: Edge, source: LayoutNode, target: LayoutNode) => ({ source, target } as LayoutLink)
+    );
+    const getLayoutNode = jest.fn((_nodes: LayoutNode[], node: Node | null) => {
+      if (node === sourceNode) {
+        return sourceLayout;
+      }
+      if (node === targetNode) {
+        return targetLayout;
+      }
+      return undefined;
+    });
+
+    const edges = [
+      edgeWith({ role: 'exit', source: sourceNode, target: targetNode }),
+      edgeWith({ role: 'entry', source: sourceNode, target: targetNode }),
+      edgeWith({ role: 'bridge', source: sourceNode, target: null as unknown as Node }),
+      edgeWith({ role: 'bridge', source: sourceNode, target: sourceNode }),
+      edgeWith({ role: 'bridge', source: sourceNode, target: targetNode })
+    ];
+
+    const links = collectLayoutLinks(edges, [sourceLayout, targetLayout], getLayoutNode, createLink, initBendpoints);
+
+    expect(links).toHaveLength(1);
+    expect(createLink).toHaveBeenCalledTimes(1);
+    expect(initBendpoints).toHaveBeenCalledTimes(1);
+    expect(initBendpoints).toHaveBeenCalledWith(edges[4]);
+  });
+});

--- a/web/src/components/tabs/netflow-topology/2d/layouts/baseLayout.ts
+++ b/web/src/components/tabs/netflow-topology/2d/layouts/baseLayout.ts
@@ -31,6 +31,7 @@ import {
 } from '@patternfly/react-topology';
 import { ForceSimulation } from '@patternfly/react-topology/dist/esm/layouts/ForceSimulation';
 import { action, makeObservable } from 'mobx';
+import { collectLayoutLinks } from './layout-edges';
 
 export const layoutDefaults: LayoutOptions = {
   linkDistance: 60,
@@ -325,17 +326,13 @@ export class BaseLayout implements Layout {
   protected getGroupNodes = (): Node[] => groupNodeElements(this.graph.getNodes()).filter(g => g.isVisible());
 
   protected getLinks(edges: Edge[]): LayoutLink[] {
-    const links: LayoutLink[] = [];
-    edges.forEach(e => {
-      const source = this.getLayoutNode(this.nodes, e.getSource());
-      const target = this.getLayoutNode(this.nodes, e.getTarget());
-      if (source && target) {
-        this.initializeEdgeBendpoints(e);
-        links.push(this.createLayoutLink(e, source, target));
-      }
-    });
-
-    return links;
+    return collectLayoutLinks(
+      edges,
+      this.nodes,
+      (nodes, node) => this.getLayoutNode(nodes, node),
+      (edge, source, target) => this.createLayoutLink(edge, source, target),
+      this.initializeEdgeBendpoints
+    );
   }
 
   protected hasVisibleChildren = (group: Node): boolean => !!group.getNodes().find(c => isNode(c) && c.isVisible());

--- a/web/src/components/tabs/netflow-topology/2d/layouts/breadthFirstLayout.ts
+++ b/web/src/components/tabs/netflow-topology/2d/layouts/breadthFirstLayout.ts
@@ -1,0 +1,29 @@
+import {
+  Edge,
+  Layout,
+  LayoutLink,
+  LayoutOptions,
+  BreadthFirstLayout as PfBreadthFirstLayout
+} from '@patternfly/react-topology';
+import { collectLayoutLinks } from './layout-edges';
+
+/**
+ * BreadthFirst with aggregate-edge-aware link filtering.
+ * PF's layout resolves group endpoints to the first leaf child; exit stubs then
+ * become self-loops, roots become empty, and every node stays at the center.
+ */
+export class BreadthFirstLayout extends PfBreadthFirstLayout implements Layout {
+  constructor(graph: ConstructorParameters<typeof PfBreadthFirstLayout>[0], options?: Partial<LayoutOptions>) {
+    super(graph, options);
+  }
+
+  protected getLinks(edges: Edge[]): LayoutLink[] {
+    return collectLayoutLinks(
+      edges,
+      this.nodes,
+      (nodes, node) => this.getLayoutNode(nodes, node),
+      (edge, source, target) => this.createLayoutLink(edge, source, target, false),
+      this.initializeEdgeBendpoints
+    );
+  }
+}

--- a/web/src/components/tabs/netflow-topology/2d/layouts/colaGroupsLayout.ts
+++ b/web/src/components/tabs/netflow-topology/2d/layouts/colaGroupsLayout.ts
@@ -1,0 +1,28 @@
+import {
+  Edge,
+  Layout,
+  LayoutLink,
+  LayoutOptions,
+  ColaGroupsLayout as PfColaGroupsLayout
+} from '@patternfly/react-topology';
+import { collectLayoutLinks } from './layout-edges';
+
+/**
+ * ColaGroups with aggregate-edge-aware link filtering (skip exit/entry stubs and
+ * self-loops). Reduces first-layout work when groupEdges is on.
+ */
+export class ColaGroupsLayout extends PfColaGroupsLayout implements Layout {
+  constructor(graph: ConstructorParameters<typeof PfColaGroupsLayout>[0], options?: Partial<LayoutOptions>) {
+    super(graph, options);
+  }
+
+  protected getLinks(edges: Edge[]): LayoutLink[] {
+    return collectLayoutLinks(
+      edges,
+      this.nodes,
+      (nodes, node) => this.getLayoutNode(nodes, node),
+      (edge, source, target) => this.createLayoutLink(edge, source, target),
+      this.initializeEdgeBendpoints
+    );
+  }
+}

--- a/web/src/components/tabs/netflow-topology/2d/layouts/layout-edges.ts
+++ b/web/src/components/tabs/netflow-topology/2d/layouts/layout-edges.ts
@@ -1,0 +1,45 @@
+import { Edge, LayoutLink, LayoutNode, Node } from '@patternfly/react-topology';
+
+/**
+ * Aggregate exit/entry stubs are leaf↔group visuals. Layout engines resolve a
+ * group endpoint to its first leaf child, which often creates a self-loop
+ * (leaf→same leaf). That empties BreadthFirst roots (everything stays centered)
+ * and adds useless/expensive constraints to Cola.
+ *
+ * Bridges (group↔group) stay in the layout graph so groups still attract.
+ */
+export const isLayoutRelevantEdge = (edge: Edge): boolean => {
+  if (!edge.isVisible()) {
+    return false;
+  }
+  const role = edge.getData()?.role as string | undefined;
+  return role !== 'exit' && role !== 'entry';
+};
+
+type GetLayoutNode = (nodes: LayoutNode[], node: Node | null) => LayoutNode | undefined;
+type CreateLayoutLink = (edge: Edge, source: LayoutNode, target: LayoutNode, isFalse?: boolean) => LayoutLink;
+type InitBendpoints = (edge: Edge) => void;
+
+export const collectLayoutLinks = (
+  edges: Edge[],
+  nodes: LayoutNode[],
+  getLayoutNode: GetLayoutNode,
+  createLayoutLink: CreateLayoutLink,
+  initializeEdgeBendpoints: InitBendpoints
+): LayoutLink[] => {
+  const links: LayoutLink[] = [];
+  edges.forEach(e => {
+    if (!isLayoutRelevantEdge(e)) {
+      return;
+    }
+    const source = getLayoutNode(nodes, e.getSource());
+    const target = getLayoutNode(nodes, e.getTarget());
+    // Skip unresolved ends and self-loops (group endpoint resolved to the same leaf).
+    if (!source || !target || source === target || source.id === target.id) {
+      return;
+    }
+    initializeEdgeBendpoints(e);
+    links.push(createLayoutLink(e, source, target));
+  });
+  return links;
+};

--- a/web/src/components/tabs/netflow-topology/2d/layouts/layoutFactory.ts
+++ b/web/src/components/tabs/netflow-topology/2d/layouts/layoutFactory.ts
@@ -1,6 +1,4 @@
 import {
-  BreadthFirstLayout,
-  ColaGroupsLayout,
   ConcentricLayout,
   DagreGroupsLayout,
   DagreLayout,
@@ -11,6 +9,8 @@ import {
   LayoutFactory
 } from '@patternfly/react-topology';
 import { LayoutName } from '../../../../../model/topology';
+import { BreadthFirstLayout } from './breadthFirstLayout';
+import { ColaGroupsLayout } from './colaGroupsLayout';
 import { ColaLayout } from './colaLayout';
 
 const layoutFactory: LayoutFactory = (type: LayoutName, graph: Graph): Layout | undefined => {

--- a/web/src/components/tabs/netflow-topology/2d/styles/styleAggregateEdge.tsx
+++ b/web/src/components/tabs/netflow-topology/2d/styles/styleAggregateEdge.tsx
@@ -1,0 +1,400 @@
+import { css } from '@patternfly/react-styles';
+import {
+  AnchorEnd,
+  Edge,
+  EdgeTerminalType,
+  isNode,
+  Node,
+  NodeStyle,
+  observer,
+  Point,
+  SELECTION_EVENT as selectionEvent,
+  SELECTION_STATE as selectionState,
+  WithSelectionProps
+} from '@patternfly/react-topology';
+import { action } from 'mobx';
+import * as React from 'react';
+import DefaultEdge from '../components/edge';
+import StyleEdge from './styleEdge';
+
+type StyleAggregateEdgeProps = {
+  element: Edge;
+} & WithSelectionProps;
+
+type XY = { x: number; y: number };
+
+/** Coarse threshold while nodes are still moving (approx snaps). */
+const MOVE_SNAP_THRESHOLD = 3;
+/** Fine threshold for settled hull snaps. */
+const HULL_SNAP_THRESHOLD = 2;
+/** After geometry stops changing, refine approx → real hull outline. */
+const HULL_SETTLE_MS = 100;
+
+const findRelatedBridge = (stub: Edge): Edge | undefined => {
+  const bridgeId = stub.getData()?.bridgeId as string | undefined;
+  if (bridgeId) {
+    return stub.getController().getEdgeById(bridgeId);
+  }
+  const bridgeKey = stub.getData()?.bridgeKey as string | undefined;
+  if (!bridgeKey) {
+    return undefined;
+  }
+  return stub
+    .getGraph()
+    .getEdges()
+    .find(e => e.getData()?.role === 'bridge' && e.getData()?.bridgeKey === bridgeKey);
+};
+
+const readGroupPadding = (group: Node): number => {
+  const padding = group.getStyle<NodeStyle>()?.padding;
+  if (typeof padding === 'number') {
+    return padding;
+  }
+  if (padding && typeof padding === 'object') {
+    const box = padding as { top?: number; right?: number; bottom?: number; left?: number };
+    return Math.max(box.top ?? 0, box.right ?? 0, box.bottom ?? 0, box.left ?? 0);
+  }
+  return 17;
+};
+
+/** Last-resort O(1) ellipse on content bounds (used only when no SVG outline exists). */
+const ellipseOnBounds = (group: Node, toward: Node): XY => {
+  const b = group.getBounds();
+  const cx = b.x + b.width / 2;
+  const cy = b.y + b.height / 2;
+  const reference = toward.getBounds().getCenter();
+  const extra = Math.max(10, readGroupPadding(group) * 0.5);
+  const width = b.width + extra * 2;
+  const height = b.height + extra * 2;
+
+  if (width === 0 || height === 0 || (cx === reference.x && cy === reference.y)) {
+    return { x: cx, y: cy };
+  }
+
+  const dispX = (cx - reference.x) / (width / 2);
+  const dispY = (cy - reference.y) / (height / 2);
+  const len = Math.sqrt(dispX * dispX + dispY * dispY);
+  if (len === 0) {
+    return { x: cx, y: cy };
+  }
+  const lenProportion = (len - 1) / len;
+  return {
+    x: (cx - reference.x) * lenProportion + reference.x,
+    y: (cy - reference.y) * lenProportion + reference.y
+  };
+};
+
+type AnchorWithSvg = {
+  svgElement?: SVGElement;
+  getLocation: (reference: Point) => Point;
+};
+
+const getAnchorSvg = (group: Node, end: AnchorEnd): SVGElement | undefined => {
+  const anchor = group.getAnchor(end) as AnchorWithSvg | undefined;
+  return anchor?.svgElement;
+};
+
+/**
+ * Motion-time border point on the *real* group outline.
+ * - rect/ellipse/circle anchors are O(1) → use full getLocation
+ * - path (hull) anchors: sample ~16 points and pick the one on the peer ray
+ *   (~5–10× cheaper than PF's up to 100 getPointAtLength calls)
+ */
+const approxBorderFacing = (group: Node, toward: Node, end: AnchorEnd = AnchorEnd.both): XY => {
+  const reference = toward.getBounds().getCenter();
+  const svg = getAnchorSvg(group, end);
+
+  // Non-path shapes: getLocation is already cheap and exact.
+  if (svg instanceof SVGRectElement || svg instanceof SVGEllipseElement || svg instanceof SVGCircleElement) {
+    const loc = group.getAnchor(end).getLocation(reference);
+    return { x: loc.x, y: loc.y };
+  }
+
+  if (svg instanceof SVGPathElement && svg.viewportElement) {
+    try {
+      const localRef = reference.clone();
+      group.translateFromParent(localRef);
+
+      const pathLength = svg.getTotalLength();
+      if (pathLength > 0) {
+        const box = svg.getBBox();
+        const cx = box.x + box.width / 2;
+        const cy = box.y + box.height / 2;
+        const vx = localRef.x - cx;
+        const vy = localRef.y - cy;
+        const vLen = Math.hypot(vx, vy) || 1;
+
+        // 16 samples ≈ outline accuracy without the full PF path walk.
+        const samples = 16;
+        let best: XY | undefined;
+        let bestScore = Infinity;
+        for (let i = 0; i < samples; i++) {
+          const p = svg.getPointAtLength((pathLength * i) / samples);
+          const wx = p.x - cx;
+          const wy = p.y - cy;
+          const dot = vx * wx + vy * wy;
+          if (dot <= 0) {
+            continue; // opposite side of the hull
+          }
+          // Perpendicular distance from sample to the center→peer ray.
+          const cross = Math.abs(vx * wy - vy * wx) / vLen;
+          if (cross < bestScore) {
+            bestScore = cross;
+            best = { x: p.x, y: p.y };
+          }
+        }
+
+        if (best) {
+          const pt = new Point(best.x, best.y);
+          group.translateToParent(pt);
+          return { x: pt.x, y: pt.y };
+        }
+      }
+    } catch {
+      // Path not ready / detached — fall through.
+    }
+  }
+
+  return ellipseOnBounds(group, toward);
+};
+
+/**
+ * Full-precision outline (PF anchor, up to ~100 path samples). Settle only.
+ */
+const hullBorderFacing = (group: Node, toward: Node, end: AnchorEnd = AnchorEnd.both): XY => {
+  const reference = toward.getBounds().getCenter();
+  const anchor = group.getAnchor(end);
+  if (anchor) {
+    const loc = anchor.getLocation(reference);
+    return { x: loc.x, y: loc.y };
+  }
+  return approxBorderFacing(group, toward, end);
+};
+
+const getPathPeer = (stub: Edge, role: 'exit' | 'entry', bridge: Edge): Node | undefined => {
+  const bridgeSource = bridge.getSource();
+  const bridgeTarget = bridge.getTarget();
+  if (!isNode(bridgeSource) || !isNode(bridgeTarget)) {
+    return undefined;
+  }
+
+  const endIds = new Set([stub.getSource().getId(), stub.getTarget().getId()]);
+  if (endIds.has(bridgeSource.getId())) {
+    return bridgeTarget;
+  }
+  if (endIds.has(bridgeTarget.getId())) {
+    return bridgeSource;
+  }
+
+  const groupNode = role === 'exit' ? stub.getTarget() : stub.getSource();
+  if (!isNode(groupNode)) {
+    return undefined;
+  }
+  const center = groupNode.getBounds().getCenter();
+  const sc = bridgeSource.getBounds().getCenter();
+  const tc = bridgeTarget.getBounds().getCenter();
+  const dSource = (sc.x - center.x) ** 2 + (sc.y - center.y) ** 2;
+  const dTarget = (tc.x - center.x) ** 2 + (tc.y - center.y) ** 2;
+  return dSource <= dTarget ? bridgeTarget : bridgeSource;
+};
+
+const getRelatedSegmentIds = (edge: Edge): string[] => {
+  const leafIds = (edge.getData()?.aggregatedEdgeIds as string[] | undefined) || [];
+  if (!leafIds.length) {
+    return [edge.getId()];
+  }
+
+  const leafSet = new Set(leafIds);
+  return edge
+    .getGraph()
+    .getEdges()
+    .filter(e => {
+      const ids = (e.getData()?.aggregatedEdgeIds as string[] | undefined) || [];
+      return ids.some(id => leafSet.has(id));
+    })
+    .map(e => e.getId());
+};
+
+const significantlyMoved = (a: Point, x: number, y: number, threshold: number): boolean =>
+  Math.abs(a.x - x) > threshold || Math.abs(a.y - y) > threshold;
+
+/** Quantized bounds fingerprint so tiny float noise does not retrigger work. */
+const boundsKey = (node: Node): string => {
+  const b = node.getBounds();
+  return `${Math.round(b.x)},${Math.round(b.y)},${Math.round(b.width)},${Math.round(b.height)}`;
+};
+
+type SnapPlan = {
+  start?: XY;
+  end?: XY;
+};
+
+const applySnapPlan = (edge: Edge, plan: SnapPlan, threshold: number, clearUnset: boolean) => {
+  action(() => {
+    const startFixed = plan.start != null;
+    const endFixed = plan.end != null;
+    if (!startFixed && !endFixed) {
+      return;
+    }
+    const startMoved = startFixed
+      ? significantlyMoved(edge.getStartPoint(), plan.start!.x, plan.start!.y, threshold)
+      : false;
+    const endMoved = endFixed ? significantlyMoved(edge.getEndPoint(), plan.end!.x, plan.end!.y, threshold) : false;
+    if (!startMoved && !endMoved) {
+      return;
+    }
+    if (startFixed) {
+      edge.setStartPoint(Math.round(plan.start!.x), Math.round(plan.start!.y));
+    } else if (clearUnset) {
+      edge.setStartPoint();
+    }
+    if (endFixed) {
+      edge.setEndPoint(Math.round(plan.end!.x), Math.round(plan.end!.y));
+    } else if (clearUnset) {
+      edge.setEndPoint();
+    }
+  })();
+};
+
+const computeSnapPlan = (edge: Edge, role: string | undefined, precise: boolean): SnapPlan | undefined => {
+  const sourceNode = edge.getSource();
+  const targetNode = edge.getTarget();
+  if (!isNode(sourceNode) || !isNode(targetNode)) {
+    return undefined;
+  }
+
+  const borderFacing = precise
+    ? (group: Node, toward: Node, end?: AnchorEnd) => hullBorderFacing(group, toward, end)
+    : (group: Node, toward: Node, end?: AnchorEnd) => approxBorderFacing(group, toward, end ?? AnchorEnd.both);
+
+  if (role === 'bridge') {
+    return {
+      start: borderFacing(sourceNode, targetNode, AnchorEnd.source),
+      end: borderFacing(targetNode, sourceNode, AnchorEnd.target)
+    };
+  }
+
+  if (role === 'exit' || role === 'entry') {
+    const bridge = findRelatedBridge(edge);
+    if (!bridge) {
+      return undefined;
+    }
+    const peer = getPathPeer(edge, role, bridge);
+    if (!peer) {
+      return undefined;
+    }
+    const plan: SnapPlan = {};
+    if (sourceNode.isGroup()) {
+      plan.start = borderFacing(sourceNode, peer, AnchorEnd.source);
+    }
+    if (targetNode.isGroup()) {
+      plan.end = borderFacing(targetNode, peer, AnchorEnd.target);
+    }
+    return plan;
+  }
+
+  return undefined;
+};
+
+const StyleAggregateEdge: React.FC<StyleAggregateEdgeProps> = ({ element, selected, onSelect: _onSelect, ...rest }) => {
+  const edge = element;
+  const data = edge.getData() || {};
+  const role = data.role as string | undefined;
+
+  // Observe geometry only — do NOT sample SVG hulls during render (Cola tick hot path).
+  const sourceNode = edge.getSource();
+  const targetNode = edge.getTarget();
+  let geoKey = `${boundsKey(sourceNode)}|${boundsKey(targetNode)}`;
+  if (role === 'exit' || role === 'entry') {
+    const bridge = findRelatedBridge(edge);
+    if (bridge) {
+      geoKey += `|${boundsKey(bridge.getSource())}|${boundsKey(bridge.getTarget())}`;
+    }
+  }
+
+  const settleTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const rafRef = React.useRef(0);
+
+  React.useEffect(() => {
+    if (role !== 'bridge' && role !== 'exit' && role !== 'entry') {
+      return undefined;
+    }
+
+    // Fast path while moving: O(1) AABB snaps, coalesced to one write per frame.
+    if (rafRef.current) {
+      cancelAnimationFrame(rafRef.current);
+    }
+    rafRef.current = requestAnimationFrame(() => {
+      const plan = computeSnapPlan(edge, role, false);
+      if (plan) {
+        applySnapPlan(edge, plan, MOVE_SNAP_THRESHOLD, true);
+      }
+    });
+
+    // Precise path after settle: expensive hull sampling once geometry stops.
+    if (settleTimerRef.current) {
+      clearTimeout(settleTimerRef.current);
+    }
+    settleTimerRef.current = setTimeout(() => {
+      const plan = computeSnapPlan(edge, role, true);
+      if (plan) {
+        applySnapPlan(edge, plan, HULL_SNAP_THRESHOLD, true);
+      }
+    }, HULL_SETTLE_MS);
+
+    return () => {
+      if (rafRef.current) {
+        cancelAnimationFrame(rafRef.current);
+      }
+      if (settleTimerRef.current) {
+        clearTimeout(settleTimerRef.current);
+      }
+    };
+  }, [edge, role, geoKey]);
+
+  const handleSelect = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    const relatedIds = getRelatedSegmentIds(edge);
+    const ordered = [edge.getId(), ...relatedIds.filter(id => id !== edge.getId())];
+    const state = edge.getController().getState<{ [selectionState]?: string[] }>();
+    const allSelected = ordered.every(id => state[selectionState]?.includes(id));
+    const selectedIds = allSelected ? [] : ordered;
+    action(() => {
+      state[selectionState] = selectedIds;
+    })();
+    edge.getController().fireEvent(selectionEvent, selectedIds);
+  };
+
+  if (role === 'bridge' || !role) {
+    return <StyleEdge element={element} {...rest} selected={selected} onSelect={handleSelect} />;
+  }
+
+  const passedData = { ...data };
+  delete passedData.tag;
+  delete passedData.tagTlsSecure;
+  delete passedData.tagTlsCleartext;
+  Object.keys(passedData).forEach(key => {
+    if (passedData[key] === undefined) {
+      delete passedData[key];
+    }
+  });
+
+  return (
+    <DefaultEdge
+      className={css('netobserv')}
+      element={element}
+      {...rest}
+      {...passedData}
+      selected={selected}
+      onSelect={handleSelect}
+      startTerminalType={EdgeTerminalType.none}
+      endTerminalType={
+        role === 'entry' && isNode(targetNode) && !targetNode.isGroup()
+          ? EdgeTerminalType.directional
+          : EdgeTerminalType.none
+      }
+    />
+  );
+};
+
+export default observer(StyleAggregateEdge);

--- a/web/src/components/tabs/netflow-topology/2d/styles/styleAggregateEdge.tsx
+++ b/web/src/components/tabs/netflow-topology/2d/styles/styleAggregateEdge.tsx
@@ -12,7 +12,7 @@ import {
   SELECTION_STATE as selectionState,
   WithSelectionProps
 } from '@patternfly/react-topology';
-import { action } from 'mobx';
+import { runInAction } from 'mobx';
 import * as React from 'react';
 import { AggregateEdgeSnapContext } from '../aggregate-edge-snap-context';
 import DefaultEdge from '../components/edge';
@@ -31,6 +31,10 @@ const HULL_SNAP_THRESHOLD = 2;
 /** After geometry stops changing, refine approx → real hull outline. */
 const HULL_SETTLE_MS = 100;
 
+/** One-shot diagnostics so path/bridge failures are visible without per-frame spam. */
+let loggedHullPathError = false;
+let loggedBridgeLookupError = false;
+
 const findRelatedBridge = (stub: Edge): Edge | undefined => {
   if (!stub.hasController()) {
     return undefined;
@@ -39,8 +43,13 @@ const findRelatedBridge = (stub: Edge): Edge | undefined => {
   if (bridgeId) {
     try {
       return stub.getController().getEdgeById(bridgeId);
-    } catch {
-      return undefined;
+    } catch (err) {
+      if (!loggedBridgeLookupError) {
+        loggedBridgeLookupError = true;
+        // eslint-disable-next-line no-console
+        console.debug('aggregate-edge: bridgeId lookup failed, falling back to bridgeKey', err);
+      }
+      // Fall through to bridgeKey resolution.
     }
   }
   const bridgeKey = stub.getData()?.bridgeKey as string | undefined;
@@ -158,7 +167,12 @@ const approxBorderFacing = (group: Node, toward: Node, end: AnchorEnd = AnchorEn
           return { x: pt.x, y: pt.y };
         }
       }
-    } catch {
+    } catch (err) {
+      if (!loggedHullPathError) {
+        loggedHullPathError = true;
+        // eslint-disable-next-line no-console
+        console.debug('aggregate-edge: hull path sample failed, using ellipse fallback', err);
+      }
       // Path not ready / detached — fall through.
     }
   }
@@ -238,30 +252,39 @@ type SnapPlan = {
 };
 
 const applySnapPlan = (edge: Edge, plan: SnapPlan, threshold: number, clearUnset: boolean) => {
-  action(() => {
+  runInAction(() => {
     const startFixed = plan.start != null;
     const endFixed = plan.end != null;
     if (!startFixed && !endFixed) {
+      if (clearUnset) {
+        edge.setStartPoint();
+        edge.setEndPoint();
+      }
       return;
     }
     const startMoved = startFixed
       ? significantlyMoved(edge.getStartPoint(), plan.start!.x, plan.start!.y, threshold)
       : false;
     const endMoved = endFixed ? significantlyMoved(edge.getEndPoint(), plan.end!.x, plan.end!.y, threshold) : false;
+
+    // Clear unset endpoints even when the fixed side has not moved.
+    if (!startFixed && clearUnset) {
+      edge.setStartPoint();
+    }
+    if (!endFixed && clearUnset) {
+      edge.setEndPoint();
+    }
+
     if (!startMoved && !endMoved) {
       return;
     }
-    if (startFixed) {
+    if (startFixed && startMoved) {
       edge.setStartPoint(Math.round(plan.start!.x), Math.round(plan.start!.y));
-    } else if (clearUnset) {
-      edge.setStartPoint();
     }
-    if (endFixed) {
+    if (endFixed && endMoved) {
       edge.setEndPoint(Math.round(plan.end!.x), Math.round(plan.end!.y));
-    } else if (clearUnset) {
-      edge.setEndPoint();
     }
-  })();
+  });
 };
 
 const computeSnapPlan = (edge: Edge, role: string | undefined, precise: boolean): SnapPlan | undefined => {
@@ -384,6 +407,9 @@ const StyleAggregateEdge: React.FC<StyleAggregateEdgeProps> = ({ element, select
     return null;
   }
 
+  // Replaces withSelection's onSelect so clicking any path segment selects the
+  // full exit/bridge/entry set. Mirrors PF Ctrl/Meta multi-select semantics on
+  // that related set (cannot delegate to _onSelect — it only toggles one id).
   const handleSelect = (e: React.MouseEvent) => {
     e.stopPropagation();
     if (!edge.hasController()) {
@@ -392,16 +418,28 @@ const StyleAggregateEdge: React.FC<StyleAggregateEdgeProps> = ({ element, select
     const relatedIds = getRelatedSegmentIds(edge);
     const ordered = [edge.getId(), ...relatedIds.filter(id => id !== edge.getId())];
     const state = edge.getController().getState<{ [selectionState]?: string[] }>();
-    const allSelected = ordered.every(id => state[selectionState]?.includes(id));
-    const selectedIds = allSelected ? [] : ordered;
-    action(() => {
-      state[selectionState] = selectedIds;
-    })();
-    edge.getController().fireEvent(selectionEvent, selectedIds);
+    const current = state[selectionState] ?? [];
+    const multi = e.ctrlKey || e.metaKey;
+
+    let nextSelected: string[];
+    if (multi) {
+      const allSelected = ordered.every(id => current.includes(id));
+      nextSelected = allSelected ? current.filter(id => !ordered.includes(id)) : [...new Set([...current, ...ordered])];
+    } else {
+      const allSelected = ordered.every(id => current.includes(id)) && current.length === ordered.length;
+      nextSelected = allSelected ? [] : ordered;
+    }
+
+    runInAction(() => {
+      state[selectionState] = nextSelected;
+    });
+    edge.getController().fireEvent(selectionEvent, nextSelected);
   };
 
+  const dataTest = `aggregate-edge-${role || 'unknown'}`;
+
   if (role === 'bridge' || !role) {
-    return <StyleEdge element={element} {...rest} selected={selected} onSelect={handleSelect} />;
+    return <StyleEdge element={element} {...rest} selected={selected} onSelect={handleSelect} data-test={dataTest} />;
   }
 
   const passedData = { ...data };
@@ -420,6 +458,7 @@ const StyleAggregateEdge: React.FC<StyleAggregateEdgeProps> = ({ element, select
       element={element}
       {...rest}
       {...passedData}
+      data-test={dataTest}
       selected={selected}
       onSelect={handleSelect}
       startTerminalType={EdgeTerminalType.none}

--- a/web/src/components/tabs/netflow-topology/2d/styles/styleAggregateEdge.tsx
+++ b/web/src/components/tabs/netflow-topology/2d/styles/styleAggregateEdge.tsx
@@ -14,6 +14,7 @@ import {
 } from '@patternfly/react-topology';
 import { action } from 'mobx';
 import * as React from 'react';
+import { AggregateEdgeSnapContext } from '../aggregate-edge-snap-context';
 import DefaultEdge from '../components/edge';
 import StyleEdge from './styleEdge';
 
@@ -31,9 +32,16 @@ const HULL_SNAP_THRESHOLD = 2;
 const HULL_SETTLE_MS = 100;
 
 const findRelatedBridge = (stub: Edge): Edge | undefined => {
+  if (!stub.hasController()) {
+    return undefined;
+  }
   const bridgeId = stub.getData()?.bridgeId as string | undefined;
   if (bridgeId) {
-    return stub.getController().getEdgeById(bridgeId);
+    try {
+      return stub.getController().getEdgeById(bridgeId);
+    } catch {
+      return undefined;
+    }
   }
   const bridgeKey = stub.getData()?.bridgeKey as string | undefined;
   if (!bridgeKey) {
@@ -297,50 +305,70 @@ const computeSnapPlan = (edge: Edge, role: string | undefined, precise: boolean)
 };
 
 const StyleAggregateEdge: React.FC<StyleAggregateEdgeProps> = ({ element, selected, onSelect: _onSelect, ...rest }) => {
+  const snapGeneration = React.useContext(AggregateEdgeSnapContext);
   const edge = element;
   const data = edge.getData() || {};
   const role = data.role as string | undefined;
+  const settleTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const rafRef = React.useRef(0);
+  const lastSnapGenerationRef = React.useRef(snapGeneration);
+  const hasController = edge.hasController();
 
   // Observe geometry only — do NOT sample SVG hulls during render (Cola tick hot path).
-  const sourceNode = edge.getSource();
-  const targetNode = edge.getTarget();
-  let geoKey = `${boundsKey(sourceNode)}|${boundsKey(targetNode)}`;
-  if (role === 'exit' || role === 'entry') {
-    const bridge = findRelatedBridge(edge);
-    if (bridge) {
-      geoKey += `|${boundsKey(bridge.getSource())}|${boundsKey(bridge.getTarget())}`;
+  let geoKey = '';
+  let sourceNode: Node | undefined;
+  let targetNode: Node | undefined;
+  if (hasController) {
+    sourceNode = edge.getSource() as Node;
+    targetNode = edge.getTarget() as Node;
+    geoKey = `${boundsKey(sourceNode)}|${boundsKey(targetNode)}`;
+    if (role === 'exit' || role === 'entry') {
+      const bridge = findRelatedBridge(edge);
+      if (bridge) {
+        geoKey += `|${boundsKey(bridge.getSource() as Node)}|${boundsKey(bridge.getTarget() as Node)}`;
+      }
     }
   }
 
-  const settleTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
-  const rafRef = React.useRef(0);
-
   React.useEffect(() => {
-    if (role !== 'bridge' && role !== 'exit' && role !== 'entry') {
+    if (!hasController || (role !== 'bridge' && role !== 'exit' && role !== 'entry')) {
       return undefined;
     }
 
-    // Fast path while moving: O(1) AABB snaps, coalesced to one write per frame.
+    // Force snap after layout end / collapse; soft threshold while dragging.
+    const forceSnap = lastSnapGenerationRef.current !== snapGeneration;
+    lastSnapGenerationRef.current = snapGeneration;
+    const moveThreshold = forceSnap ? 0 : MOVE_SNAP_THRESHOLD;
+    const settleThreshold = forceSnap ? 0 : HULL_SNAP_THRESHOLD;
+
     if (rafRef.current) {
       cancelAnimationFrame(rafRef.current);
     }
     rafRef.current = requestAnimationFrame(() => {
+      if (!edge.hasController()) {
+        return;
+      }
       const plan = computeSnapPlan(edge, role, false);
       if (plan) {
-        applySnapPlan(edge, plan, MOVE_SNAP_THRESHOLD, true);
+        applySnapPlan(edge, plan, moveThreshold, true);
       }
     });
 
-    // Precise path after settle: expensive hull sampling once geometry stops.
     if (settleTimerRef.current) {
       clearTimeout(settleTimerRef.current);
     }
-    settleTimerRef.current = setTimeout(() => {
-      const plan = computeSnapPlan(edge, role, true);
-      if (plan) {
-        applySnapPlan(edge, plan, HULL_SNAP_THRESHOLD, true);
-      }
-    }, HULL_SETTLE_MS);
+    settleTimerRef.current = setTimeout(
+      () => {
+        if (!edge.hasController()) {
+          return;
+        }
+        const plan = computeSnapPlan(edge, role, true);
+        if (plan) {
+          applySnapPlan(edge, plan, settleThreshold, true);
+        }
+      },
+      forceSnap ? 0 : HULL_SETTLE_MS
+    );
 
     return () => {
       if (rafRef.current) {
@@ -350,10 +378,17 @@ const StyleAggregateEdge: React.FC<StyleAggregateEdgeProps> = ({ element, select
         clearTimeout(settleTimerRef.current);
       }
     };
-  }, [edge, role, geoKey]);
+  }, [edge, role, geoKey, snapGeneration, hasController]);
+
+  if (!hasController || !sourceNode || !targetNode) {
+    return null;
+  }
 
   const handleSelect = (e: React.MouseEvent) => {
     e.stopPropagation();
+    if (!edge.hasController()) {
+      return;
+    }
     const relatedIds = getRelatedSegmentIds(edge);
     const ordered = [edge.getId(), ...relatedIds.filter(id => id !== edge.getId())];
     const state = edge.getController().getState<{ [selectionState]?: string[] }>();

--- a/web/src/components/tabs/netflow-topology/2d/styles/styleEdge.tsx
+++ b/web/src/components/tabs/netflow-topology/2d/styles/styleEdge.tsx
@@ -5,6 +5,7 @@ import DefaultEdge from '../components/edge';
 
 type StyleEdgeProps = {
   element: Edge;
+  'data-test'?: string;
 } & WithSelectionProps;
 
 const StyleEdge: React.FC<StyleEdgeProps> = ({ element, ...rest }) => {

--- a/web/src/components/tabs/netflow-topology/2d/styles/styleGroup.tsx
+++ b/web/src/components/tabs/netflow-topology/2d/styles/styleGroup.tsx
@@ -1,5 +1,6 @@
 import {
   DefaultGroup,
+  Dimensions,
   Node,
   observer,
   ScaleDetailsLevel,
@@ -8,6 +9,7 @@ import {
   WithSelectionProps
 } from '@patternfly/react-topology';
 import useDetailsLevel from '@patternfly/react-topology/dist/esm/hooks/useDetailsLevel';
+import { action } from 'mobx';
 import * as React from 'react';
 import { TopologyGroupIcon } from '../../../../icons';
 
@@ -28,6 +30,29 @@ type StyleGroupProps = {
 } & WithDragNodeProps &
   WithSelectionProps;
 
+/**
+ * Wraps node setCollapsed/setDimensions in MobX action so Console's DefaultGroup
+ * (which may not batch them yet) stays strict-mode safe. Do not deep-import
+ * DefaultGroupCollapsed/Expanded — that duplicates ElementContext vs the shared
+ * Console vendors copy and breaks useDragNode.
+ */
+const useMobxSafeCollapseMutations = (element: Node): void => {
+  React.useLayoutEffect(() => {
+    const setCollapsedOrig = element.setCollapsed.bind(element);
+    const setDimensionsOrig = element.setDimensions.bind(element);
+    element.setCollapsed = ((collapsed: boolean) => {
+      action(() => setCollapsedOrig(collapsed))();
+    }) as Node['setCollapsed'];
+    element.setDimensions = ((dimensions: Dimensions) => {
+      action(() => setDimensionsOrig(dimensions))();
+    }) as Node['setDimensions'];
+    return () => {
+      element.setCollapsed = setCollapsedOrig;
+      element.setDimensions = setDimensionsOrig;
+    };
+  }, [element]);
+};
+
 const StyleGroup: React.FunctionComponent<StyleGroupProps> = ({
   element,
   collapsedWidth = 75,
@@ -36,6 +61,7 @@ const StyleGroup: React.FunctionComponent<StyleGroupProps> = ({
 }) => {
   const data = element.getData();
   const detailsLevel = useDetailsLevel();
+  useMobxSafeCollapseMutations(element);
 
   const renderIcon = (): React.ReactNode => {
     const iconSize = Math.min(collapsedWidth, collapsedHeight) - iconPadding * 2;

--- a/web/src/components/tabs/netflow-topology/2d/styles/styleGroup.tsx
+++ b/web/src/components/tabs/netflow-topology/2d/styles/styleGroup.tsx
@@ -9,7 +9,7 @@ import {
   WithSelectionProps
 } from '@patternfly/react-topology';
 import useDetailsLevel from '@patternfly/react-topology/dist/esm/hooks/useDetailsLevel';
-import { action } from 'mobx';
+import { runInAction } from 'mobx';
 import * as React from 'react';
 import { TopologyGroupIcon } from '../../../../icons';
 
@@ -41,10 +41,10 @@ const useMobxSafeCollapseMutations = (element: Node): void => {
     const setCollapsedOrig = element.setCollapsed.bind(element);
     const setDimensionsOrig = element.setDimensions.bind(element);
     element.setCollapsed = ((collapsed: boolean) => {
-      action(() => setCollapsedOrig(collapsed))();
+      runInAction(() => setCollapsedOrig(collapsed));
     }) as Node['setCollapsed'];
     element.setDimensions = ((dimensions: Dimensions) => {
-      action(() => setDimensionsOrig(dimensions))();
+      runInAction(() => setDimensionsOrig(dimensions));
     }) as Node['setDimensions'];
     return () => {
       element.setCollapsed = setCollapsedOrig;

--- a/web/src/components/tabs/netflow-topology/2d/topology-content.tsx
+++ b/web/src/components/tabs/netflow-topology/2d/topology-content.tsx
@@ -30,6 +30,7 @@ import { getStat } from '../../../../model/metrics';
 import { useNetflowContext } from '../../../../model/netflow-context';
 import { getStepInto, resolveGroupTypes, ScopeConfigDef } from '../../../../model/scope';
 import {
+  AGGREGATE_EDGE_TYPE,
   Decorated,
   ElementData,
   FilterDir,
@@ -372,10 +373,11 @@ export const TopologyContent: React.FC<TopologyContentProps> = ({
       highlightedId = selectedIdsRef.current[0];
     }
 
+    const currentOptions = getOptions();
     const updatedModel = generateDataModel(
       metrics,
       droppedMetrics,
-      getOptions(),
+      currentOptions,
       metricScope,
       scopes,
       searchEvent?.searchValue || '',
@@ -399,13 +401,13 @@ export const TopologyContent: React.FC<TopologyContentProps> = ({
       }
     });
 
-    updatedModel.edges = maybeAggregateEdges(updatedModel.nodes, updatedModel.edges, getOptions(), highlightedId, t);
+    updatedModel.edges = maybeAggregateEdges(updatedModel.nodes, updatedModel.edges, currentOptions, highlightedId, t);
 
     // Highlight all selected aggregate path segments (selection can be multi-id).
-    const selected = selectedIdsRef.current;
-    if (selected.length > 1) {
+    const selectedIdsForHighlight = selectedIdsRef.current;
+    if (selectedIdsForHighlight.length > 1) {
       updatedModel.edges?.forEach(e => {
-        if (selected.includes(e.id)) {
+        if (selectedIdsForHighlight.includes(e.id)) {
           e.data = { ...e.data, highlighted: true };
         }
       });
@@ -512,7 +514,7 @@ export const TopologyContent: React.FC<TopologyContentProps> = ({
       prevOptions?.layout !== options.layout ||
       prevOptions?.groupTypes !== options.groupTypes ||
       prevResolvedGroupTypes !== resolvedGroupTypes ||
-      prevOptions.startCollapsed !== options.startCollapsed ||
+      prevOptions?.startCollapsed !== options.startCollapsed ||
       prevOptions?.groupEdges !== options.groupEdges
     ) {
       resetGraph();
@@ -551,7 +553,7 @@ export const TopologyContent: React.FC<TopologyContentProps> = ({
       if (prevMetricFunction !== metricFunction || prevMetricType !== metricType) {
         //remove edge tags on metrics change
         controller.getElements().forEach(e => {
-          if (e.getType() === 'edge' || e.getType() === 'aggregate-edge') {
+          if (e.getType() === 'edge' || e.getType() === AGGREGATE_EDGE_TYPE) {
             e.setData({
               ...e.getData(),
               tag: undefined,

--- a/web/src/components/tabs/netflow-topology/2d/topology-content.tsx
+++ b/web/src/components/tabs/netflow-topology/2d/topology-content.tsx
@@ -46,6 +46,7 @@ import {
 import { usePrevious } from '../../../../utils/previous-hook';
 import { Empty } from '../../../messages/empty';
 import { SearchEvent, SearchHandle } from '../../../search/search';
+import { AggregateEdgeSnapContext } from './aggregate-edge-snap-context';
 import { filterEvent, stepIntoEvent } from './styles/styleDecorators';
 import './topology-content.css';
 
@@ -126,6 +127,7 @@ export const TopologyContent: React.FC<TopologyContentProps> = ({
 
   const [selectedIds, setSelectedIds] = React.useState<string[]>([]);
   const [hoveredId, setHoveredId] = React.useState<string>('');
+  const [snapGeneration, setSnapGeneration] = React.useState(0);
   // Refs so hover/select highlight can update in place without rebuilding the aggregated model.
   const hoveredIdRef = React.useRef(hoveredId);
   hoveredIdRef.current = hoveredId;
@@ -270,7 +272,29 @@ export const TopologyContent: React.FC<TopologyContentProps> = ({
     }
   }, [controller]);
 
+  const clearAggregateEdgeEndpoints = React.useCallback(() => {
+    if (!controller?.hasGraph()) {
+      return;
+    }
+    action(() => {
+      controller.getElements().forEach(e => {
+        if (e.getType() === AGGREGATE_EDGE_TYPE && isEdge(e)) {
+          e.setStartPoint();
+          e.setEndPoint();
+        }
+      });
+    })();
+  }, [controller]);
+
+  const bumpSnapGeneration = React.useCallback(() => {
+    setSnapGeneration(g => g + 1);
+  }, []);
+
   const onLayoutEnd = React.useCallback(() => {
+    // Drop stale fixed endpoints from mid-layout snaps, then force-resnap.
+    clearAggregateEdgeEndpoints();
+    bumpSnapGeneration();
+
     //fit view to new loaded elements
     if (requestFit) {
       requestFit = false;
@@ -290,7 +314,7 @@ export const TopologyContent: React.FC<TopologyContentProps> = ({
         requestAnimationFrame(fitOnFrame);
       }
     }
-  }, [fitView, options.layout]);
+  }, [bumpSnapGeneration, clearAggregateEdgeEndpoints, fitView, options.layout]);
 
   const onLayoutPositionChange = React.useCallback(() => {
     if (controller && controller.hasGraph()) {
@@ -453,6 +477,14 @@ export const TopologyContent: React.FC<TopologyContentProps> = ({
     resourceStats
   ]);
 
+  const onCollapseChange = React.useCallback(() => {
+    // Rebuild aggregates from live Node.collapsed. Clear + resnap only here (and
+    // on layout end) — not on routine metric/tag updateModel refreshes.
+    updateModel();
+    clearAggregateEdgeEndpoints();
+    bumpSnapGeneration();
+  }, [bumpSnapGeneration, clearAggregateEdgeEndpoints, updateModel]);
+
   // Hover / selection highlight only — avoid regenerating + re-aggregating the whole model.
   React.useEffect(() => {
     if (!controller?.hasGraph()) {
@@ -605,7 +637,7 @@ export const TopologyContent: React.FC<TopologyContentProps> = ({
   useEventListener(graphLayoutEndEvent, onLayoutEnd);
   useEventListener(graphPositionChangeEvent, onLayoutPositionChange);
   // Rebuild aggregate edges when groups are collapsed/expanded interactively.
-  useEventListener(nodeCollapseChangeEvent, updateModel);
+  useEventListener(nodeCollapseChangeEvent, onCollapseChange);
 
   if (_.isEmpty(metrics) && _.isEmpty(droppedMetrics) && _.isEmpty(expectedNodes)) {
     return (
@@ -616,40 +648,42 @@ export const TopologyContent: React.FC<TopologyContentProps> = ({
   }
 
   return (
-    <TopologyView
-      data-test="topology-view"
-      id="topology-view"
-      controlBar={
-        <TopologyControlBar
-          data-test="topology-control-bar"
-          controlButtons={createTopologyControlButtons({
-            ...defaultControlButtonsOptions,
-            fitToScreen: false,
-            zoomInCallback: () => {
-              if (controller) {
-                controller.getGraph().scaleBy(zoomIn);
-              }
-            },
-            zoomOutCallback: () => {
-              if (controller) {
-                controller.getGraph().scaleBy(zoomOut);
-              }
-            },
-            resetViewCallback: () => {
-              if (controller) {
-                requestFit = true;
-                controller.getGraph().reset();
-                controller.getGraph().layout();
-              }
-            },
-            //TODO: enable legend with display icons and colors
-            legend: false
-          })}
-        />
-      }
-    >
-      <VisualizationSurface data-test="visualization-surface" state={{ selectedIds }} />
-    </TopologyView>
+    <AggregateEdgeSnapContext.Provider value={snapGeneration}>
+      <TopologyView
+        data-test="topology-view"
+        id="topology-view"
+        controlBar={
+          <TopologyControlBar
+            data-test="topology-control-bar"
+            controlButtons={createTopologyControlButtons({
+              ...defaultControlButtonsOptions,
+              fitToScreen: false,
+              zoomInCallback: () => {
+                if (controller) {
+                  controller.getGraph().scaleBy(zoomIn);
+                }
+              },
+              zoomOutCallback: () => {
+                if (controller) {
+                  controller.getGraph().scaleBy(zoomOut);
+                }
+              },
+              resetViewCallback: () => {
+                if (controller) {
+                  requestFit = true;
+                  controller.getGraph().reset();
+                  controller.getGraph().layout();
+                }
+              },
+              //TODO: enable legend with display icons and colors
+              legend: false
+            })}
+          />
+        }
+      >
+        <VisualizationSurface data-test="visualization-surface" state={{ selectedIds }} />
+      </TopologyView>
+    </AggregateEdgeSnapContext.Provider>
   );
 };
 

--- a/web/src/components/tabs/netflow-topology/2d/topology-content.tsx
+++ b/web/src/components/tabs/netflow-topology/2d/topology-content.tsx
@@ -6,8 +6,8 @@ import {
   GRAPH_LAYOUT_END_EVENT as graphLayoutEndEvent,
   GRAPH_POSITION_CHANGE_EVENT as graphPositionChangeEvent,
   isEdge,
+  isNode,
   Model,
-  Node,
   NODE_COLLAPSE_CHANGE_EVENT as nodeCollapseChangeEvent,
   SELECTION_EVENT as selectionEvent,
   SelectionEventListener,
@@ -18,7 +18,7 @@ import {
   VisualizationSurface
 } from '@patternfly/react-topology';
 import _ from 'lodash';
-import { action } from 'mobx';
+import { runInAction } from 'mobx';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { TopologyMetrics } from '../../../../api/query-response';
@@ -276,14 +276,14 @@ export const TopologyContent: React.FC<TopologyContentProps> = ({
     if (!controller?.hasGraph()) {
       return;
     }
-    action(() => {
+    runInAction(() => {
       controller.getElements().forEach(e => {
         if (e.getType() === AGGREGATE_EDGE_TYPE && isEdge(e)) {
           e.setStartPoint();
           e.setEndPoint();
         }
       });
-    })();
+    });
   }, [controller]);
 
   const bumpSnapGeneration = React.useCallback(() => {
@@ -417,10 +417,10 @@ export const TopologyContent: React.FC<TopologyContentProps> = ({
 
     // Preserve interactive collapse before aggregating (collapsedGroups remapping).
     controller.getElements().forEach(e => {
-      if (e.getType() === 'group') {
+      if (e.getType() === 'group' && isNode(e)) {
         const updatedGroup = updatedModel.nodes?.find(n => n.id === e.getId());
         if (updatedGroup) {
-          updatedGroup.collapsed = (e as Node).isCollapsed();
+          updatedGroup.collapsed = e.isCollapsed();
         }
       }
     });
@@ -495,7 +495,7 @@ export const TopologyContent: React.FC<TopologyContentProps> = ({
       highlightedId = selectedIds[0];
     }
 
-    action(() => {
+    runInAction(() => {
       controller.getElements().forEach(el => {
         if (el.getType() === 'graph') {
           return;
@@ -535,7 +535,7 @@ export const TopologyContent: React.FC<TopologyContentProps> = ({
           el.setData({ ...data, highlighted });
         }
       });
-    })();
+    });
   }, [controller, hoveredId, selectedIds]);
 
   //update model on layout / metrics / filters change

--- a/web/src/components/tabs/netflow-topology/2d/topology-content.tsx
+++ b/web/src/components/tabs/netflow-topology/2d/topology-content.tsx
@@ -5,8 +5,10 @@ import {
   defaultControlButtonsOptions,
   GRAPH_LAYOUT_END_EVENT as graphLayoutEndEvent,
   GRAPH_POSITION_CHANGE_EVENT as graphPositionChangeEvent,
+  isEdge,
   Model,
   Node,
+  NODE_COLLAPSE_CHANGE_EVENT as nodeCollapseChangeEvent,
   SELECTION_EVENT as selectionEvent,
   SelectionEventListener,
   TopologyControlBar,
@@ -16,6 +18,7 @@ import {
   VisualizationSurface
 } from '@patternfly/react-topology';
 import _ from 'lodash';
+import { action } from 'mobx';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { TopologyMetrics } from '../../../../api/query-response';
@@ -34,6 +37,7 @@ import {
   GraphElementPeer,
   isDirElementFiltered,
   LayoutName,
+  maybeAggregateEdges,
   NodeData,
   toggleDirElementFilter,
   TopologyOptions
@@ -121,6 +125,11 @@ export const TopologyContent: React.FC<TopologyContentProps> = ({
 
   const [selectedIds, setSelectedIds] = React.useState<string[]>([]);
   const [hoveredId, setHoveredId] = React.useState<string>('');
+  // Refs so hover/select highlight can update in place without rebuilding the aggregated model.
+  const hoveredIdRef = React.useRef(hoveredId);
+  hoveredIdRef.current = hoveredId;
+  const selectedIdsRef = React.useRef(selectedIds);
+  selectedIdsRef.current = selectedIds;
 
   const onSelectIds = React.useCallback(
     (ids: string[]) => {
@@ -357,10 +366,10 @@ export const TopologyContent: React.FC<TopologyContentProps> = ({
     }
     waitForMetrics = false;
 
-    //highlight either hoveredId or selected id
-    let highlightedId = hoveredId;
-    if (!highlightedId && selectedIds.length === 1) {
-      highlightedId = selectedIds[0];
+    // Highlight from refs so hover/select can update independently (see effect below).
+    let highlightedId = hoveredIdRef.current;
+    if (!highlightedId && selectedIdsRef.current.length === 1) {
+      highlightedId = selectedIdsRef.current[0];
     }
 
     const updatedModel = generateDataModel(
@@ -379,6 +388,29 @@ export const TopologyContent: React.FC<TopologyContentProps> = ({
       isDark,
       resourceStats
     );
+
+    // Preserve interactive collapse before aggregating (collapsedGroups remapping).
+    controller.getElements().forEach(e => {
+      if (e.getType() === 'group') {
+        const updatedGroup = updatedModel.nodes?.find(n => n.id === e.getId());
+        if (updatedGroup) {
+          updatedGroup.collapsed = (e as Node).isCollapsed();
+        }
+      }
+    });
+
+    updatedModel.edges = maybeAggregateEdges(updatedModel.nodes, updatedModel.edges, getOptions(), highlightedId, t);
+
+    // Highlight all selected aggregate path segments (selection can be multi-id).
+    const selected = selectedIdsRef.current;
+    if (selected.length > 1) {
+      updatedModel.edges?.forEach(e => {
+        if (selected.includes(e.id)) {
+          e.data = { ...e.data, highlighted: true };
+        }
+      });
+    }
+
     const allIds = [...(updatedModel.nodes || []), ...(updatedModel.edges || [])].map(item => item.id);
     controller.getElements().forEach(e => {
       if (e.getType() !== 'graph') {
@@ -392,10 +424,7 @@ export const TopologyContent: React.FC<TopologyContentProps> = ({
               }
               break;
             case 'group':
-              const updatedGroup = updatedModel.nodes?.find(n => n.id === e.getId());
-              if (updatedGroup) {
-                updatedGroup.collapsed = (e as Node).isCollapsed();
-              }
+              // collapsed already synced above before aggregation
               break;
           }
         } else {
@@ -409,8 +438,6 @@ export const TopologyContent: React.FC<TopologyContentProps> = ({
     prevMetrics,
     metrics,
     droppedMetrics,
-    hoveredId,
-    selectedIds,
     getOptions,
     metricScope,
     scopes,
@@ -424,6 +451,59 @@ export const TopologyContent: React.FC<TopologyContentProps> = ({
     resourceStats
   ]);
 
+  // Hover / selection highlight only — avoid regenerating + re-aggregating the whole model.
+  React.useEffect(() => {
+    if (!controller?.hasGraph()) {
+      return;
+    }
+    let highlightedId = hoveredId;
+    if (!highlightedId && selectedIds.length === 1) {
+      highlightedId = selectedIds[0];
+    }
+
+    action(() => {
+      controller.getElements().forEach(el => {
+        if (el.getType() === 'graph') {
+          return;
+        }
+        const data = el.getData() || {};
+        if (data.shadowed) {
+          if (data.highlighted) {
+            el.setData({ ...data, highlighted: false });
+          }
+          return;
+        }
+
+        let highlighted = false;
+        if (highlightedId) {
+          if (el.getType() === 'node' || el.getType() === 'group') {
+            const peerId = data.peer?.id as string | undefined;
+            highlighted = !!peerId && highlightedId.includes(peerId);
+          } else if (isEdge(el)) {
+            highlighted =
+              el.getId().includes(highlightedId) ||
+              el.getSource().getId() === highlightedId ||
+              el.getTarget().getId() === highlightedId;
+            const leafIds = (data.aggregatedEdgeIds as string[] | undefined) || [];
+            if (!highlighted && leafIds.length) {
+              highlighted = leafIds.some(
+                id =>
+                  id.includes(highlightedId) || id.startsWith(`${highlightedId}.`) || id.endsWith(`.${highlightedId}`)
+              );
+            }
+          }
+        }
+        if (selectedIds.length > 1 && selectedIds.includes(el.getId())) {
+          highlighted = true;
+        }
+
+        if (Boolean(data.highlighted) !== highlighted) {
+          el.setData({ ...data, highlighted });
+        }
+      });
+    })();
+  }, [controller, hoveredId, selectedIds]);
+
   //update model on layout / metrics / filters change
   React.useEffect(() => {
     //update graph if layout changes or if resolved group types changed (including via 'auto' resolution)
@@ -432,7 +512,8 @@ export const TopologyContent: React.FC<TopologyContentProps> = ({
       prevOptions?.layout !== options.layout ||
       prevOptions?.groupTypes !== options.groupTypes ||
       prevResolvedGroupTypes !== resolvedGroupTypes ||
-      prevOptions.startCollapsed !== options.startCollapsed
+      prevOptions.startCollapsed !== options.startCollapsed ||
+      prevOptions?.groupEdges !== options.groupEdges
     ) {
       resetGraph();
     }
@@ -470,7 +551,7 @@ export const TopologyContent: React.FC<TopologyContentProps> = ({
       if (prevMetricFunction !== metricFunction || prevMetricType !== metricType) {
         //remove edge tags on metrics change
         controller.getElements().forEach(e => {
-          if (e.getType() === 'edge') {
+          if (e.getType() === 'edge' || e.getType() === 'aggregate-edge') {
             e.setData({
               ...e.getData(),
               tag: undefined,
@@ -521,6 +602,8 @@ export const TopologyContent: React.FC<TopologyContentProps> = ({
   useEventListener(hoverEvent, onHover);
   useEventListener(graphLayoutEndEvent, onLayoutEnd);
   useEventListener(graphPositionChangeEvent, onLayoutPositionChange);
+  // Rebuild aggregate edges when groups are collapsed/expanded interactively.
+  useEventListener(nodeCollapseChangeEvent, updateModel);
 
   if (_.isEmpty(metrics) && _.isEmpty(droppedMetrics) && _.isEmpty(expectedNodes)) {
     return (

--- a/web/src/model/__tests__/topology.spec.ts
+++ b/web/src/model/__tests__/topology.spec.ts
@@ -135,7 +135,9 @@ describe('maybeAggregateEdges', () => {
     // Hidden leaves are dropped after metrics are copied onto aggregates.
     expect(result.every(e => e.visible !== false)).toBe(true);
     expect(result.filter(e => e.type === 'edge')).toHaveLength(0);
-    expect(result.filter(e => e.type === AGGREGATE_EDGE_TYPE).length).toBeGreaterThanOrEqual(3);
+    expect(result.filter(e => e.type === AGGREGATE_EDGE_TYPE && e.data?.role === 'exit')).toHaveLength(2);
+    expect(result.filter(e => e.type === AGGREGATE_EDGE_TYPE && e.data?.role === 'bridge')).toHaveLength(1);
+    expect(result.filter(e => e.type === AGGREGATE_EDGE_TYPE && e.data?.role === 'entry')).toHaveLength(1);
   });
 
   it('bridges at outermost differing groups when nested', () => {

--- a/web/src/model/__tests__/topology.spec.ts
+++ b/web/src/model/__tests__/topology.spec.ts
@@ -1,6 +1,11 @@
+import { EdgeModel, NodeModel, NodeShape } from '@patternfly/react-topology';
+import { TFunction } from 'i18next';
 import { ScopeDefSample } from '../../components/__tests-data__/scopes';
 import { ContextSingleton } from '../../utils/context';
 import { getGroupName, getGroupsForScope, getStepInto, resolveGroupTypes } from '../scope';
+import { AGGREGATE_EDGE_TYPE, DefaultOptions, maybeAggregateEdges } from '../topology';
+
+const t = ((s: string) => s) as TFunction;
 
 describe('Check enabled groups', () => {
   beforeEach(() => {
@@ -77,5 +82,125 @@ describe('Check enabled groups', () => {
 
     next = getStepInto('resource', ['cluster', 'zone', 'host', 'namespace', 'owner', 'resource']);
     expect(next).toEqual(undefined);
+  });
+});
+
+describe('maybeAggregateEdges', () => {
+  const leaf = (id: string): NodeModel => ({
+    id,
+    type: 'node',
+    width: 40,
+    height: 40,
+    shape: NodeShape.ellipse
+  });
+
+  const group = (id: string, children: string[]): NodeModel => ({
+    id,
+    type: 'group',
+    group: true,
+    children,
+    style: { padding: 10 }
+  });
+
+  const edge = (source: string, target: string, bps: number): EdgeModel => ({
+    id: `${source}.${target}`,
+    type: 'edge',
+    source,
+    target,
+    data: { sourceId: source, targetId: target, bps, drops: 0 }
+  });
+
+  const nodes: NodeModel[] = [leaf('a1'), leaf('a2'), leaf('b1'), group('ns-a', ['a1', 'a2']), group('ns-b', ['b1'])];
+
+  const edges: EdgeModel[] = [edge('a1', 'b1', 100), edge('a2', 'b1', 50)];
+
+  it('defaults to grouping edges (groupEdges true)', () => {
+    const result = maybeAggregateEdges(nodes, edges, { ...DefaultOptions, groupTypes: 'namespaces' }, '', t);
+    const bridges = result.filter(e => e.type === AGGREGATE_EDGE_TYPE && e.data?.role === 'bridge');
+    expect(bridges).toHaveLength(1);
+    expect(bridges[0].data.bps).toBe(150);
+    expect(bridges[0].data.aggregatedEdgeIds).toEqual(expect.arrayContaining(['a1.b1', 'a2.b1']));
+    // Hidden leaves are dropped after metrics are copied onto aggregates.
+    expect(result.every(e => e.visible !== false)).toBe(true);
+    expect(result.filter(e => e.type === 'edge')).toHaveLength(0);
+    expect(result.filter(e => e.type === AGGREGATE_EDGE_TYPE).length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('bridges at outermost differing groups when nested', () => {
+    const nestedNodes: NodeModel[] = [
+      leaf('p1'),
+      leaf('p2'),
+      group('owner-a', ['p1']),
+      group('owner-b', ['p2']),
+      group('ns-a', ['owner-a']),
+      group('ns-b', ['owner-b'])
+    ];
+    const nestedEdges: EdgeModel[] = [edge('p1', 'p2', 10)];
+    const result = maybeAggregateEdges(
+      nestedNodes,
+      nestedEdges,
+      { ...DefaultOptions, groupTypes: 'namespaces+owners' },
+      '',
+      t
+    );
+    const bridges = result.filter(e => e.type === AGGREGATE_EDGE_TYPE && e.data?.role === 'bridge');
+    expect(bridges).toHaveLength(1);
+    // Cross-namespace: bridge between namespaces, not owners.
+    expect([bridges[0].source, bridges[0].target].sort()).toEqual(['ns-a', 'ns-b']);
+    // Exit steps through each nested hull: pod → owner → namespace.
+    const exits = result.filter(e => e.data?.role === 'exit');
+    expect(exits).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ source: 'p1', target: 'owner-a' }),
+        expect.objectContaining({ source: 'owner-a', target: 'ns-a' })
+      ])
+    );
+    expect(exits).toHaveLength(2);
+    const entries = result.filter(e => e.data?.role === 'entry');
+    expect(entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ source: 'ns-b', target: 'owner-b' }),
+        expect.objectContaining({ source: 'owner-b', target: 'p2' })
+      ])
+    );
+    expect(entries).toHaveLength(2);
+  });
+
+  it('bridges at inner groups when they share an outer group', () => {
+    const nestedNodes: NodeModel[] = [
+      leaf('p1'),
+      leaf('p2'),
+      group('owner-a', ['p1']),
+      group('owner-b', ['p2']),
+      group('ns-a', ['owner-a', 'owner-b'])
+    ];
+    const nestedEdges: EdgeModel[] = [edge('p1', 'p2', 10)];
+    const result = maybeAggregateEdges(
+      nestedNodes,
+      nestedEdges,
+      { ...DefaultOptions, groupTypes: 'namespaces+owners' },
+      '',
+      t
+    );
+    const bridges = result.filter(e => e.type === AGGREGATE_EDGE_TYPE && e.data?.role === 'bridge');
+    expect(bridges).toHaveLength(1);
+    expect([bridges[0].source, bridges[0].target].sort()).toEqual(['owner-a', 'owner-b']);
+  });
+
+  it('skips aggregation when groupEdges is false', () => {
+    const result = maybeAggregateEdges(
+      nodes,
+      edges,
+      { ...DefaultOptions, groupTypes: 'namespaces', groupEdges: false },
+      '',
+      t
+    );
+    expect(result).toEqual(edges);
+    expect(result.every(e => e.type === 'edge')).toBe(true);
+  });
+
+  it('skips aggregation when groupTypes is none', () => {
+    const result = maybeAggregateEdges(nodes, edges, { ...DefaultOptions, groupTypes: 'none' }, '', t);
+    expect(result).toEqual(edges);
   });
 });

--- a/web/src/model/__tests__/topology.spec.ts
+++ b/web/src/model/__tests__/topology.spec.ts
@@ -110,12 +110,24 @@ describe('maybeAggregateEdges', () => {
     data: { sourceId: source, targetId: target, bps, drops: 0 }
   });
 
-  const nodes: NodeModel[] = [leaf('a1'), leaf('a2'), leaf('b1'), group('ns-a', ['a1', 'a2']), group('ns-b', ['b1'])];
+  const baseNodes = (): NodeModel[] => [
+    leaf('a1'),
+    leaf('a2'),
+    leaf('b1'),
+    group('ns-a', ['a1', 'a2']),
+    group('ns-b', ['b1'])
+  ];
 
-  const edges: EdgeModel[] = [edge('a1', 'b1', 100), edge('a2', 'b1', 50)];
+  const baseEdges = (): EdgeModel[] => [edge('a1', 'b1', 100), edge('a2', 'b1', 50)];
 
   it('defaults to grouping edges (groupEdges true)', () => {
-    const result = maybeAggregateEdges(nodes, edges, { ...DefaultOptions, groupTypes: 'namespaces' }, '', t);
+    const result = maybeAggregateEdges(
+      baseNodes(),
+      baseEdges(),
+      { ...DefaultOptions, groupTypes: 'namespaces' },
+      '',
+      t
+    );
     const bridges = result.filter(e => e.type === AGGREGATE_EDGE_TYPE && e.data?.role === 'bridge');
     expect(bridges).toHaveLength(1);
     expect(bridges[0].data.bps).toBe(150);
@@ -188,19 +200,25 @@ describe('maybeAggregateEdges', () => {
   });
 
   it('skips aggregation when groupEdges is false', () => {
+    const input = baseEdges();
+    const expected = input.map(e => ({ ...e, data: { ...e.data } }));
     const result = maybeAggregateEdges(
-      nodes,
-      edges,
+      baseNodes(),
+      input,
       { ...DefaultOptions, groupTypes: 'namespaces', groupEdges: false },
       '',
       t
     );
-    expect(result).toEqual(edges);
+    expect(result).toBe(input);
+    expect(result).toEqual(expected);
     expect(result.every(e => e.type === 'edge')).toBe(true);
   });
 
   it('skips aggregation when groupTypes is none', () => {
-    const result = maybeAggregateEdges(nodes, edges, { ...DefaultOptions, groupTypes: 'none' }, '', t);
-    expect(result).toEqual(edges);
+    const input = baseEdges();
+    const expected = input.map(e => ({ ...e, data: { ...e.data } }));
+    const result = maybeAggregateEdges(baseNodes(), input, { ...DefaultOptions, groupTypes: 'none' }, '', t);
+    expect(result).toBe(input);
+    expect(result).toEqual(expected);
   });
 });

--- a/web/src/model/topology.ts
+++ b/web/src/model/topology.ts
@@ -29,6 +29,7 @@ import {
   findFromFilters
 } from '../model/filters';
 import { ContextSingleton } from '../utils/context';
+import { createAggregateEdges } from '../utils/create-aggregate-edges';
 import { findFilter } from '../utils/filter-definitions';
 import { getTopologyEdgeId } from '../utils/ids';
 import { createPeer, getFormattedValue } from '../utils/metrics';
@@ -67,6 +68,11 @@ export interface TopologyOptions {
   nodeBadges?: boolean;
   edges?: boolean;
   edgeTags?: boolean;
+  /**
+   * When true (default), cross-group leaf edges are split into exit / bridge / entry
+   * segments and parallel bridges between the same parent groups are merged.
+   */
+  groupEdges?: boolean;
   startCollapsed?: boolean;
   truncateLength: TruncateLength;
   layout: LayoutName;
@@ -86,6 +92,7 @@ export const DefaultOptions: TopologyOptions = {
   nodeBadges: true,
   edges: true,
   edgeTags: true,
+  groupEdges: true,
   maxEdgeStat: 0,
   startCollapsed: false,
   truncateLength: TruncateLength.M,
@@ -98,6 +105,8 @@ export const DefaultOptions: TopologyOptions = {
   showEmpty: false,
   showCleartextEdgeLock: false
 };
+
+export const AGGREGATE_EDGE_TYPE = 'aggregate-edge';
 
 export type GraphElementPeer = GraphElement<ElementModel, NodeData>;
 export type ElementData = Partial<NodeData>;
@@ -454,6 +463,138 @@ const getEdgeTag = (value: number, options: TopologyOptions, t: TFunction) => {
     return getFormattedValue(value, options.metricType, metricFunction, t);
   }
   return undefined;
+};
+
+/**
+ * After structural aggregation, copy/sum leaf NetObserv metrics onto aggregate segments.
+ * Metric tags and TLS hints go on the bridge (or sole segment); stubs keep visual flags only.
+ */
+export const applyAggregateEdgeData = (
+  edges: EdgeModel[],
+  options: TopologyOptions,
+  highlightedId: string,
+  t: TFunction
+): EdgeModel[] => {
+  const byId = new Map(edges.map(e => [e.id, e]));
+
+  edges.forEach(edge => {
+    const role = edge.data?.role as string | undefined;
+    const leafIds: string[] = edge.data?.aggregatedEdgeIds || [];
+    if (!leafIds.length) {
+      return;
+    }
+
+    const leaves = leafIds.map(id => byId.get(id)).filter((e): e is EdgeModel => !!e);
+    if (!leaves.length) {
+      return;
+    }
+
+    const shadowed = leaves.some(l => l.data?.shadowed);
+    const filtered = leaves.some(l => l.data?.filtered);
+    const isDark = leaves.some(l => l.data?.isDark);
+    const highlighted =
+      !shadowed &&
+      !_.isEmpty(highlightedId) &&
+      (edge.id.includes(highlightedId) ||
+        edge.source === highlightedId ||
+        edge.target === highlightedId ||
+        leaves.some(
+          l =>
+            l.id.includes(highlightedId) ||
+            l.data?.sourceId === highlightedId ||
+            l.data?.targetId === highlightedId ||
+            l.source === highlightedId ||
+            l.target === highlightedId
+        ));
+
+    // Stubs: no metric tag; directional arrow only on entry.
+    if (role === 'exit' || role === 'entry') {
+      edge.edgeStyle = EdgeStyle.dashed;
+      edge.data = {
+        ...edge.data,
+        shadowed,
+        filtered,
+        highlighted,
+        isDark,
+        tag: undefined,
+        tagStatus: NodeStatus.default,
+        tagTlsSecure: undefined,
+        tagTlsLockSeverity: undefined,
+        tagTlsCleartext: undefined,
+        startTerminalType: EdgeTerminalType.none,
+        startTerminalStatus: NodeStatus.default,
+        endTerminalType: role === 'entry' ? EdgeTerminalType.directional : EdgeTerminalType.none,
+        endTerminalStatus: NodeStatus.default
+      };
+      return;
+    }
+
+    // Bridge (or collapse-only aggregate): sum metrics and TLS from leaves.
+    const bps = leaves.reduce((sum, l) => sum + (l.data?.bps || 0), 0);
+    const drops = leaves.reduce((sum, l) => sum + (l.data?.drops || 0), 0);
+    const tls = tlsPanelFromLabelArrays(
+      leaves.flatMap(l => l.data?.tlsVersionLabels || []),
+      leaves.flatMap(l => l.data?.tlsGroupLabels || [])
+    );
+    const tagTlsCleartext =
+      Boolean(options.isTLSTracking) &&
+      Boolean(options.showCleartextEdgeLock) &&
+      showTLSHints(options.metricType) &&
+      !tls?.tagTlsSecure &&
+      bps > 0 &&
+      leaves.some(l => l.data?.tagTlsCleartext);
+    const bidirectional = Boolean(edge.data?.bidirectional);
+
+    edge.edgeStyle = getEdgeStyle(bps);
+    edge.animationSpeed = getAnimationSpeed(bps, options.maxEdgeStat);
+    edge.data = {
+      ...edge.data,
+      shadowed,
+      filtered,
+      highlighted,
+      isDark,
+      bps,
+      drops,
+      tag: getEdgeTag(bps, options, t),
+      tagStatus: getTagStatus(bps, options.maxEdgeStat),
+      startTerminalType: bidirectional ? EdgeTerminalType.directional : EdgeTerminalType.none,
+      startTerminalStatus: NodeStatus.default,
+      endTerminalType: bps > 0 ? EdgeTerminalType.directional : EdgeTerminalType.none,
+      endTerminalStatus: NodeStatus.default,
+      ...(tls || { tagTlsSecure: false, tagTlsLockSeverity: undefined }),
+      tagTlsCleartext: tagTlsCleartext ? true : undefined
+    };
+    if (!tls) {
+      delete edge.data.tlsVersionLabels;
+      delete edge.data.tlsGroupLabels;
+    }
+  });
+
+  return edges;
+};
+
+/** Aggregate cross-group edges when groupEdges is enabled; no-op otherwise. */
+export const maybeAggregateEdges = (
+  nodes: NodeModel[] | undefined,
+  edges: EdgeModel[] | undefined,
+  options: TopologyOptions,
+  highlightedId: string,
+  t: TFunction
+): EdgeModel[] => {
+  if (!edges?.length) {
+    return [];
+  }
+  if (options.edges === false || options.groupEdges === false || options.groupTypes === 'none' || !nodes?.length) {
+    return edges;
+  }
+  const aggregated = createAggregateEdges(AGGREGATE_EDGE_TYPE, edges, nodes, {
+    groupEdges: true,
+    collapsedGroups: true
+  });
+  const withData = applyAggregateEdgeData(aggregated, options, highlightedId, t);
+  // Drop hidden leaf edges after metrics are copied onto aggregates. Leaving them in the
+  // model forces Cola layout to simulate every invisible link and inflates element count.
+  return withData.filter(e => e.visible !== false);
 };
 
 const generateEdge = (
@@ -813,5 +954,6 @@ export const generateDataModel = (
     });
   }
 
+  // Aggregation runs after collapse state is synced in TopologyContent.updateModel.
   return { nodes, edges };
 };

--- a/web/src/utils/create-aggregate-edges.ts
+++ b/web/src/utils/create-aggregate-edges.ts
@@ -303,7 +303,6 @@ const aggregateByCollapsedGroups = (
   parentOf: ParentIndex,
   collapsedIds: Set<string>
 ): EdgeModel[] => {
-  const pendingAggregates: EdgeModel[] = [];
   const segmentIndex = new Map<string, EdgeModel>();
 
   return edges.reduce((newEdges: EdgeModel[], edge: EdgeModel) => {
@@ -339,9 +338,6 @@ const aggregateByCollapsedGroups = (
       // Keep children for backward compatibility with prior collapse aggregation.
       existing.children = existing.data.aggregatedEdgeIds;
       edge.visible = false;
-      if (!newEdges.includes(existing)) {
-        newEdges.push(existing);
-      }
     } else {
       const aggregate = createSegmentEdge(
         aggregateEdgeType,
@@ -353,8 +349,9 @@ const aggregateByCollapsedGroups = (
         true
       );
       aggregate.children = [edge.id];
-      pendingAggregates.push(aggregate);
       segmentIndex.set(key, aggregate);
+      newEdges.push(aggregate);
+      edge.visible = false;
     }
 
     newEdges.push(edge);

--- a/web/src/utils/create-aggregate-edges.ts
+++ b/web/src/utils/create-aggregate-edges.ts
@@ -1,0 +1,482 @@
+import { EdgeModel, NodeModel } from '@patternfly/react-topology';
+
+/**
+ * Vendored from @patternfly/react-topology (PR #320) until Console ships a shared
+ * module that supports AggregateEdgesOptions.groupEdges. Console provides
+ * react-topology as a singleton shared module (import: false), so a custom
+ * package version in the plugin image is ignored at runtime.
+ *
+ * Local performance tweaks vs upstream:
+ * - parentIndex Map (O(1) parent lookup instead of scanning all nodes)
+ * - segmentIndex Map (O(1) merge lookup instead of linear find)
+ * - stubs store bridgeId for O(1) runtime bridge resolution
+ */
+
+export type AggregateEdgeRole = 'exit' | 'bridge' | 'entry';
+
+export interface AggregateEdgesOptions {
+  /**
+   * Remap edge endpoints to their topmost collapsed ancestor and merge
+   * parallel remapped edges into aggregate edges.
+   * Defaults to `true`.
+   */
+  collapsedGroups?: boolean;
+  /**
+   * Split cross-group edges into an exit stub (node → parent group), a bridge
+   * between parent groups (merged across leaf edges), and an entry stub
+   * (parent group → node). Defaults to `false`.
+   */
+  groupEdges?: boolean;
+}
+
+interface PathSegment {
+  source: string;
+  target: string;
+  role: AggregateEdgeRole;
+  /** When true, merge undirected (A→B same as B→A). Exit/entry stay directed. */
+  undirected: boolean;
+  /**
+   * Stable key for the bridge this segment belongs to (sorted endpoint pair).
+   * Exit/entry stubs are scoped to a bridge so paths to different peers stay separate.
+   */
+  bridgeKey: string;
+}
+
+type ParentIndex = Map<string, string>;
+
+const buildParentIndex = (nodes: NodeModel[]): ParentIndex => {
+  const parentOf: ParentIndex = new Map();
+  nodes.forEach(n => {
+    n.children?.forEach(childId => {
+      parentOf.set(childId, n.id);
+    });
+  });
+  return parentOf;
+};
+
+const getAncestorChain = (nodeId: string, parentOf: ParentIndex): string[] => {
+  const chain: string[] = [];
+  let current: string | undefined = nodeId;
+  while (current) {
+    chain.push(current);
+    current = parentOf.get(current);
+  }
+  return chain;
+};
+
+const isAncestorOf = (ancestorId: string, nodeId: string, parentOf: ParentIndex): boolean =>
+  getAncestorChain(nodeId, parentOf).includes(ancestorId);
+
+const makeBridgeKey = (a: string, b: string): string => [a, b].sort((x, y) => x.localeCompare(y)).join('__');
+
+/**
+ * Walk up to the topmost collapsed ancestor (or the node itself if none).
+ * Mirrors runtime `getTopCollapsedParent` against the declarative model.
+ */
+const getCollapsedDisplayedNode = (nodeId: string, parentOf: ParentIndex, collapsedIds: Set<string>): string => {
+  let displayedNodeId = nodeId;
+  let parentId = parentOf.get(nodeId);
+  while (parentId) {
+    if (collapsedIds.has(parentId)) {
+      displayedNodeId = parentId;
+    }
+    parentId = parentOf.get(parentId);
+  }
+  return displayedNodeId;
+};
+
+/**
+ * Decompose a cross-group leaf edge into exit / bridge / entry segments.
+ *
+ * Uses the lowest common ancestor so the *bridge* sits at the outermost
+ * differing ancestors (e.g. namespaces). Exit/entry paths step through each
+ * nested group so the edge touches every hull on the way out/in:
+ *
+ *   pod → ownerA → namespaceA → namespaceB → ownerB → pod
+ *
+ * Example (flat groups, no nesting):
+ *   exit:   2-1 → Group2
+ *   bridge: Group2 → Subgroup3
+ *   entry:  Subgroup3 → 3-1
+ *
+ * When an endpoint is already a group, that group is the bridge terminus
+ * (no exit/entry stub beyond it).
+ */
+const getGroupPathSegments = (
+  sourceId: string,
+  targetId: string,
+  nodesById: Map<string, NodeModel>,
+  parentOf: ParentIndex
+): PathSegment[] | null => {
+  if (sourceId === targetId) {
+    return null;
+  }
+
+  if (isAncestorOf(sourceId, targetId, parentOf) || isAncestorOf(targetId, sourceId, parentOf)) {
+    return null; // node ↔ ancestor: hide, no segments
+  }
+
+  const sourceModel = nodesById.get(sourceId);
+  const targetModel = nodesById.get(targetId);
+  const sourceIsGroup = !!sourceModel?.group;
+  const targetIsGroup = !!targetModel?.group;
+
+  const sourceParent = parentOf.get(sourceId);
+  const targetParent = parentOf.get(targetId);
+
+  // Same immediate parent (siblings) or both graph-level non-nested ends — keep the original edge.
+  if (sourceParent === targetParent) {
+    return [];
+  }
+
+  // Leaf→root chains, then root-first for LCA.
+  const sourceRootFirst = [...getAncestorChain(sourceId, parentOf)].reverse();
+  const targetRootFirst = [...getAncestorChain(targetId, parentOf)].reverse();
+
+  let lcaDepth = -1;
+  const shared = Math.min(sourceRootFirst.length, targetRootFirst.length);
+  for (let i = 0; i < shared; i++) {
+    if (sourceRootFirst[i] === targetRootFirst[i]) {
+      lcaDepth = i;
+    } else {
+      break;
+    }
+  }
+
+  // First unique ancestor on each side (child of LCA, or root of chain when no shared ancestor).
+  const sourceUnique = sourceRootFirst.slice(lcaDepth + 1);
+  const targetUnique = targetRootFirst.slice(lcaDepth + 1);
+  if (!sourceUnique.length || !targetUnique.length) {
+    return null;
+  }
+
+  // Bridge between outermost differing groups when present; otherwise the node itself.
+  const pickBridgeEnd = (uniqueChain: string[], isGroupEndpoint: boolean, endpointId: string): string => {
+    if (isGroupEndpoint) {
+      return endpointId;
+    }
+    // Prefer the topmost group in the unique chain (skip the leaf at the end).
+    const top = uniqueChain[0];
+    const topModel = nodesById.get(top);
+    if (topModel?.group) {
+      return top;
+    }
+    // Unique chain is only the leaf (ungrouped vs grouped peer): use leaf as terminus.
+    return endpointId;
+  };
+
+  const bridgeSource = pickBridgeEnd(sourceUnique, sourceIsGroup, sourceId);
+  const bridgeTarget = pickBridgeEnd(targetUnique, targetIsGroup, targetId);
+
+  if (bridgeSource === bridgeTarget) {
+    return [];
+  }
+
+  const bridgeKey = makeBridgeKey(bridgeSource, bridgeTarget);
+  const segments: PathSegment[] = [];
+
+  // Exit path: step leaf → … → bridgeSource through each nested group.
+  if (!sourceIsGroup && bridgeSource !== sourceId) {
+    // sourceUnique is root-first ([ns, owner, leaf]); reverse for ascent.
+    const ascent = [...sourceUnique].reverse();
+    const bridgeIdx = ascent.indexOf(bridgeSource);
+    const steps = bridgeIdx >= 0 ? ascent.slice(0, bridgeIdx + 1) : ascent;
+    for (let i = 0; i < steps.length - 1; i++) {
+      segments.push({ source: steps[i], target: steps[i + 1], role: 'exit', undirected: false, bridgeKey });
+    }
+  }
+
+  segments.push({ source: bridgeSource, target: bridgeTarget, role: 'bridge', undirected: true, bridgeKey });
+
+  // Entry path: step bridgeTarget → … → leaf through each nested group.
+  if (!targetIsGroup && bridgeTarget !== targetId) {
+    // targetUnique is root-first ([ns, owner, leaf]).
+    const bridgeIdx = targetUnique.indexOf(bridgeTarget);
+    const steps = bridgeIdx >= 0 ? targetUnique.slice(bridgeIdx) : targetUnique;
+    for (let i = 0; i < steps.length - 1; i++) {
+      segments.push({ source: steps[i], target: steps[i + 1], role: 'entry', undirected: false, bridgeKey });
+    }
+  }
+
+  return segments;
+};
+
+const segmentId = (segment: PathSegment, legacyBridgeId = false): string => {
+  if (segment.role === 'bridge') {
+    if (legacyBridgeId) {
+      return `aggregate_${segment.source}_${segment.target}`;
+    }
+    return `aggregate_bridge_${segment.bridgeKey}`;
+  }
+  // Scope stubs to their bridge so paths to different peers do not share selection/geometry.
+  return `aggregate_${segment.role}_${segment.source}_${segment.target}_${segment.bridgeKey}`;
+};
+
+const segmentLookupKey = (aggregateEdgeType: string, segment: PathSegment): string => {
+  if (segment.undirected) {
+    return `${aggregateEdgeType}|${segment.role}|${segment.bridgeKey}`;
+  }
+  return `${aggregateEdgeType}|${segment.role}|${segment.bridgeKey}|${segment.source}->${segment.target}`;
+};
+
+/** Prefer the bridge for labels so multi-part paths show the label once along the path. */
+const isLabelBearer = (segments: PathSegment[], segment: PathSegment): boolean => {
+  const bearer = segments.find(s => s.role === 'bridge') || segments[0];
+  return (
+    !!bearer && bearer.role === segment.role && bearer.source === segment.source && bearer.target === segment.target
+  );
+};
+
+const applyLeafLabel = (aggregate: EdgeModel, leafLabel: string | undefined, carryLabel: boolean): void => {
+  if (!carryLabel || !leafLabel) {
+    return;
+  }
+  const labels: string[] = aggregate.data?.labels ? [...aggregate.data.labels] : [];
+  if (!labels.includes(leafLabel)) {
+    labels.push(leafLabel);
+  }
+  aggregate.data = { ...aggregate.data, labels };
+  aggregate.label = labels.join(', ');
+};
+
+const createSegmentEdge = (
+  aggregateEdgeType: string,
+  segment: PathSegment,
+  leafEdgeId: string,
+  leafSource: string,
+  legacyBridgeId = false,
+  leafLabel?: string,
+  carryLabel = false
+): EdgeModel => {
+  const model: EdgeModel = {
+    id: segmentId(segment, legacyBridgeId),
+    type: aggregateEdgeType,
+    source: segment.source,
+    target: segment.target,
+    data: {
+      role: segment.role,
+      bridgeKey: segment.bridgeKey,
+      // O(1) bridge lookup for exit/entry stub snapping (avoids scanning all graph edges).
+      ...(segment.role !== 'bridge' ? { bridgeId: `aggregate_bridge_${segment.bridgeKey}` } : {}),
+      bidirectional: false,
+      count: 1,
+      aggregatedEdgeIds: [leafEdgeId]
+    }
+  };
+  applyLeafLabel(model, leafLabel, carryLabel);
+  return model;
+};
+
+const mergeSegment = (
+  existing: EdgeModel,
+  leafEdgeId: string,
+  leafSource: string,
+  segment: PathSegment,
+  leafLabel?: string,
+  carryLabel = false
+): void => {
+  const ids: string[] = existing.data?.aggregatedEdgeIds ? [...existing.data.aggregatedEdgeIds] : [];
+  if (!ids.includes(leafEdgeId)) {
+    ids.push(leafEdgeId);
+  }
+  existing.data = {
+    ...existing.data,
+    role: segment.role,
+    bridgeKey: segment.bridgeKey,
+    count: ids.length,
+    aggregatedEdgeIds: ids,
+    bidirectional:
+      segment.role === 'bridge'
+        ? existing.data?.bidirectional || existing.source !== leafSource
+        : existing.data?.bidirectional || false
+  };
+  applyLeafLabel(existing, leafLabel, carryLabel);
+};
+
+/**
+ * Collapse-only aggregation (historical behavior): remap endpoints to collapsed
+ * ancestors and create a single aggregate when 2+ parallel remapped edges exist.
+ */
+const aggregateByCollapsedGroups = (
+  aggregateEdgeType: string,
+  edges: EdgeModel[],
+  parentOf: ParentIndex,
+  collapsedIds: Set<string>
+): EdgeModel[] => {
+  const pendingAggregates: EdgeModel[] = [];
+  const segmentIndex = new Map<string, EdgeModel>();
+
+  return edges.reduce((newEdges: EdgeModel[], edge: EdgeModel) => {
+    edge.visible = 'visible' in edge ? edge.visible : true;
+
+    const source = getCollapsedDisplayedNode(edge.source || '', parentOf, collapsedIds);
+    const target = getCollapsedDisplayedNode(edge.target || '', parentOf, collapsedIds);
+    const remapped = source !== edge.source || target !== edge.target;
+
+    if (!remapped) {
+      newEdges.push(edge);
+      return newEdges;
+    }
+
+    if (source === target) {
+      edge.visible = false;
+      newEdges.push(edge);
+      return newEdges;
+    }
+
+    const segment: PathSegment = {
+      source,
+      target,
+      role: 'bridge',
+      undirected: true,
+      bridgeKey: makeBridgeKey(source, target)
+    };
+    const key = segmentLookupKey(aggregateEdgeType, segment);
+    const existing = segmentIndex.get(key);
+
+    if (existing) {
+      mergeSegment(existing, edge.id, edge.source || '', segment, edge.label, true);
+      // Keep children for backward compatibility with prior collapse aggregation.
+      existing.children = existing.data.aggregatedEdgeIds;
+      edge.visible = false;
+      if (!newEdges.includes(existing)) {
+        newEdges.push(existing);
+      }
+    } else {
+      const aggregate = createSegmentEdge(
+        aggregateEdgeType,
+        segment,
+        edge.id,
+        edge.source || '',
+        true,
+        edge.label,
+        true
+      );
+      aggregate.children = [edge.id];
+      pendingAggregates.push(aggregate);
+      segmentIndex.set(key, aggregate);
+    }
+
+    newEdges.push(edge);
+    return newEdges;
+  }, [] as EdgeModel[]);
+};
+
+/**
+ * Group-edge aggregation: split each cross-group leaf into exit / bridge / entry
+ * segments and merge bridges (and stubs for the same bridge) across leaf edges.
+ */
+const aggregateByGroupEdges = (
+  aggregateEdgeType: string,
+  edges: EdgeModel[],
+  nodesById: Map<string, NodeModel>,
+  parentOf: ParentIndex,
+  collapsedIds: Set<string>,
+  collapsedGroups: boolean
+): EdgeModel[] => {
+  const result: EdgeModel[] = [];
+  const segmentIndex = new Map<string, EdgeModel>();
+
+  edges.forEach(edge => {
+    edge.visible = 'visible' in edge ? edge.visible : true;
+
+    let source = edge.source || '';
+    let target = edge.target || '';
+
+    if (collapsedGroups) {
+      source = getCollapsedDisplayedNode(source, parentOf, collapsedIds);
+      target = getCollapsedDisplayedNode(target, parentOf, collapsedIds);
+    }
+
+    if (source === target) {
+      edge.visible = false;
+      result.push(edge);
+      return;
+    }
+
+    const segments = getGroupPathSegments(source, target, nodesById, parentOf);
+
+    if (segments === null) {
+      // Ancestor relationship — hide.
+      edge.visible = false;
+      result.push(edge);
+      return;
+    }
+
+    if (segments.length === 0) {
+      // Same group siblings / both ungrouped — keep leaf (unless collapse remapped).
+      if (source !== edge.source || target !== edge.target) {
+        // Collapsed remap with no further group split: treat like collapse-only single edge.
+        edge.visible = true;
+      }
+      result.push(edge);
+      return;
+    }
+
+    edge.visible = false;
+    result.push(edge);
+
+    segments.forEach(segment => {
+      const carryLabel = isLabelBearer(segments, segment);
+      const key = segmentLookupKey(aggregateEdgeType, segment);
+      const existing = segmentIndex.get(key);
+      if (existing) {
+        mergeSegment(existing, edge.id, edge.source || '', segment, edge.label, carryLabel);
+      } else {
+        const created = createSegmentEdge(
+          aggregateEdgeType,
+          segment,
+          edge.id,
+          edge.source || '',
+          false,
+          edge.label,
+          carryLabel
+        );
+        segmentIndex.set(key, created);
+        result.push(created);
+      }
+    });
+  });
+
+  return result;
+};
+
+/**
+ * Create aggregate edges that replace sets of leaf edges with visible summary edges.
+ *
+ * @param aggregateEdgeType Type string for created aggregate edges (for component factories).
+ * @param edges Leaf edges to process.
+ * @param nodes Full node model (including groups) used to resolve parents and collapse.
+ * @param options Aggregation modes. Defaults: `{ collapsedGroups: true, groupEdges: false }`.
+ */
+const createAggregateEdges = (
+  aggregateEdgeType: string,
+  edges: EdgeModel[] | undefined,
+  nodes: NodeModel[] | undefined,
+  options: AggregateEdgesOptions = {}
+): EdgeModel[] => {
+  if (!edges?.length) {
+    return [];
+  }
+  if (!nodes?.length) {
+    return edges;
+  }
+
+  const collapsedGroups = options.collapsedGroups ?? true;
+  const groupEdges = options.groupEdges ?? false;
+  const parentOf = buildParentIndex(nodes);
+  const nodesById = new Map(nodes.map(n => [n.id, n]));
+  const collapsedIds = new Set(nodes.filter(n => n.collapsed).map(n => n.id));
+
+  if (groupEdges) {
+    return aggregateByGroupEdges(aggregateEdgeType, edges, nodesById, parentOf, collapsedIds, collapsedGroups);
+  }
+
+  if (collapsedGroups) {
+    return aggregateByCollapsedGroups(aggregateEdgeType, edges, parentOf, collapsedIds);
+  }
+
+  return edges;
+};
+
+export { createAggregateEdges };


### PR DESCRIPTION
## Description

- Add **Group edges** topology option (default **on**) that aggregates cross-group traffic into exit → bridge → entry segments instead of drawing every leaf edge across group boundaries.
- Vendors the aggregation algorithm locally (`web/src/utils/create-aggregate-edges.ts`) because OpenShift Console provides `@patternfly/react-topology` as a shared singleton — a custom package version in the plugin image is ignored at runtime until Console ships topology with `groupEdges` ([patternfly/react-topology#320](https://github.com/patternfly/react-topology/pull/320)).
- Renders aggregates via `StyleAggregateEdge` with nested-group path stepping (touch each hull on the way out/in), LCA-based bridges at the outermost differing groups, and performance-minded snap (coarse outline while layout moves, precise hull refine after settle).
- Keeps layout engines healthy by excluding exit/entry stubs from force/BFS link graphs (avoids self-loops that broke BreadthFirst and slowed Cola).
- Updates highlight on hover/select in place so mousing around does not rebuild/re-aggregate the full model.

## Motivation

With groups enabled, dense leaf edges between pods in different namespaces/owners are hard to read. Group-edge aggregation merges parallel flows onto shared bridges while preserving per-connection exit/entry stubs and metric/TLS tags on the bridge.

## Implementation notes

| Area | Approach |
|------|----------|
| Aggregation | LCA bridge between outermost differing ancestors; exit/entry step through nested groups (`pod → owner → namespace → …`) |
| Rendering | Custom `aggregate-edge` component; stubs/bridges snap to group outlines toward the far peer |
| Performance | Drop hidden leaf edges after metrics copy; skip stubs in layout links; hover highlight without full rebuild; coarse path sample mid-layout, full hull after settle |
| Layout | Custom BreadthFirst / ColaGroups wrappers + shared `collectLayoutLinks` filter |
| UI | Display option checkbox (disabled when edges off or `groupTypes === none`); Cypress coverage |

<img width="1717" height="1284" alt="image" src="https://github.com/user-attachments/assets/8a2c152b-16d3-4f2a-b9eb-f4ae253c6fdd" />
<img width="1717" height="1284" alt="image" src="https://github.com/user-attachments/assets/1c1fc647-ae98-4ed3-b5dc-8d085b0fac6a" />


## Follow-up

- Drop the vendored `create-aggregate-edges.ts` once Console’s shared `@patternfly/react-topology` includes `groupEdges` and nested behavior is aligned (or upstream adopts LCA + nested hops).
- Optionally upstream NetObserv-specific snap/layout fixes to react-topology.

## Test plan

- [ ] Enable groups (`namespaces`, `namespaces+owners`) with **Group edges** on — bridges merge parallel flows; tags appear on bridges
- [ ] Nested groups: path touches owner then namespace hulls (not a straight jump to the outer group only)
- [ ] Toggle **Group edges** off — leaf edges restored
- [ ] Collapse/expand groups — aggregates rebuild correctly
- [ ] Layouts: BreadthFirst spreads nodes (not stacked); Cola / ColaNoForce / ColaGroups remain usable
- [ ] Hover/select feel responsive (no full model rebuild stutter)
- [ ] Plugin + standalone smoke check
- [ ] `make frontend` / unit tests for `maybeAggregateEdges`

## Dependencies

n/a

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Group edges” option to topology display settings, enabled by default.
  * Grouped related connections into shared bridge paths with entry and exit segments.
  * Improved aggregate-edge rendering, selection, highlighting, metrics, and resnapping after layout or group changes.
  * Added support for grouping behavior across supported topology layouts.

* **Bug Fixes**
  * Improved collapse and expand behavior for topology groups.
  * Prevented hidden and intermediate edge segments from affecting layout calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->