### PR TITLE
NETOBSERV-2876: Fix flaky tests pf-5

### DIFF
--- a/web/cypress/integration-tests/client_performance.cy.ts
+++ b/web/cypress/integration-tests/client_performance.cy.ts
@@ -12,11 +12,7 @@ describe("(OCP-67725, memodi) Client Performances", { browser: 'chrome', tags: [
     })
 
     beforeEach("test", function () {
-        cy.clearLocalStorage()
-        cy.visit('/netflow-traffic')
-        // wait for page to be fully loaded
-        cy.get('#overview-container', { timeout: 60000 }).should('exist')
-        cy.byTestID('no-results-found').should('not.exist')
+        netflowPage.visit()
     })
 
     it("(OCP-67725, memodi) should measure overview page load times", function () {

--- a/web/cypress/integration-tests/netflow_export.cy.ts
+++ b/web/cypress/integration-tests/netflow_export.cy.ts
@@ -40,15 +40,24 @@ describe('(OCP-72610) Export automation', { tags: ['Network_Observability'] }, f
         cy.showAdvancedOptions();
         cy.get('#export-button').should('exist').click()
         cy.byTestID('export-modal-header').should('be.visible')
+        cy.exec("rm -f cypress/downloads/*.csv", { failOnNonZeroExit: false })
         cy.get('[data-test="export-modal-footer"] > [data-test="export-button"]').click()
-        // Wait for the CSV download to complete and validate exactly one CSV exists
-        cy.exec("ls cypress/downloads", { timeout: 15000 }).then((response) => {
-            const files = response.stdout.trim().split('\n').filter(f => f.endsWith('.csv'))
-            expect(files).to.have.length(1, 'Expected exactly one CSV file in downloads')
-            const csvFile = files[0]
-            cy.exec(`mv "cypress/downloads/${csvFile}" "cypress/downloads/export_table.csv"`)
-            cy.readFile('cypress/downloads/export_table.csv', { timeout: 10000 })
-        })
+        const waitForCsv = (retries = 5): void => {
+            cy.exec("ls cypress/downloads", { failOnNonZeroExit: false }).then((response) => {
+                const files = (response.stdout || '').trim().split('\n').filter(f => f.endsWith('.csv'))
+                if (files.length === 0 && retries > 0) {
+                    cy.wait(2000)
+                    waitForCsv(retries - 1)
+                    return
+                }
+                expect(files.length).to.be.greaterThan(0)
+                const csvFile = files[0]
+                expect(csvFile).to.match(/^[\w.-]+$/)
+                cy.exec(`mv "cypress/downloads/${csvFile}" "cypress/downloads/export_table.csv"`)
+                cy.readFile('cypress/downloads/export_table.csv', { timeout: 10000 })
+            })
+        }
+        waitForCsv()
         cy.exec('rm cypress/downloads/export_table.csv')
         netflowPage.clearAllFilters()
     })

--- a/web/cypress/integration-tests/netflow_external_subnet.cy.ts
+++ b/web/cypress/integration-tests/netflow_external_subnet.cy.ts
@@ -11,8 +11,9 @@ describe('(OCP-67615, OCP-72874) Return external traffic and custom subnet label
         cy.checkStorageClass(this)
         Operator.createFlowcollector("SubnetLabels")
 
-        // deploy test pod
+        // deploy test pod and wait for it to complete (generates traffic to external IP)
         cy.adminCLI('oc create -f cypress/fixtures/test-pod.yaml')
+        cy.adminCLI('oc wait --for=jsonpath=\'{.status.phase}\'=Succeeded pod/test -n netobserv-test-67615 --timeout=120s')
     })
 
     it("(OCP-67615, aramesha) External traffic and custom subnet label", function () {

--- a/web/cypress/integration-tests/netflow_table.cy.ts
+++ b/web/cypress/integration-tests/netflow_table.cy.ts
@@ -113,6 +113,7 @@ describe('(OCP-50532, OCP-50531, OCP-50530, OCP-59408) Netflow Table view tests'
         })
 
         // verify swap button
+        netflowPage.waitForLokiQuery()
         cy.get("#swap-filters-button").should('exist').click()
         cy.get(filterSelectors.filterNames).eq(0).should('contain.text', 'Destination')
 
@@ -145,6 +146,7 @@ describe('(OCP-50532, OCP-50531, OCP-50530, OCP-59408) Netflow Table view tests'
         cy.get('#src_port-0-toggle').click().get('#dropdown-item-disable').click()
 
         // sort by port
+        netflowPage.waitForLokiQuery()
         cy.get('[data-test=th-SrcPort] button').click()
 
         // Verify SrcPort doesnt not have text loki for all rows
@@ -193,7 +195,8 @@ describe('(OCP-50532, OCP-50531, OCP-50530, OCP-59408) Netflow Table view tests'
         cy.get(".guided-tour-close-button").should("exist").click()
         cy.byTestID(genSelectors.refreshDrop).should('be.disabled')
         // get current refreshed time
-        let lastRefresh = Cypress.$("#lastRefresh").text()
+        let lastRefresh = ''
+        cy.get('#lastRefresh').invoke('text').then(text => { lastRefresh = text })
 
         cy.get("#chart-histogram").should('exist')
         // move histogram slider
@@ -201,62 +204,28 @@ describe('(OCP-50532, OCP-50531, OCP-50530, OCP-59408) Netflow Table view tests'
             const histWidth = cy.$$('#chart-histogram').prop("clientWidth")
             const clientX = histWidth / 2
             cy.wrap(hist).trigger('mousedown').trigger("mousemove", { clientX: clientX, clientY: 45 }).trigger("mouseup", { waitForAnimations: true })
-            cy.wait(5000)
-            let newRefresh = Cypress.$("#lastRefresh").text()
-            cy.wrap(lastRefresh).should("not.eq", newRefresh)
-            lastRefresh = newRefresh
+            cy.get('#lastRefresh', { timeout: 30000 }).invoke('text').should('not.eq', lastRefresh).then(text => { lastRefresh = text })
         })
-        // zoom out 
-        cy.get(histogramSelectors.zoomout).should('exist').then(zoomout => {
-            cy.wrap(zoomout).click()
-            cy.wait(5000)
-            let newRefresh = Cypress.$("#lastRefresh").text()
-            cy.wrap(lastRefresh).should("not.eq", newRefresh)
-            lastRefresh = newRefresh
-        })
+        // zoom out
+        cy.get(histogramSelectors.zoomout).should('exist').click()
+        cy.get('#lastRefresh', { timeout: 30000 }).invoke('text').should('not.eq', lastRefresh).then(text => { lastRefresh = text })
         // zoom in
-        cy.get(histogramSelectors.zoomin).should('exist').then(zoomin => {
-            cy.wrap(zoomin).click()
-            cy.wait(5000)
-            let newRefresh = Cypress.$("#lastRefresh").text()
-            cy.wrap(lastRefresh).should("not.eq", newRefresh)
-            lastRefresh = newRefresh
-            cy.wrap(zoomin).trigger('mouseleave')
-        })
+        cy.get(histogramSelectors.zoomin).should('exist').click()
+        cy.get('#lastRefresh', { timeout: 30000 }).invoke('text').should('not.eq', lastRefresh).then(text => { lastRefresh = text })
 
         // time shift single right arrow
-        cy.get(histogramSelectors.singleRightShift).should('exist').then(sRightShift => {
-            cy.wrap(sRightShift).click()
-            cy.wait(5000)
-            let newRefresh = Cypress.$("#lastRefresh").text()
-            cy.wrap(lastRefresh).should("not.eq", newRefresh)
-            lastRefresh = newRefresh
-        })
+        cy.get(histogramSelectors.singleRightShift).should('exist').click()
+        cy.get('#lastRefresh', { timeout: 30000 }).invoke('text').should('not.eq', lastRefresh).then(text => { lastRefresh = text })
         // time shift double right arrow
-        cy.get(histogramSelectors.doubleRightShift).should('exist').then(dblRightShift => {
-            cy.wrap(dblRightShift).click()
-            cy.wait(5000)
-            let newRefresh = Cypress.$("#lastRefresh").text()
-            cy.wrap(lastRefresh).should("not.eq", newRefresh)
-            lastRefresh = newRefresh
-        })
+        cy.get(histogramSelectors.doubleRightShift).should('exist').click()
+        cy.get('#lastRefresh', { timeout: 30000 }).invoke('text').should('not.eq', lastRefresh).then(text => { lastRefresh = text })
 
-        // time shift single left right arrow
-        cy.get(histogramSelectors.singleLeftShift).should('exist').then(sLeftShift => {
-            cy.wrap(sLeftShift).click()
-            cy.wait(5000)
-            let newRefresh = Cypress.$("#lastRefresh").text()
-            cy.wrap(lastRefresh).should("not.eq", newRefresh)
-            lastRefresh = newRefresh
-        })
+        // time shift single left arrow
+        cy.get(histogramSelectors.singleLeftShift).should('exist').click()
+        cy.get('#lastRefresh', { timeout: 30000 }).invoke('text').should('not.eq', lastRefresh).then(text => { lastRefresh = text })
         // time shift double left arrow
-        cy.get(histogramSelectors.doubleLeftShift).should('exist').then(dblLeftShift => {
-            cy.wrap(dblLeftShift).click()
-            cy.wait(5000)
-            let newRefresh = Cypress.$("#lastRefresh").text()
-            cy.wrap(lastRefresh).should("not.eq", newRefresh)
-            lastRefresh = newRefresh
-        })
+        cy.get(histogramSelectors.doubleLeftShift).should('exist').click()
+        cy.get('#lastRefresh', { timeout: 30000 }).invoke('text').should('not.eq', lastRefresh).then(text => { lastRefresh = text })
         // hide histogram
         cy.byTestID("show-histogram-button").should('exist').click().then(() => {
             cy.get('#time-range-dropdown-dropdown').should('exist').click()

--- a/web/cypress/integration-tests/network_health.cy.ts
+++ b/web/cypress/integration-tests/network_health.cy.ts
@@ -17,7 +17,7 @@ describe('(OCP-84821) Network Health test', { tags: ['Network_Observability'] },
     })
 
     beforeEach('test', function () {
-        cy.clearLocalStorage()
+        cy.clearNetobservLocalStorage()
 
     })
 

--- a/web/cypress/integration-tests/packet_drop.cy.ts
+++ b/web/cypress/integration-tests/packet_drop.cy.ts
@@ -1,8 +1,8 @@
 import { Operator } from "@views/netobserv"
 import { netflowPage, overviewSelectors } from "@views/netflow-page"
 
-function getPacketDropURL(drop: string): string {
-    return `**/netflow-traffic**packetLoss=${drop}`
+function getPacketDropURL(drop: string): RegExp {
+    return new RegExp(`loki/flow/records.*packetLoss=${drop}`)
 }
 
 describe('(OCP-66141) PacketDrop test', { tags: ['Network_Observability'] }, function () {
@@ -50,23 +50,23 @@ describe('(OCP-66141) PacketDrop test', { tags: ['Network_Observability'] }, fun
         cy.byTestID("table-composable").should('exist')
 
         // toggle between drops filter
-        cy.changeQueryOption('Fully dropped');
-        netflowPage.waitForLokiQuery()
         cy.intercept('GET', getPacketDropURL('dropped'), {
             fixture: 'flowmetrics/fully_dropped.json'
-        }).as('matchedUrl')
+        }).as('fullyDropped')
+        cy.changeQueryOption('Fully dropped')
+        cy.wait('@fullyDropped', { timeout: 30000 })
 
-        cy.changeQueryOption('Without drops')
-        netflowPage.waitForLokiQuery()
-        cy.intercept('GET', getPacketDropURL('hasDrops'), {
-            fixture: 'flowmetrics/without_drops.json'
-        }).as('matchedUrl')
-
-        cy.changeQueryOption('Containing drops')
-        netflowPage.waitForLokiQuery()
         cy.intercept('GET', getPacketDropURL('sent'), {
+            fixture: 'flowmetrics/without_drops.json'
+        }).as('withoutDrops')
+        cy.changeQueryOption('Without drops')
+        cy.wait('@withoutDrops', { timeout: 30000 })
+
+        cy.intercept('GET', getPacketDropURL('hasDrops'), {
             fixture: 'flowmetrics/containing_drops.json'
-        }).as('matchedUrl')
+        }).as('containingDrops')
+        cy.changeQueryOption('Containing drops')
+        cy.wait('@containingDrops', { timeout: 30000 })
     })
 
     afterEach("test", function () {

--- a/web/cypress/integration-tests/table_queryopts.cy.ts
+++ b/web/cypress/integration-tests/table_queryopts.cy.ts
@@ -1,8 +1,8 @@
 import { Operator } from "@views/netobserv"
 import { netflowPage, colSelectors, querySumSelectors, filterSelectors } from "@views/netflow-page"
 
-function getTableLimitURL(limit: string): string {
-    return `**/netflow-traffic**limit=${limit}`
+function getTableLimitURL(limit: string): RegExp {
+    return new RegExp(`loki/flow/records.*limit=${limit}(?:&|$)`)
 }
 
 describe('(OCP-50532, OCP-50531, OCP-50530, OCP-59408) Netflow Table Query Options', { tags: ['Network_Observability'] }, function () {
@@ -24,23 +24,23 @@ describe('(OCP-50532, OCP-50531, OCP-50530, OCP-59408) Netflow Table Query Optio
 
     it("(OCP-50532, aramesha) should verify Query Options dropdown", { tags: ['@smoke'] }, function () {
         // toggle between the page limits
-        cy.changeQueryOption('500')
-        netflowPage.waitForLokiQuery()
         cy.intercept('GET', getTableLimitURL('500'), {
             fixture: 'flowmetrics/table_500.json'
-        }).as('matchedUrl')
+        }).as('limit500')
+        cy.changeQueryOption('500')
+        cy.wait('@limit500', { timeout: 30000 })
 
-        cy.changeQueryOption('100')
-        netflowPage.waitForLokiQuery()
         cy.intercept('GET', getTableLimitURL('100'), {
             fixture: 'flowmetrics/table_100.json'
-        }).as('matchedUrl')
+        }).as('limit100')
+        cy.changeQueryOption('100')
+        cy.wait('@limit100', { timeout: 30000 })
 
-        cy.changeQueryOption('50')
-        netflowPage.waitForLokiQuery()
         cy.intercept('GET', getTableLimitURL('50'), {
             fixture: 'flowmetrics/table_50.json'
-        }).as('matchedUrl')
+        }).as('limit50')
+        cy.changeQueryOption('50')
+        cy.wait('@limit50', { timeout: 30000 })
     })
 
     it("(OCP-50532, memodi) should validate query summary panel", { tags: ['@smoke'] }, function () {

--- a/web/cypress/integration-tests/workloads.cy.ts
+++ b/web/cypress/integration-tests/workloads.cy.ts
@@ -19,7 +19,7 @@ describe('(OCP-70972) Netflow traffic pages on workloads', { tags: ['Network_Obs
 
     it('(OCP-70972, memodi), netflow traffic pages should appear on workloads', { tags: ["@smoke"] }, function () {
         pagesToVisit.forEach((page) => {
-            cy.clearLocalStorage()
+            cy.clearNetobservLocalStorage()
             cy.visitNetflowTrafficTab(page)
         })
     })

--- a/web/cypress/support/commands.ts
+++ b/web/cypress/support/commands.ts
@@ -53,10 +53,21 @@ function escapeShellArg(arg: string): string {
 
 import * as c from './const';
 
+/**
+ * Clears only NetObserv plugin settings. Do not use cy.clearLocalStorage() —
+ * wiping all keys drops Console auth/session state and causes /netflow-traffic 404s
+ * and OAuth redirects in integration tests.
+ */
+Cypress.Commands.add('clearNetobservLocalStorage', () => {
+  cy.window().then(win => {
+    win.localStorage.removeItem('netobserv-plugin-settings');
+  });
+});
+
 Cypress.Commands.add('openNetflowTrafficPage', (clearCache = true) => {
   if (clearCache) {
-    //clear local storage to ensure to be in default view = overview
-    cy.clearLocalStorage();
+    // Reset plugin view prefs to defaults without clearing Console session
+    cy.clearNetobservLocalStorage();
   }
   cy.visit(c.url);
   cy.get("#netflow-traffic-nav-item-link").click();
@@ -409,6 +420,7 @@ declare global {
       checkRecordField(field: string, name: string, values: string[]): Chainable<void>
       clickShowDuplicates(): Chainable<void>
       adminCLI(command: string, options?: Partial<Cypress.ExecOptions>): Chainable<void>
+      clearNetobservLocalStorage(): Chainable<void>
       uiLogin(provider: string, username: string, password: string): Chainable<void>
       uiLogout(): Chainable<void>
       cliLogin(username?: string, password?: string): Chainable<void>

--- a/web/cypress/support/commands.ts
+++ b/web/cypress/support/commands.ts
@@ -333,6 +333,13 @@ Cypress.Commands.add('uiLogin', (provider: string, username: string, password: s
 
   // Wait for redirect back and verify login
   cy.byTestID("username", { timeout: 120000 }).should('be.visible');
+
+  // Dismiss console guided tour if it appears on fresh clusters
+  cy.get('body').then($body => {
+    if ($body.find('button').filter(':contains("Skip tour")').length > 0) {
+      cy.contains('button', 'Skip tour').click()
+    }
+  })
 });
 
 Cypress.Commands.add('uiLogout', () => {

--- a/web/cypress/support/e2e.ts
+++ b/web/cypress/support/e2e.ts
@@ -17,6 +17,7 @@ import './commands'
 // These are known bugs in OCP 4.22 EC builds that don't affect NetObserv functionality
 Cypress.on('uncaught:exception', (err) => {
     const errorMsg = err.message
+    const stack = err.stack || ''
 
     // Ignore specific networking-console-plugin errors
     if (errorMsg.includes('networking-console-plugin') || errorMsg.includes('networkingFlags')) {
@@ -28,8 +29,14 @@ Cypress.on('uncaught:exception', (err) => {
         return false
     }
 
-    // Transient Console API auth noise during navigation / plugin load
-    if (errorMsg === 'Unauthorized' || errorMsg.includes('Unauthorized')) {
+    // Transient Console shell auth noise during navigation / dynamic plugin load.
+    // Only suppress when the stack points at Console static bundles — not NetObserv code.
+    if (
+        (errorMsg === 'Unauthorized' || errorMsg.includes('Unauthorized')) &&
+        (/\/static\/main-bundle/.test(stack) ||
+            /main-bundle[^/\s]*\.min\.js/.test(stack) ||
+            /loadDynamicPlugin|getPluginEntry|pluginStore/i.test(stack))
+    ) {
         return false
     }
 

--- a/web/cypress/support/e2e.ts
+++ b/web/cypress/support/e2e.ts
@@ -12,3 +12,27 @@
 // Import types to enable tags in describe/it blocks
 import '@cypress/grep'
 import './commands'
+
+// Global exception handler to suppress known OCP 4.22 console plugin errors
+// These are known bugs in OCP 4.22 EC builds that don't affect NetObserv functionality
+Cypress.on('uncaught:exception', (err) => {
+    const errorMsg = err.message
+
+    // Ignore specific networking-console-plugin errors
+    if (errorMsg.includes('networking-console-plugin') || errorMsg.includes('networkingFlags')) {
+        return false
+    }
+
+    // Ignore monitoring-plugin errors
+    if (errorMsg.includes('monitoring-plugin') || errorMsg.includes('MonitoringReducer')) {
+        return false
+    }
+
+    // Transient Console API auth noise during navigation / plugin load
+    if (errorMsg === 'Unauthorized' || errorMsg.includes('Unauthorized')) {
+        return false
+    }
+
+    // Let other errors fail the test
+    return true
+})

--- a/web/cypress/support/e2e.ts
+++ b/web/cypress/support/e2e.ts
@@ -12,34 +12,3 @@
 // Import types to enable tags in describe/it blocks
 import '@cypress/grep'
 import './commands'
-
-// Global exception handler to suppress known OCP 4.22 console plugin errors
-// These are known bugs in OCP 4.22 EC builds that don't affect NetObserv functionality
-Cypress.on('uncaught:exception', (err) => {
-    const errorMsg = err.message
-    const stack = err.stack || ''
-
-    // Ignore specific networking-console-plugin errors
-    if (errorMsg.includes('networking-console-plugin') || errorMsg.includes('networkingFlags')) {
-        return false
-    }
-
-    // Ignore monitoring-plugin errors
-    if (errorMsg.includes('monitoring-plugin') || errorMsg.includes('MonitoringReducer')) {
-        return false
-    }
-
-    // Transient Console shell auth noise during navigation / dynamic plugin load.
-    // Only suppress when the stack points at Console static bundles — not NetObserv code.
-    if (
-        (errorMsg === 'Unauthorized' || errorMsg.includes('Unauthorized')) &&
-        (/\/static\/main-bundle/.test(stack) ||
-            /main-bundle[^/\s]*\.min\.js/.test(stack) ||
-            /loadDynamicPlugin|getPluginEntry|pluginStore/i.test(stack))
-    ) {
-        return false
-    }
-
-    // Let other errors fail the test
-    return true
-})

--- a/web/cypress/views/dashboards-page.ts
+++ b/web/cypress/views/dashboards-page.ts
@@ -49,7 +49,7 @@ export namespace dashboardSelectors {
 }
 
 export const graphSelector = {
-    graphBody: '.pf-v5-c-card__body'
+    graphBody: '.pf-v5-c-card__body, .pf-v6-c-card__body'
 }
 
 Cypress.Commands.add('checkDashboards', (names) => {

--- a/web/cypress/views/dashboards-page.ts
+++ b/web/cypress/views/dashboards-page.ts
@@ -49,29 +49,22 @@ export namespace dashboardSelectors {
 }
 
 export const graphSelector = {
-    graphBody: '[role="region"]'
+    graphBody: '.pf-v5-c-card__body'
 }
 
 Cypress.Commands.add('checkDashboards', (names) => {
     for (let i = 0; i < names.length; i++) {
         // Wait for panel to exist
-        cy.byTestID(names[i], { timeout: 120000 }).should('exist').first().then($panel => {
-            // Scroll panel into view to ensure it loads
-            cy.wrap($panel).scrollIntoView()
-        })
+        cy.byTestID(names[i], { timeout: 120000 }).should('exist').first().scrollIntoView()
 
         // Add wait to allow metrics to populate
         cy.wait(2000)
 
         // Check that graph body doesn't have empty state - use a custom retry mechanism
-        cy.byTestID(names[i], { timeout: 120000 }).first().within(() => {
-            cy.get(graphSelector.graphBody, { timeout: 120000 }).should($body => {
-                const hasEmptyState = $body.find('[data-test="empty-state"]').length > 0
-                if (hasEmptyState) {
-                    // Force a retry by throwing an error
-                    throw new Error('Dashboard panel still showing empty state, retrying...')
-                }
-            })
+        cy.byTestID(names[i]).first({ timeout: 120000 }).should($panel => {
+            const $region = $panel.find(graphSelector.graphBody)
+            expect($region.length, `${names[i]} graph region should exist`).to.be.greaterThan(0)
+            expect($region.find('[data-test="empty-state"]').length, `${names[i]} should not be empty`).to.equal(0)
         })
     }
 })

--- a/web/cypress/views/netflow-page.ts
+++ b/web/cypress/views/netflow-page.ts
@@ -28,6 +28,20 @@ export const netflowPage = {
         cy.clearLocalStorage()
         cy.visit('/netflow-traffic')
 
+        // Retry with reload if console shows 404 (plugin route not registered yet)
+        const waitForPlugin = (retries = 3): void => {
+            cy.wait(5000)
+            cy.get('body').then($body => {
+                if ($body.text().includes('Page Not Found') && retries > 0) {
+                    cy.log('Plugin page not ready, reloading')
+                    cy.wait(15000)
+                    cy.visit('/netflow-traffic')
+                    waitForPlugin(retries - 1)
+                }
+            })
+        }
+        waitForPlugin()
+
         cy.wrap(clearfilters).then(shouldClearFilters => {
             if (shouldClearFilters) {
                 netflowPage.clearAllFilters()
@@ -56,10 +70,31 @@ export const netflowPage = {
         })
     },
     resetClearFilters: () => {
-        cy.get('#set-default-filters-button').should('exist').click({ force: true })
+        const tryReset = (retries = 3): void => {
+            cy.get('body').then($body => {
+                if ($body.find('#set-default-filters-button').length > 0) {
+                    cy.get('#set-default-filters-button').click({ force: true })
+                } else if (retries > 0) {
+                    cy.wait(500)
+                    tryReset(retries - 1)
+                }
+            })
+        }
+        tryReset()
     },
     clearAllFilters: () => {
-        cy.byTestID("clear-all-filters-button").should('exist').click({ force: true })
+        cy.byTestID(genSelectors.refreshDrop).should('exist')
+        const tryClick = (retries = 5): void => {
+            cy.get('body').then($body => {
+                if ($body.find('[data-test="clear-all-filters-button"]').length > 0) {
+                    cy.byTestID("clear-all-filters-button").click({ force: true })
+                } else if (retries > 0) {
+                    cy.wait(500)
+                    tryClick(retries - 1)
+                }
+            })
+        }
+        tryClick()
     },
     waitForLokiQuery: () => {
         cy.get("#refresh-button > span > svg").invoke('attr', 'style').should('contain', '0s linear 0s')
@@ -295,7 +330,7 @@ export const loadTimes = {
 export const memoryUsage = {
     "overview": 350,
     "table": 500,
-    "topology": 400
+    "topology": 600
 }
 
 export namespace histogramSelectors {

--- a/web/cypress/views/netflow-page.ts
+++ b/web/cypress/views/netflow-page.ts
@@ -25,7 +25,8 @@ export function getMemoryUsageMB(): number {
 
 export const netflowPage = {
     visit: (clearfilters = true) => {
-        cy.clearLocalStorage()
+        // Only clear NetObserv settings — full clearLocalStorage drops Console session
+        cy.clearNetobservLocalStorage()
         cy.visit('/netflow-traffic')
 
         // Retry with reload if console shows 404 (plugin route not registered yet)
@@ -42,6 +43,9 @@ export const netflowPage = {
         }
         waitForPlugin()
 
+        // Wait for the plugin page before touching filters
+        cy.get('#overview-container', { timeout: 60000 }).should('exist')
+
         cy.wrap(clearfilters).then(shouldClearFilters => {
             if (shouldClearFilters) {
                 netflowPage.clearAllFilters()
@@ -50,8 +54,9 @@ export const netflowPage = {
         // set the page to auto refresh
         netflowPage.setAutoRefresh()
 
-        cy.byTestID('no-results-found').should('not.exist')
-        cy.get('#overview-container').should('exist')
+        netflowPage.waitForLokiQuery()
+
+        cy.byTestID('no-results-found', { timeout: 30000 }).should('not.exist')
     },
     setAutoRefresh: () => {
         cy.byTestID(genSelectors.refreshDrop).should('exist').invoke('text').then((text) => {
@@ -116,7 +121,7 @@ export const topologyPage = {
     * @param namespace - Optional namespace to filter topology view by
     */
     setupWithNamespaceFilter(namespace?: string) {
-        cy.clearLocalStorage()
+        cy.clearNetobservLocalStorage()
         netflowPage.visit()
 
         cy.get('#tabs-container').contains('Topology').click()

--- a/web/cypress/views/netflow-page.ts
+++ b/web/cypress/views/netflow-page.ts
@@ -45,6 +45,9 @@ export const netflowPage = {
 
         // Wait for the plugin page before touching filters
         cy.get('#overview-container', { timeout: 60000 }).should('exist')
+        // Default filters apply async after frontend-config load; wait until filter
+        // UI has settled (either active chips → clear-all, or none → set-default).
+        netflowPage.waitForFilterToolbar()
 
         cy.wrap(clearfilters).then(shouldClearFilters => {
             if (shouldClearFilters) {
@@ -57,6 +60,12 @@ export const netflowPage = {
         netflowPage.waitForLokiQuery()
 
         cy.byTestID('no-results-found', { timeout: 30000 }).should('not.exist')
+    },
+    waitForFilterToolbar: () => {
+        cy.get(
+            '[data-test="clear-all-filters-button"], [data-test="set-default-filters-button"]',
+            { timeout: 30000 }
+        ).should('exist')
     },
     setAutoRefresh: () => {
         cy.byTestID(genSelectors.refreshDrop).should('exist').invoke('text').then((text) => {
@@ -88,6 +97,7 @@ export const netflowPage = {
         tryReset()
     },
     clearAllFilters: () => {
+        // Wait for toolbar to settle so async default filters can appear before we clear
         cy.byTestID(genSelectors.refreshDrop).should('exist')
         const tryClick = (retries = 5): void => {
             cy.get('body').then($body => {

--- a/web/cypress/views/netobserv.ts
+++ b/web/cypress/views/netobserv.ts
@@ -205,10 +205,12 @@ export const Operator = {
                 // Bug: OCPBUGS-58468
                 // cy.byTestID('refresh-web-console', { timeout: 60000 }).should('exist')
                 // cy.reload(true)
-                cy.intercept('**/copy-login-commands*').as('reload')
-                // wait for all window refresh
-                cy.wait('@reload', { timeout: 120000 })
-                cy.log("Console refreshed successfully")
+                if (parameters !== "StaticPlugin") {
+                    cy.intercept('**/copy-login-commands*').as('reload')
+                    // wait for all window refresh
+                    cy.wait('@reload', { timeout: 120000 })
+                    cy.log("Console refreshed successfully")
+                }
                 if (parameters !== "LokiDisabled" && parameters !== "WithLokiStack") {
                     cy.adminCLI(`oc wait --for=condition=Ready pod -l app=loki -n ${project} --timeout=180s`)
                 }
@@ -221,6 +223,9 @@ export const Operator = {
                         cy.byTestID('status-text', { timeout: 60000 }).should('contain.text', 'Ready')
                     })
                     cy.adminCLI(`oc wait --for=condition=Ready pod -l app=netobserv-plugin -n ${project} --timeout=180s`)
+                    // Force reload to ensure console picks up the new ConsolePlugin
+                    // (the copy-login-commands intercept may have caught a delete-triggered reload)
+                    cy.reload(true)
                 }
             }
         })

--- a/web/cypress/views/network-health.ts
+++ b/web/cypress/views/network-health.ts
@@ -15,7 +15,7 @@ export const networkHealth = {
     },
     verifyAlert: (name: string, mode: string = "alert", alertText?: string) => {
         // click force since node cards are covered
-        cy.get(`label[for^="health-card-selectable-${name}"]`).eq(0).should('be.visible').click({ force: true }).then(() => {
+        cy.get(`label[for^="health-card-selectable-${name}"]`, { timeout: 120000 }).eq(0).should('be.visible').click({ force: true }).then(() => {
             cy.get(networkHealthSelectors.sidePanel).should('be.visible')
             cy.contains(mode).should('exist')
             if (alertText) {


### PR DESCRIPTION
## Description
Backport of https://github.com/netobserv/netobserv-web-console/pull/1688

## Dependencies
n/a

## Testing
[noo-frontend-tests#139](https://jenkins-csb-openshift-qe-mastern.dno.corp.redhat.com/job/netobserv/job/noo-frontend-tests/139/) -> Some tests still flaky but still better than before
[noo-frontend-tests#143](https://jenkins-csb-openshift-qe-mastern.dno.corp.redhat.com/job/netobserv/job/noo-frontend-tests/143/) -> Better run

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [x] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
