### PR TITLE
NETOBSERV-2761 add VM / VMI default tabs

### DIFF
--- a/web/src/components/dropdowns/query-options-dropdown.tsx
+++ b/web/src/components/dropdowns/query-options-dropdown.tsx
@@ -34,7 +34,13 @@ export const QueryOptionsDropdown: React.FC<QueryOptionsProps> = props => {
 
   const trigger = React.useCallback(() => {
     return (
-      <Button ref={triggerRef} variant="link" onClick={() => setOpen(!isOpen)} data-test="query-options-dropdown">
+      <Button
+        ref={triggerRef}
+        variant="link"
+        className="overflow-button"
+        onClick={() => setOpen(!isOpen)}
+        data-test="query-options-dropdown"
+      >
         {t('Query options')}
       </Button>
     );

--- a/web/src/components/netflow-traffic-tab.tsx
+++ b/web/src/components/netflow-traffic-tab.tsx
@@ -129,12 +129,14 @@ export const NetflowTrafficTab: React.FC<NetflowTrafficTabProps> = ({ match, obj
           }
         }
 
+        // Flows enrich VMI (not VM) as owner; VM and VMI share name/namespace.
+        const kind = obj.kind === 'VirtualMachine' ? 'VirtualMachineInstance' : obj.kind;
         setForcedFilters({
           list: [
             {
               def: findFilter(filterDefinitions, 'src_resource')!,
               compare: FilterCompare.equal,
-              values: [{ v: `${obj.kind}.${obj.metadata!.namespace}.${obj.metadata!.name}` }]
+              values: [{ v: `${kind}.${obj.metadata!.namespace}.${obj.metadata!.name}` }]
             }
           ],
           match: 'bidirectional'

--- a/web/src/components/netflow-traffic-tab.tsx
+++ b/web/src/components/netflow-traffic-tab.tsx
@@ -115,7 +115,9 @@ export const NetflowTrafficTab: React.FC<NetflowTrafficTabProps> = ({ match, obj
       case 'StatefulSet':
       case 'DaemonSet':
       case 'Job':
-      case 'CronJob': {
+      case 'CronJob':
+      case 'VirtualMachine':
+      case 'VirtualMachineInstance': {
         // Check for Gateway label on Deployments
         if (obj.kind === 'Deployment') {
           const gatewayLabel = obj.metadata?.labels?.['gateway.networking.k8s.io/gateway-name'];

--- a/web/src/components/netflow-traffic.css
+++ b/web/src/components/netflow-traffic.css
@@ -222,16 +222,66 @@ span.pf-v6-c-button__icon.pf-m-start {
 }
 
 .netobserv-tab-container {
-    margin-top: 1.5rem;
+    margin-top: 0;
     box-sizing: border-box;
     display: flex;
     flex-direction: column;
     overflow: hidden;
+    /* Enable container queries for nested NetObserv layouts in narrow resource tabs */
+    container-type: inline-size;
+    container-name: netobserv-tab;
 }
 
 .netobserv-tab-container>section#pageSection {
     flex: 1 1 auto;
     min-height: 0;
+}
+
+#pageSection.tab {
+    container-type: inline-size;
+    container-name: netobserv-page;
+}
+
+.netobserv-filters-toolbar-item {
+    min-width: 0;
+    padding-right: 1.5rem;
+}
+
+#pageSection.tab #filter-toolbar-search-filters {
+    padding-top: var(--pf-t--global--spacer--md, 1rem);
+}
+
+@container netobserv-tab (max-width: 56rem) {
+    #filter-toolbar {
+        padding-left: var(--pf-t--global--spacer--md, 1rem);
+        padding-right: var(--pf-t--global--spacer--md, 1rem);
+    }
+
+    .filter-search-toolbar-item {
+        flex: 1 1 100%;
+    }
+}
+
+@container netobserv-page (max-width: 56rem) {
+    .filter-search-toolbar-item {
+        flex: 1 1 100%;
+    }
+
+    /* Narrow pane: Time range / Refresh stay on the first row, controls below */
+    div#filter-toolbar-search-filters.netobserv-controls-with-trailing > .pf-v6-c-toolbar__content-section {
+        grid-template-columns: 1fr;
+    }
+
+    div#filter-toolbar-search-filters .netobserv-toolbar-trailing {
+        grid-column: 1;
+        grid-row: 1;
+        justify-self: end;
+    }
+
+    div#filter-toolbar-search-filters .netobserv-toolbar-leading {
+        grid-column: 1;
+        grid-row: 2;
+    }
 }
 
 .chips-popover-close-button {

--- a/web/src/components/netflow-traffic.tsx
+++ b/web/src/components/netflow-traffic.tsx
@@ -477,37 +477,35 @@ export const NetflowTraffic: React.FC<NetflowTrafficProps> = ({
       >
         {!hideTitle && pageHeader()}
         {!_.isEmpty(caps.filterDefs) && (
-          <Flex direction={{ default: 'row' }} style={{ paddingRight: hideTitle ? '1.5rem' : undefined }}>
-            <FlexItem style={{ paddingTop: hideTitle ? '1.8rem' : undefined }} flex={{ default: 'flex_1' }}>
-              <FiltersToolbar
-                id="filter-toolbar"
-                filters={filters}
-                forcedFilters={forcedFilters}
-                setFilters={updateTableFilters}
-                clearFilters={clearFilters}
-                resetFilters={resetDefaultFilters}
-                queryOptionsProps={{
-                  limit,
-                  recordType,
-                  dataSource,
-                  packetLoss,
-                  setLimit,
-                  setRecordType,
-                  setDataSource,
-                  setPacketLoss,
-                  allowLoki: caps.allowLoki,
-                  allowProm: caps.allowProm,
-                  allowFlow: caps.isFlow,
-                  allowConnection: caps.isConnectionTracking,
-                  allowPktDrops: caps.isPktDrop,
-                  useTopK: selectedViewId === 'overview'
-                }}
-                isFullScreen={isFullScreen}
-                setFullScreen={setFullScreen}
-              />
-            </FlexItem>
-            {hideTitle && <FlexItem style={{ alignSelf: 'flex-start' }}>{actions()}</FlexItem>}
-          </Flex>
+          <div className={hideTitle ? 'netobserv-filters-toolbar-item' : undefined}>
+            <FiltersToolbar
+              id="filter-toolbar"
+              filters={filters}
+              forcedFilters={forcedFilters}
+              setFilters={updateTableFilters}
+              clearFilters={clearFilters}
+              resetFilters={resetDefaultFilters}
+              queryOptionsProps={{
+                limit,
+                recordType,
+                dataSource,
+                packetLoss,
+                setLimit,
+                setRecordType,
+                setDataSource,
+                setPacketLoss,
+                allowLoki: caps.allowLoki,
+                allowProm: caps.allowProm,
+                allowFlow: caps.isFlow,
+                allowConnection: caps.isConnectionTracking,
+                allowPktDrops: caps.isPktDrop,
+                useTopK: selectedViewId === 'overview'
+              }}
+              isFullScreen={isFullScreen}
+              setFullScreen={setFullScreen}
+              trailingContent={hideTitle ? actions() : undefined}
+            />
+          </div>
         )}
         {
           <TabsContainer

--- a/web/src/components/tabs/netflow-overview/netflow-overview.css
+++ b/web/src/components/tabs/netflow-overview/netflow-overview.css
@@ -20,6 +20,7 @@
 .overview-flex-item.full {
   flex: auto;
   width: 100%;
+  min-width: 100%;
 }
 
 .emptygraph {
@@ -30,4 +31,46 @@
 
 #top_avg_donut {
   position: relative;
+}
+
+.overview-root {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow-y: auto;
+  container-type: inline-size;
+  container-name: netobserv-overview;
+}
+
+/* Room for the sticky scope slider (matches former JS: min(7.5% of container, 5.5rem)) */
+#overview-graph-list {
+  margin-left: min(7.5cqw, 5.5rem);
+}
+
+/* Stack overview cards when embedded in a narrow resource tab / split pane */
+@container netobserv-overview (max-width: 48rem) {
+  .overview-flex-item {
+    min-width: 100%;
+    width: 100%;
+  }
+
+  #overview-flex {
+    flex-direction: column;
+  }
+
+  /* Focus mode sets inline width/marginLeft; override so the list can stack full-width */
+  #overview-sticky-graph ~ #overview-graph-list {
+    width: auto !important;
+    margin-left: 0 !important;
+  }
+}
+
+@container netobserv-overview (max-width: 36rem) {
+  #overview-scope-slider-div {
+    display: none;
+  }
+
+  #overview-graph-list {
+    margin-left: 0 !important;
+  }
 }

--- a/web/src/components/tabs/netflow-overview/netflow-overview.tsx
+++ b/web/src/components/tabs/netflow-overview/netflow-overview.tsx
@@ -1471,9 +1471,7 @@ export const NetflowOverview = React.forwardRef<NetflowOverviewHandle, NetflowOv
                   width: containerSize.width / 5 - containerPadding,
                   marginLeft: (containerSize.width * 4) / 5 - containerPadding
                 }
-              : {
-                  marginLeft: containerSize.width * 0.075
-                }
+              : undefined
           }
         >
           <Flex
