### PR TITLE
[NETOBSERV-2885][QE][Main] Status page via OLM Page

### DIFF
--- a/web/cypress/integration-tests/static_plugin.cy.ts
+++ b/web/cypress/integration-tests/static_plugin.cy.ts
@@ -114,14 +114,6 @@ describe('(OCP-84156 OCP-88744) StaticPlugin test with Status Check', { tags: ['
         cy.get(flowcollectorStatusSelectors.statusIndicator).click()
         cy.contains('Network Observability FlowCollector status', { timeout: 30000 }).should('exist')
     })
-    it("(OCP-88744, kapjain) Verify Open Network Traffic button opens traffic page", function () {
-        flowcollectorStatusPage.visit()
-
-        cy.byLegacyTestID('open-network-traffic').should('exist')
-            .should('not.have.attr', 'aria-disabled', 'true')
-            .click()
-        cy.url({ timeout: 30000 }).should('include', '/netflow-traffic')
-    })
     it("(OCP-88744, kapjain) Verify FlowCollector status via search and cluster columns", function () {
         // Search for FlowCollector via search page
         searchPage.navToSearchPage()

--- a/web/cypress/integration-tests/static_plugin.cy.ts
+++ b/web/cypress/integration-tests/static_plugin.cy.ts
@@ -114,14 +114,6 @@ describe('(OCP-84156 OCP-88744) StaticPlugin test with Status Check', { tags: ['
         cy.get(flowcollectorStatusSelectors.statusIndicator).click()
         cy.contains('Network Observability FlowCollector status', { timeout: 30000 }).should('exist')
     })
-    it("(OCP-88744, kapjain) Verify Edit FlowCollector button opens edit page", function () {
-        flowcollectorStatusPage.visit()
-
-        cy.get(flowcollectorStatusSelectors.editFlowCollectorBtn).should('exist').click()
-        cy.url({ timeout: 30000 }).should('include', '/flows.netobserv.io~v1beta2~FlowCollector/edit')
-        cy.get(pluginSelectors.update, { timeout: 30000 }).should('exist')
-    })
-
     it("(OCP-88744, kapjain) Verify Open Network Traffic button opens traffic page", function () {
         flowcollectorStatusPage.visit()
 
@@ -146,27 +138,6 @@ describe('(OCP-84156 OCP-88744) StaticPlugin test with Status Check', { tags: ['
         // Verify status column shows Ready
         cy.byTestID('additional-printer-column-data-Status').should('contain.text', 'Ready')
     })
-    it("(OCP-88744, kapjain) Verify delete button exists and delete modal cancel works", function () {
-        flowcollectorStatusPage.visit()
-
-        cy.get(flowcollectorStatusSelectors.editFlowCollectorBtn).should('exist')
-        cy.get(flowcollectorStatusSelectors.deleteFlowCollectorBtn).should('exist')
-            .should('contain.text', 'Delete FlowCollector')
-
-        cy.get(flowcollectorStatusSelectors.deleteFlowCollectorBtn).click()
-
-        cy.get(flowcollectorStatusSelectors.deleteModal, { timeout: 10000 }).should('exist')
-        cy.get(flowcollectorStatusSelectors.deleteModal).should('contain.text', 'Delete FlowCollector cluster')
-        cy.get(flowcollectorStatusSelectors.deleteModal).should('contain.text', 'This action cannot be undone')
-        cy.get(flowcollectorStatusSelectors.deleteModal)
-            .should('contain.text', 'It will disable flow collection globally')
-
-        cy.get(flowcollectorStatusSelectors.cancelDeleteBtn).should('exist').click()
-
-        cy.get(flowcollectorStatusSelectors.deleteModal).should('not.exist')
-        cy.get(flowcollectorStatusSelectors.readyRow).should('exist')
-    })
-
     it("(OCP-88744, kapjain) Verify delete FlowCollector reloads status page with only create option", function () {
         flowcollectorStatusPage.visit()
 
@@ -177,10 +148,6 @@ describe('(OCP-84156 OCP-88744) StaticPlugin test with Status Check', { tags: ['
         cy.get(flowcollectorStatusSelectors.createFlowCollectorBtn, { timeout: 60000 }).should('exist')
         cy.contains('No FlowCollector resource was found', { timeout: 30000 }).should('exist')
         cy.contains('Create one to enable network flow collection').should('exist')
-
-        cy.get(flowcollectorStatusSelectors.statusButton).should('not.exist')
-        cy.get(flowcollectorStatusSelectors.editFlowCollectorBtn).should('not.exist')
-        cy.get(flowcollectorStatusSelectors.deleteFlowCollectorBtn).should('not.exist')
 
         cy.get(flowcollectorStatusSelectors.createFlowCollectorBtn)
             .should('contain.text', 'Create FlowCollector')

--- a/web/cypress/integration-tests/static_plugin.cy.ts
+++ b/web/cypress/integration-tests/static_plugin.cy.ts
@@ -60,7 +60,8 @@ describe('(OCP-84156 OCP-88744) StaticPlugin test with Status Check', { tags: ['
         // Updating ebpf Sampling to 1
         cy.get(pluginSelectors.editFlowcollector).click()
         cy.get('#root_spec_agent_accordion-toggle').click()
-        cy.get('#root_spec_agent_ebpf_sampling').clear().type('1')
+        cy.get('#root_spec_agent_ebpf_sampling').clear()
+        cy.get('#root_spec_agent_ebpf_sampling').type('1')
         cy.get(pluginSelectors.update).click()
 
         // Wait for flowcollector to get ready
@@ -79,28 +80,96 @@ describe('(OCP-84156 OCP-88744) StaticPlugin test with Status Check', { tags: ['
         cy.checkNetflowTraffic()
         netflowPage.resetClearFilters()
     })
+    it("(OCP-88744, kapjain) Verify OLM page 'cluster' click opens status page", function () {
+        Operator.visitFlowcollector()
 
-        it("(OCP-88744, kapjain) Verify status indicator on Network Health page", function () {
-            cy.visit('/network-health')
-
-            cy.get(flowcollectorStatusSelectors.statusIndicator).should('exist')
-                .find('span span').trigger('mouseenter', { force: true })
-            cy.get(flowcollectorStatusSelectors.statusTooltip, { timeout: 10000 })
-                .should('contain.text', 'FlowCollector is ready')
-            cy.get(flowcollectorStatusSelectors.statusIndicator).click()
-            cy.contains('Network Observability FlowCollector status', { timeout: 30000 }).should('exist')
+        cy.contains('td a', 'cluster', { timeout: 30000 }).should('be.visible')
+            .invoke('attr', 'href').then(href => {
+            cy.visit(href as string)
         })
 
-        it("(OCP-88744, kapjain) Verify status indicator on Network Traffic page", function () {
-            cy.visit('/netflow-traffic')
+        cy.url({ timeout: 30000 }).should('include', '/flows.netobserv.io~v1beta2~FlowCollector/cluster')
+        cy.contains('Network Observability FlowCollector', { timeout: 30000 }).should('exist')
+        cy.get(flowcollectorStatusSelectors.readyRow, { timeout: 120000 }).should('exist')
+    })
 
-            cy.get(flowcollectorStatusSelectors.statusIndicator).should('exist')
-                .find('span span').trigger('mouseenter', { force: true })
-            cy.get(flowcollectorStatusSelectors.statusTooltip, { timeout: 10000 })
-                .should('contain.text', 'FlowCollector is ready')
-            cy.get(flowcollectorStatusSelectors.statusIndicator).click()
-            cy.contains('Network Observability FlowCollector status', { timeout: 30000 }).should('exist')
-        })
+    it("(OCP-88744 kapjain) Verify status indicator on Network Health page", function () {
+        cy.visit('/network-health')
+
+        cy.get(flowcollectorStatusSelectors.statusIndicator).should('exist')
+            .find('span span').first().trigger('mouseenter', { force: true })
+        cy.get(flowcollectorStatusSelectors.statusTooltip, { timeout: 10000 })
+            .should('contain.text', 'FlowCollector is ready')
+        cy.get(flowcollectorStatusSelectors.statusIndicator).click()
+        cy.contains('Network Observability FlowCollector status', { timeout: 30000 }).should('exist')
+    })
+
+    it("(OCP-88744 kapjain) Verify status indicator on Network Traffic page", function () {
+        cy.visit('/netflow-traffic')
+
+        cy.get(flowcollectorStatusSelectors.statusIndicator).should('exist')
+            .find('span span').first().trigger('mouseenter', { force: true })
+        cy.get(flowcollectorStatusSelectors.statusTooltip, { timeout: 10000 })
+            .should('contain.text', 'FlowCollector is ready')
+        cy.get(flowcollectorStatusSelectors.statusIndicator).click()
+        cy.contains('Network Observability FlowCollector status', { timeout: 30000 }).should('exist')
+    })
+    it("(OCP-88744, kapjain) Verify Edit FlowCollector button opens edit page", function () {
+        flowcollectorStatusPage.visit()
+
+        cy.get(flowcollectorStatusSelectors.editFlowCollectorBtn).should('exist').click()
+        cy.url({ timeout: 30000 }).should('include', '/flows.netobserv.io~v1beta2~FlowCollector/edit')
+        cy.get(pluginSelectors.update, { timeout: 30000 }).should('exist')
+    })
+
+    it("(OCP-88744, kapjain) Verify Open Network Traffic button opens traffic page", function () {
+        flowcollectorStatusPage.visit()
+
+        cy.byLegacyTestID('open-network-traffic').should('exist')
+            .should('not.have.attr', 'aria-disabled', 'true')
+            .click()
+        cy.url({ timeout: 30000 }).should('include', '/netflow-traffic')
+    })
+    it("(OCP-88744, kapjain) Verify delete button exists and delete modal cancel works", function () {
+        flowcollectorStatusPage.visit()
+
+        cy.get(flowcollectorStatusSelectors.editFlowCollectorBtn).should('exist')
+        cy.get(flowcollectorStatusSelectors.deleteFlowCollectorBtn).should('exist')
+            .should('contain.text', 'Delete FlowCollector')
+
+        cy.get(flowcollectorStatusSelectors.deleteFlowCollectorBtn).click()
+
+        cy.get(flowcollectorStatusSelectors.deleteModal, { timeout: 10000 }).should('exist')
+        cy.get(flowcollectorStatusSelectors.deleteModal).should('contain.text', 'Delete FlowCollector cluster')
+        cy.get(flowcollectorStatusSelectors.deleteModal).should('contain.text', 'This action cannot be undone')
+        cy.get(flowcollectorStatusSelectors.deleteModal)
+            .should('contain.text', 'It will disable flow collection globally')
+
+        cy.get(flowcollectorStatusSelectors.cancelDeleteBtn).should('exist').click()
+
+        cy.get(flowcollectorStatusSelectors.deleteModal).should('not.exist')
+        cy.get(flowcollectorStatusSelectors.readyRow).should('exist')
+    })
+
+    it("(OCP-88744, kapjain) Verify delete FlowCollector reloads status page with only create option", function () {
+        flowcollectorStatusPage.visit()
+
+        cy.get(flowcollectorStatusSelectors.deleteFlowCollectorBtn).click()
+        cy.get(flowcollectorStatusSelectors.deleteModal, { timeout: 10000 }).should('exist')
+        cy.get(flowcollectorStatusSelectors.confirmDeleteBtn).should('exist').click()
+
+        cy.get(flowcollectorStatusSelectors.createFlowCollectorBtn, { timeout: 60000 }).should('exist')
+        cy.contains('No FlowCollector resource was found', { timeout: 30000 }).should('exist')
+        cy.contains('Create one to enable network flow collection').should('exist')
+
+        cy.get(flowcollectorStatusSelectors.statusButton).should('not.exist')
+        cy.get(flowcollectorStatusSelectors.editFlowCollectorBtn).should('not.exist')
+        cy.get(flowcollectorStatusSelectors.deleteFlowCollectorBtn).should('not.exist')
+
+        cy.get(flowcollectorStatusSelectors.createFlowCollectorBtn)
+            .should('contain.text', 'Create FlowCollector')
+    })
+
 
         it("(OCP-88744, kapjain) Verify FlowCollector status via search and cluster columns", function () {
             // Search for FlowCollector via search page

--- a/web/cypress/integration-tests/static_plugin.cy.ts
+++ b/web/cypress/integration-tests/static_plugin.cy.ts
@@ -130,6 +130,22 @@ describe('(OCP-84156 OCP-88744) StaticPlugin test with Status Check', { tags: ['
             .click()
         cy.url({ timeout: 30000 }).should('include', '/netflow-traffic')
     })
+    it("(OCP-88744, kapjain) Verify FlowCollector status via search and cluster columns", function () {
+        // Search for FlowCollector via search page
+        searchPage.navToSearchPage()
+        searchPage.chooseResourceType('FlowCollector')
+        cy.byTestID('data-view-table', { timeout: 30000 }).should('exist')
+        cy.byTestID('data-view-cell-cluster-name').should('exist')
+
+        // Verify additionalPrinterColumn headers
+        cy.byTestID('additional-printer-column-header-Agent').should('exist')
+        cy.byTestID('additional-printer-column-header-Processor').should('exist')
+        cy.byTestID('additional-printer-column-header-Web Console').should('exist')
+        cy.byTestID('additional-printer-column-header-Status').should('exist')
+
+        // Verify status column shows Ready
+        cy.byTestID('additional-printer-column-data-Status').should('contain.text', 'Ready')
+    })
     it("(OCP-88744, kapjain) Verify delete button exists and delete modal cancel works", function () {
         flowcollectorStatusPage.visit()
 
@@ -169,24 +185,6 @@ describe('(OCP-84156 OCP-88744) StaticPlugin test with Status Check', { tags: ['
         cy.get(flowcollectorStatusSelectors.createFlowCollectorBtn)
             .should('contain.text', 'Create FlowCollector')
     })
-
-
-        it("(OCP-88744, kapjain) Verify FlowCollector status via search and cluster columns", function () {
-            // Search for FlowCollector via search page
-            searchPage.navToSearchPage()
-            searchPage.chooseResourceType('FlowCollector')
-            cy.byTestID('data-view-table', { timeout: 30000 }).should('exist')
-            cy.byTestID('data-view-cell-cluster-name').should('exist')
-
-            // Verify additionalPrinterColumn headers
-            cy.byTestID('additional-printer-column-header-Agent').should('exist')
-            cy.byTestID('additional-printer-column-header-Processor').should('exist')
-            cy.byTestID('additional-printer-column-header-Plugin').should('exist')
-            cy.byTestID('additional-printer-column-header-Status').should('exist')
-
-            // Verify status column shows Ready
-            cy.byTestID('additional-printer-column-data-Status').should('contain.text', 'Ready')
-        })
 
     after("after all tests", function () {
         Operator.deleteFlowCollector()

--- a/web/cypress/views/flowcollector-status.ts
+++ b/web/cypress/views/flowcollector-status.ts
@@ -21,16 +21,6 @@ export namespace flowcollectorStatusSelectors {
 export const flowcollectorStatusPage = {
     visit: () => {
         cy.visit('k8s/cluster/flows.netobserv.io~v1beta2~FlowCollector/status')
-        cy.get(flowcollectorStatusSelectors.readyRow, { timeout: 120000 })
-            .should('have.attr', 'data-test-status', 'True')
-            .should('have.attr', 'data-test-reason', 'Ready')
-    },
-    visitWithoutWaitingForReady: () => {
-        cy.visit('k8s/cluster/flows.netobserv.io~v1beta2~FlowCollector/status')
-        cy.contains('Network Observability FlowCollector', { timeout: 30000 }).should('exist')
-    },
-    visitViaClusterPath: () => {
-        cy.visit('k8s/cluster/flows.netobserv.io~v1beta2~FlowCollector/cluster')
         cy.contains('Network Observability FlowCollector', { timeout: 30000 }).should('exist')
     }
 }

--- a/web/cypress/views/flowcollector-status.ts
+++ b/web/cypress/views/flowcollector-status.ts
@@ -21,7 +21,9 @@ export namespace flowcollectorStatusSelectors {
 export const flowcollectorStatusPage = {
     visit: () => {
         cy.visit('k8s/cluster/flows.netobserv.io~v1beta2~FlowCollector/status')
-        cy.get(flowcollectorStatusSelectors.readyRow, { timeout: 30000 }).should('exist')
+        cy.get(flowcollectorStatusSelectors.readyRow, { timeout: 120000 })
+            .should('have.attr', 'data-test-status', 'True')
+            .should('have.attr', 'data-test-reason', 'Ready')
     },
     visitWithoutWaitingForReady: () => {
         cy.visit('k8s/cluster/flows.netobserv.io~v1beta2~FlowCollector/status')

--- a/web/cypress/views/flowcollector-status.ts
+++ b/web/cypress/views/flowcollector-status.ts
@@ -10,11 +10,25 @@ export namespace flowcollectorStatusSelectors {
     export const flpMonolithRow = '[id=WaitingFLPMonolith-row]'
     export const lokiStackRow = '[id=WaitingLokiStack-row]'
     export const flpParentRow = '[id=WaitingFLPParent-row]'
+    export const deleteFlowCollectorBtn = '[data-test-id="delete-flow-collector"]'
+    export const editFlowCollectorBtn = '[data-test-id="edit-flow-collector"]'
+    export const createFlowCollectorBtn = '[data-test-id="create-flow-collector"]'
+    export const deleteModal = '#delete-modal'
+    export const confirmDeleteBtn = '[data-test-id="confirm-delete-popup-button"]'
+    export const cancelDeleteBtn = '[data-test-id="cancel-delete-popup-button"]'
 }
 
 export const flowcollectorStatusPage = {
     visit: () => {
         cy.visit('k8s/cluster/flows.netobserv.io~v1beta2~FlowCollector/status')
         cy.get(flowcollectorStatusSelectors.readyRow, { timeout: 30000 }).should('exist')
+    },
+    visitWithoutWaitingForReady: () => {
+        cy.visit('k8s/cluster/flows.netobserv.io~v1beta2~FlowCollector/status')
+        cy.contains('Network Observability FlowCollector', { timeout: 30000 }).should('exist')
+    },
+    visitViaClusterPath: () => {
+        cy.visit('k8s/cluster/flows.netobserv.io~v1beta2~FlowCollector/cluster')
+        cy.contains('Network Observability FlowCollector', { timeout: 30000 }).should('exist')
     }
 }


### PR DESCRIPTION
## Description

Test cases for change [NETOBSERV-2693](https://redhat.atlassian.net/browse/NETOBSERV-2693) Open Flowcollector status page from OLM page


## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end coverage for cluster navigation, network status indicators, traffic actions, search columns, and FlowCollector readiness.
  * Added coverage for creating, editing, and deleting FlowCollectors, including confirmation of the empty-state view after deletion.
  * Improved validation of FlowCollector page loading and delete confirmation workflows.
  * Updated sampling input interactions and aligned search-column expectations with the displayed “Web Console” label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->