@@ -1502,11 +1500,8 @@ export const NetflowOverview = React.forwardRef<NetflowOverviewHandle, NetflowOv
 
   return (
     <div
+      className="overview-root"
       style={{
-        position: 'relative',
-        width: '100%',
-        height: '100%',
-        overflowY: 'auto',
         padding: `${containerPadding}px 0 ${containerPadding}px ${containerPadding}px`
       }}
       ref={containerRef}

--- a/web/src/components/toolbar/filters-toolbar.css
+++ b/web/src/components/toolbar/filters-toolbar.css
@@ -23,7 +23,7 @@ button.pf-v6-c-button.pf-m-link.pf-m-inline:empty {
   display: none;
 }
 
-/* align toolbar content top */
+/* align toolbar content top (chips / search rows) */
 .flex-start {
   align-self: flex-start;
 }
@@ -44,6 +44,60 @@ div#filter-toolbar-search-filters {
   padding: 0;
   padding-top: 1em;
   padding-bottom: 1em;
+}
+
+/*
+ * Pin Time range / Refresh to the top-right when the left controls wrap.
+ * Grid is on PF's content-section (children live there, not on __content).
+ */
+div#filter-toolbar-search-filters.netobserv-controls-with-trailing > .pf-v6-c-toolbar__content-section {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
+  column-gap: var(--pf-t--global--spacer--md, 1rem);
+  row-gap: var(--pf-t--global--spacer--sm, 0.5rem);
+}
+
+.netobserv-toolbar-leading {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  column-gap: var(--pf-t--global--spacer--md, 1rem);
+  row-gap: var(--pf-t--global--spacer--sm, 0.5rem);
+  min-width: 0;
+}
+
+.netobserv-toolbar-trailing {
+  grid-column: 2;
+  grid-row: 1;
+  justify-self: end;
+  align-self: end;
+  flex-shrink: 0;
+}
+
+/* Keep Query options / Hide filters / Expand on one baseline */
+.netobserv-toolbar-leading > .pf-v6-c-toolbar__item {
+  align-self: center;
+  display: flex;
+  align-items: center;
+}
+
+div#filter-toolbar-search-filters #query-options-dropdown-container,
+div#filter-toolbar-search-filters #show-filters-button,
+div#filter-toolbar-search-filters #fullscreen-button,
+div#filter-toolbar-search-filters .overflow-button {
+  display: inline-flex;
+  align-items: center;
+  vertical-align: middle;
+}
+
+div#filter-toolbar-search-filters #query-options-dropdown-container .pf-v6-c-button,
+div#filter-toolbar-search-filters #show-filters-button,
+div#filter-toolbar-search-filters #fullscreen-button,
+div#filter-toolbar-search-filters .overflow-button {
+  min-height: var(--pf-t--global--spacer--2xl, 2.25rem);
+  padding-block: 0;
+  line-height: var(--pf-t--global--font--line-height--body, 1.5);
 }
 
 .pf-v6-c-toolbar__item.pf-m-align-right {

--- a/web/src/components/toolbar/filters-toolbar.tsx
+++ b/web/src/components/toolbar/filters-toolbar.tsx
@@ -1,16 +1,9 @@
-import {
-  ExpandableSectionToggle,
-  Toolbar,
-  ToolbarContent,
-  ToolbarItem,
-  Tooltip,
-  ValidatedOptions
-} from '@patternfly/react-core';
-import { CompressIcon, ExpandIcon } from '@patternfly/react-icons';
+import { Button, Toolbar, ToolbarContent, ToolbarItem, Tooltip, ValidatedOptions } from '@patternfly/react-core';
+import { AngleDownIcon, AngleRightIcon, CompressIcon, ExpandIcon } from '@patternfly/react-icons';
 import * as _ from 'lodash';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Filter, FilterCompare, FilterDefinition, Filters, summarizeFilters } from '../../model/filters';
+import { Filter, FilterCompare, FilterDefinition, Filters } from '../../model/filters';
 import { useNetflowContext } from '../../model/netflow-context';
 import { autoCompleteCache } from '../../utils/autocomplete-cache';
 import { findFilter, matcher } from '../../utils/filter-definitions';
@@ -34,6 +27,8 @@ export interface FiltersToolbarProps {
   queryOptionsProps: QueryOptionsProps;
   isFullScreen: boolean;
   setFullScreen: (b: boolean) => void;
+  /** Optional content rendered on the same controls row, pinned to the end (e.g. time range). */
+  trailingContent?: React.ReactNode;
 }
 
 export type Direction = 'source' | 'destination' | undefined;
@@ -48,6 +43,7 @@ export const FiltersToolbar: React.FC<FiltersToolbarProps> = ({
   resetFilters,
   isFullScreen,
   setFullScreen,
+  trailingContent,
   ...props
 }) => {
   const { t } = useTranslation('plugin__netobserv-plugin');
@@ -132,7 +128,7 @@ export const FiltersToolbar: React.FC<FiltersToolbarProps> = ({
 
   const getFilterToolbar = React.useCallback(() => {
     return (
-      <ToolbarItem className="flex-start">
+      <ToolbarItem className="flex-start filter-search-toolbar-item">
         <Tooltip
           //css hide tooltip here to avoid render issue
           className={`filters-tooltip${_.isEmpty(message) ? '-empty' : ''}`}
@@ -191,64 +187,68 @@ export const FiltersToolbar: React.FC<FiltersToolbarProps> = ({
   } else if (defaultFilters.length > 0) {
     showHideText = showFilters ? t('Hide filters') : t('Show filters');
   }
-  const showHideItem = (
-    <ToolbarItem className="flex-start">
-      <ExpandableSectionToggle
-        data-test="show-filters-button"
-        id="show-filters-button"
-        className="overflow-button"
-        isExpanded={showFilters}
-        onToggle={isExpanded => setShowFilters(isExpanded)}
-      >
-        {showHideText}
-      </ExpandableSectionToggle>
-    </ToolbarItem>
-  );
-  const showHideTooltip = showFilters ? (
-    showHideItem
-  ) : (
-    <Tooltip content={summarizeFilters(filtersOrForced)}>{showHideItem}</Tooltip>
-  );
   return (
     <>
       <Toolbar data-test={id} id={id}>
-        <ToolbarContent data-test={`${id}-search-filters`} id={`${id}-search-filters`} toolbarId={id}>
-          <ToolbarItem className="flex-start">
-            <QueryOptionsDropdown {...props.queryOptionsProps} />
-          </ToolbarItem>
-          {!isForced && quickFilters.length > 0 && (
-            <ToolbarItem className="flex-start">
-              <QuickFilters
-                quickFilters={quickFilters}
-                activeFilters={filters?.list || []}
-                setFilters={list => setFilters({ ...filters!, list })}
+        <ToolbarContent
+          data-test={`${id}-search-filters`}
+          id={`${id}-search-filters`}
+          toolbarId={id}
+          className={trailingContent ? 'netobserv-controls-with-trailing' : undefined}
+        >
+          <div className="netobserv-toolbar-leading">
+            <ToolbarItem>
+              <QueryOptionsDropdown {...props.queryOptionsProps} />
+            </ToolbarItem>
+            {!isForced && quickFilters.length > 0 && (
+              <ToolbarItem className="flex-start">
+                <QuickFilters
+                  quickFilters={quickFilters}
+                  activeFilters={filters?.list || []}
+                  setFilters={list => setFilters({ ...filters!, list })}
+                />
+              </ToolbarItem>
+            )}
+            {!isForced && getFilterToolbar()}
+            {showHideText && countActiveFilters > 0 && (
+              <ToolbarItem>
+                <Button
+                  data-test="show-filters-button"
+                  id="show-filters-button"
+                  variant="link"
+                  className="overflow-button"
+                  icon={showFilters ? <AngleDownIcon /> : <AngleRightIcon />}
+                  aria-expanded={showFilters}
+                  onClick={() => setShowFilters(!showFilters)}
+                >
+                  {showHideText}
+                </Button>
+              </ToolbarItem>
+            )}
+            <ToolbarItem>
+              <LinksOverflow
+                id={'filters-more-options'}
+                items={[
+                  {
+                    id: 'fullscreen',
+                    label: isFullScreen ? t('Collapse') : t('Expand'),
+                    onClick: () => setFullScreen(!isFullScreen),
+                    icon: isFullScreen ? <CompressIcon /> : <ExpandIcon />
+                  },
+                  {
+                    id: 'set-default-filters',
+                    label: t('Default filters'),
+                    onClick: () => {
+                      resetFilters();
+                      autoCompleteCache.clear();
+                    },
+                    enabled: countActiveFilters === 0
+                  }
+                ]}
               />
             </ToolbarItem>
-          )}
-          {!isForced && getFilterToolbar()}
-          {showHideText && countActiveFilters > 0 && <>{showHideTooltip}</>}
-          <ToolbarItem className="flex-start">
-            <LinksOverflow
-              id={'filters-more-options'}
-              items={[
-                {
-                  id: 'fullscreen',
-                  label: isFullScreen ? t('Collapse') : t('Expand'),
-                  onClick: () => setFullScreen(!isFullScreen),
-                  icon: isFullScreen ? <CompressIcon /> : <ExpandIcon />
-                },
-                {
-                  id: 'set-default-filters',
-                  label: t('Default filters'),
-                  onClick: () => {
-                    resetFilters();
-                    autoCompleteCache.clear();
-                  },
-                  enabled: countActiveFilters === 0
-                }
-              ]}
-            />
-          </ToolbarItem>
+          </div>
+          {trailingContent && <div className="netobserv-toolbar-trailing">{trailingContent}</div>}
         </ToolbarContent>
       </Toolbar>
       {showFilters && countActiveFilters > 0 && (

--- a/web/src/components/toolbar/filters/autocomplete-filter.css
+++ b/web/src/components/toolbar/filters/autocomplete-filter.css
@@ -7,5 +7,6 @@
 #autocomplete-container {
   margin: 0;
   padding: 0;
-  min-width: 330px;
+  min-width: min(330px, 100%);
+  max-width: 100%;
 }

--- a/web/src/components/toolbar/filters/filter-search-input.css
+++ b/web/src/components/toolbar/filters/filter-search-input.css
@@ -1,5 +1,22 @@
-#filter-search-input, #filter-popper {
-  min-width: 500px !important;
+#filter-search-input-container {
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+}
+
+#filter-search-input,
+#filter-popper {
+  width: 100% !important;
+  min-width: 0 !important;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+/* Prefer a comfortable default width when space allows */
+@media (min-width: 48rem) {
+  #filter-search-input-container {
+    min-width: min(500px, 100%);
+  }
 }
 
 .filters-actions {
@@ -11,4 +28,15 @@
 .filter-text-ellipsis {
   text-overflow: ellipsis;
   overflow: hidden;
+}
+
+/* Let the search field claim remaining toolbar space and shrink on narrow panes */
+.filter-search-toolbar-item {
+  flex: 1 1 16rem;
+  min-width: min(100%, 12rem);
+  max-width: 100%;
+}
+
+#filter-toolbar-search-filters {
+  flex-wrap: wrap;
 }

--- a/web/src/components/toolbar/filters/filters-chips.css
+++ b/web/src/components/toolbar/filters/filters-chips.css
@@ -57,8 +57,32 @@
   padding-left: 1.5em;
 }
 
-.flex-block.no-wrap {
-  flex-wrap: nowrap;
+/* Filter groups (Source / Destination / …): wrap when the pane is narrow */
+#filter-toolbar-chips .pf-v6-c-toolbar__content-section {
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
+#filters,
+#forced-filters {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  column-gap: 0;
+  row-gap: var(--pf-t--global--spacer--sm, 0.5rem);
+  min-width: 0;
+  max-width: 100%;
+  flex: 1 1 auto;
+}
+
+.filters-group {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.filters-group .custom-chip-box {
+  min-width: 0;
+  max-width: 100%;
 }
 
 .toolbar-item-center {

--- a/web/src/components/toolbar/filters/filters-chips.tsx
+++ b/web/src/components/toolbar/filters/filters-chips.tsx
@@ -411,7 +411,7 @@ export const FiltersChips: React.FC<FiltersChipsProps> = ({
           .filter(gp => gp.filters.length)
           .map((gp, index) => {
             return (
-              <div key={gp.id} className="flex-block no-wrap">
+              <div key={gp.id} className="flex-block filters-group">
                 {getAndOr(filters.match, index, true)}
                 <div className={`custom-chip-box ${gp.id !== 'common' ? 'custom-chip-peer' : ''}`}>
                   {hasSrcOrDstFilters(gp.filters) && (

--- a/web/src/components/toolbar/filters/filters-dropdown.css
+++ b/web/src/components/toolbar/filters/filters-dropdown.css
@@ -5,9 +5,11 @@
 }
 
 #direction-column-filter-dropdowns {
-  min-width: 370px;
+  min-width: min(370px, 100%);
+  max-width: 100%;
 }
 
 #direction-filter-dropdown-container, #column-filter-dropdown-container {
   flex: 1;
+  min-width: 0;
 }

--- a/web/src/components/toolbar/links-overflow.tsx
+++ b/web/src/components/toolbar/links-overflow.tsx
@@ -95,9 +95,7 @@ export const LinksOverflow: React.FC<LinksOverflowProps> = ({ id, items, text })
               isExpanded={isOpen}
               onClick={() => setOpen(!isOpen)}
             >
-              <>
-                <EllipsisVIcon /> {text || t('More options')}
-              </>
+              {text || t('More options')}
             </MenuToggle>
           )}
         >

--- a/web/src/components/toolbar/view-options-toolbar.tsx
+++ b/web/src/components/toolbar/view-options-toolbar.tsx
@@ -234,9 +234,7 @@ export const ViewOptionsToolbar = React.forwardRef<SearchHandle, ViewOptionsTool
             onClick={() => props.setViewOptionOverflowMenuOpen(!props.isViewOptionOverflowMenuOpen)}
             onBlur={() => props.setViewOptionOverflowMenuOpen(false)}
           >
-            <>
-              <EllipsisVIcon /> {t('More options')}
-            </>
+            {t('More options')}
           </MenuToggle>
         )}
       >

--- a/web/src/utils/__tests__/fullscreen-hook.spec.ts
+++ b/web/src/utils/__tests__/fullscreen-hook.spec.ts
@@ -91,4 +91,97 @@ describe('useFullScreen', () => {
 
     navToggle.remove();
   });
+
+  it('should click VMs tree toggle when panel is open (aria-expanded=true)', () => {
+    const panel = document.createElement('div');
+    panel.id = 'vms-tree-view-panel';
+    const toggle = document.createElement('button');
+    toggle.className = 'vms-tree-view__panel-toggle-button';
+    toggle.setAttribute('aria-expanded', 'true');
+    toggle.setAttribute('aria-label', 'Fermer le panneau arborescence');
+    const clickSpy = jest.spyOn(toggle, 'click');
+    panel.appendChild(toggle);
+    document.body.appendChild(panel);
+
+    const { result } = renderHook(() => useFullScreen());
+
+    act(() => result.current[1](true));
+    expect(clickSpy).toHaveBeenCalled();
+
+    panel.remove();
+  });
+
+  it('should not click VMs tree toggle when panel is closed (aria-expanded=false)', () => {
+    const panel = document.createElement('div');
+    panel.id = 'vms-tree-view-panel';
+    const toggle = document.createElement('button');
+    toggle.className = 'vms-tree-view__panel-toggle-button';
+    toggle.setAttribute('aria-expanded', 'false');
+    toggle.setAttribute('aria-label', 'Close tree view panel');
+    const clickSpy = jest.spyOn(toggle, 'click');
+    panel.appendChild(toggle);
+    document.body.appendChild(panel);
+
+    const { result } = renderHook(() => useFullScreen());
+
+    act(() => result.current[1](true));
+    expect(clickSpy).not.toHaveBeenCalled();
+
+    panel.remove();
+  });
+
+  it('should click VMs tree toggle when open without aria-expanded (search input present)', () => {
+    const panel = document.createElement('div');
+    panel.id = 'vms-tree-view-panel';
+    const toggle = document.createElement('button');
+    toggle.className = 'vms-tree-view__panel-toggle-button';
+    const search = document.createElement('input');
+    search.id = 'vms-tree-view-search-input';
+    const clickSpy = jest.spyOn(toggle, 'click');
+    panel.appendChild(toggle);
+    panel.appendChild(search);
+    document.body.appendChild(panel);
+
+    const { result } = renderHook(() => useFullScreen());
+
+    act(() => result.current[1](true));
+    expect(clickSpy).toHaveBeenCalled();
+
+    panel.remove();
+  });
+
+  it('should click VMs tree toggle when open without aria-expanded (pf-m-resizable)', () => {
+    const panel = document.createElement('div');
+    panel.id = 'vms-tree-view-panel';
+    panel.classList.add('pf-m-resizable');
+    const toggle = document.createElement('button');
+    toggle.className = 'vms-tree-view__panel-toggle-button';
+    const clickSpy = jest.spyOn(toggle, 'click');
+    panel.appendChild(toggle);
+    document.body.appendChild(panel);
+
+    const { result } = renderHook(() => useFullScreen());
+
+    act(() => result.current[1](true));
+    expect(clickSpy).toHaveBeenCalled();
+
+    panel.remove();
+  });
+
+  it('should not click VMs tree toggle when closed without aria-expanded', () => {
+    const panel = document.createElement('div');
+    panel.id = 'vms-tree-view-panel';
+    const toggle = document.createElement('button');
+    toggle.className = 'vms-tree-view__panel-toggle-button';
+    const clickSpy = jest.spyOn(toggle, 'click');
+    panel.appendChild(toggle);
+    document.body.appendChild(panel);
+
+    const { result } = renderHook(() => useFullScreen());
+
+    act(() => result.current[1](true));
+    expect(clickSpy).not.toHaveBeenCalled();
+
+    panel.remove();
+  });
 });

--- a/web/src/utils/fullscreen-hook.ts
+++ b/web/src/utils/fullscreen-hook.ts
@@ -1,13 +1,43 @@
 import * as React from 'react';
 
+const VMS_TREE_PANEL_ID = 'vms-tree-view-panel';
+const VMS_TREE_SEARCH_ID = 'vms-tree-view-search-input';
+const VMS_TREE_TOGGLE_SELECTOR = '.vms-tree-view__panel-toggle-button';
+
+const isVmsTreeOpen = (panel: Element, toggle: HTMLButtonElement): boolean => {
+  const expanded = toggle.getAttribute('aria-expanded');
+  if (expanded === 'true') {
+    return true;
+  }
+  if (expanded === 'false') {
+    return false;
+  }
+  // Fallback when kubevirt has not yet exposed aria-expanded on the toggle:
+  // open tree renders the search input and marks the panel resizable.
+  return panel.classList.contains('pf-m-resizable') || !!panel.querySelector(`#${VMS_TREE_SEARCH_ID}`);
+};
+
+const closeOpenPanels = () => {
+  const pageSidebar = document.querySelector('.pf-v6-c-page__sidebar');
+  const sidebarOpen = pageSidebar?.getAttribute('aria-hidden') === 'false';
+  if (sidebarOpen) {
+    document.getElementById('nav-toggle')?.click();
+  }
+
+  // Close kubevirt VMs tree drawer when present and open (same idea as nav-toggle)
+  const vmsTreePanel = document.getElementById(VMS_TREE_PANEL_ID);
+  const vmsTreeToggle = vmsTreePanel?.querySelector<HTMLButtonElement>(VMS_TREE_TOGGLE_SELECTOR);
+  if (vmsTreePanel && vmsTreeToggle && isVmsTreeOpen(vmsTreePanel, vmsTreeToggle)) {
+    vmsTreeToggle.click();
+  }
+};
+
 export function useFullScreen(): [boolean, React.Dispatch<React.SetStateAction<boolean>>] {
   const [isFullScreen, setFullScreen] = React.useState(false);
 
   React.useEffect(() => {
-    const pageSidebar = document.querySelector('.pf-v6-c-page__sidebar');
-    const sidebarOpen = pageSidebar?.getAttribute('aria-hidden') === 'false';
-    if (isFullScreen && sidebarOpen) {
-      document.getElementById('nav-toggle')?.click();
+    if (isFullScreen) {
+      closeOpenPanels();
     }
 
     const elements = document.querySelectorAll(

--- a/web/src/utils/k8s-models-hook.ts
+++ b/web/src/utils/k8s-models-hook.ts
@@ -99,6 +99,10 @@ export function useK8sModelsWithColors() {
 
     //$color-gateway-dark = $pf-v5-color-blue-500 = #004080 (same as deployments)
     setModel('Gateway', 'G', '#004080');
+
+    //$color-pod-overlord = $pf-v5-color-blue-500 = #004080 (same as deployments)
+    setModel('VirtualMachine', 'VM', '#004080');
+    setModel('VirtualMachineInstance', 'VMI', '#004080');
   }
 
   return k8sModels;

--- a/web/src/utils/metrics.ts
+++ b/web/src/utils/metrics.ts
@@ -36,7 +36,9 @@ const shortKindMap: { [k: string]: string } = {
   Service: 'svc',
   Deployment: 'depl',
   DaemonSet: 'ds',
-  StatefulSet: 'sts'
+  StatefulSet: 'sts',
+  VirtualMachine: 'vm',
+  VirtualMachineInstance: 'vmi'
 };
 
 export const percentileValues = [90, 99];

--- a/web/webpack.config.ts
+++ b/web/webpack.config.ts
@@ -438,6 +438,40 @@ module.exports = {
           }
         },
         {
+          type: "console.tab/horizontalNav",
+          properties: {
+            model: {
+              version: "v1",
+              group: "kubevirt.io",
+              kind: "VirtualMachine"
+            },
+            component: {
+              "$codeRef": "netflowTab.default"
+            },
+            "page": {
+              name: "%plugin__netobserv-plugin~Network Traffic%",
+              "href": "netflow"
+            }
+          }
+        },
+        {
+          type: "console.tab/horizontalNav",
+          properties: {
+            model: {
+              version: "v1",
+              group: "kubevirt.io",
+              kind: "VirtualMachineInstance"
+            },
+            component: {
+              "$codeRef": "netflowTab.default"
+            },
+            "page": {
+              name: "%plugin__netobserv-plugin~Network Traffic%",
+              "href": "netflow"
+            }
+          }
+        },
+        {
           type: "console.tab",
           properties: {
             "contextId": "dev-console-observe",


### PR DESCRIPTION
## Description

Add VirtualMachine and VirtualMachineInstance tabs support on default views. It also works in kubevirt console plugin as it [merge it's custom tabs with existing ones](https://github.com/jpinsonneau/kubevirt-plugin/blob/main/src/utils/components/HorizontalNavbar/utils/useDynamicPages.ts#L32C16-L32C36).

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Network Traffic navigation tabs for **Virtual Machines** and **Virtual Machine Instances** in the OpenShift Console.
  - Added filtering and consistent display labeling and colors for **VM** and **VMI** resources.

- **Improvements**
  - Improved Network Traffic toolbar responsiveness and filter wrapping on narrow screens.
  - Enhanced resource name disambiguation for supported workload types.
  - Fullscreen mode now closes relevant open panels more reliably.
  - Improved overflow menu presentation and responsive overview layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->