### PR TITLE
fix(cypress): preserve Console session when resetting plugin storage

### DIFF
--- a/web/cypress/integration-tests/client_performance.cy.ts
+++ b/web/cypress/integration-tests/client_performance.cy.ts
@@ -12,7 +12,7 @@ describe("(OCP-67725, memodi) Network_Observability Client Performances", { brow
     })
 
     beforeEach("test", function () {
-        cy.clearLocalStorage()
+        cy.clearNetobservLocalStorage()
         cy.visit('/netflow-traffic')
         // wait for page to be fully loaded
         cy.get('#overview-container', { timeout: 60000 }).should('exist')

--- a/web/cypress/integration-tests/network_health.cy.ts
+++ b/web/cypress/integration-tests/network_health.cy.ts
@@ -17,7 +17,7 @@ describe('(OCP-84821) Network Health test', { tags: ['Network_Observability'] },
     })
 
     beforeEach('test', function () {
-        cy.clearLocalStorage()
+        cy.clearNetobservLocalStorage()
 
     })
 

--- a/web/cypress/integration-tests/workloads.cy.ts
+++ b/web/cypress/integration-tests/workloads.cy.ts
@@ -19,7 +19,7 @@ describe('(OCP-70972) Netflow traffic pages on workloads', { tags: ['Network_Obs
 
     it('(OCP-70972, memodi), netflow traffic pages should appear on workloads', { tags: ["@smoke"] }, function () {
         pagesToVisit.forEach((page) => {
-            cy.clearLocalStorage()
+            cy.clearNetobservLocalStorage()
             cy.visitNetflowTrafficTab(page)
         })
     })

--- a/web/cypress/support/commands.ts
+++ b/web/cypress/support/commands.ts
@@ -53,10 +53,21 @@ function escapeShellArg(arg: string): string {
 
 import * as c from './const';
 
+/**
+ * Clears only NetObserv plugin settings. Do not use cy.clearLocalStorage() —
+ * wiping all keys drops Console auth/session state and causes /netflow-traffic 404s
+ * and OAuth redirects in integration tests.
+ */
+Cypress.Commands.add('clearNetobservLocalStorage', () => {
+  cy.window().then(win => {
+    win.localStorage.removeItem('netobserv-plugin-settings');
+  });
+});
+
 Cypress.Commands.add('openNetflowTrafficPage', (clearCache = true) => {
   if (clearCache) {
-    //clear local storage to ensure to be in default view = overview
-    cy.clearLocalStorage();
+    // Reset plugin view prefs to defaults without clearing Console session
+    cy.clearNetobservLocalStorage();
   }
   cy.visit(c.url);
   cy.get("#netflow-traffic-nav-item-link").click();
@@ -413,6 +424,7 @@ declare global {
       checkRecordField(field: string, name: string, values: string[]): Chainable<void>
       clickShowDuplicates(): Chainable<void>
       adminCLI(command: string, options?: Partial<Cypress.ExecOptions>): Chainable<void>
+      clearNetobservLocalStorage(): Chainable<void>
       uiLogin(provider: string, username: string, password: string): Chainable<void>
       uiLogout(): Chainable<void>
       cliLogin(username?: string, password?: string): Chainable<void>

--- a/web/cypress/support/e2e.ts
+++ b/web/cypress/support/e2e.ts
@@ -28,6 +28,11 @@ Cypress.on('uncaught:exception', (err) => {
         return false
     }
 
+    // Transient Console API auth noise during navigation / plugin load
+    if (errorMsg === 'Unauthorized' || errorMsg.includes('Unauthorized')) {
+        return false
+    }
+
     // Let other errors fail the test
     return true
 })

--- a/web/cypress/support/e2e.ts
+++ b/web/cypress/support/e2e.ts
@@ -17,6 +17,7 @@ import './commands'
 // These are known bugs in OCP 4.22 EC builds that don't affect NetObserv functionality
 Cypress.on('uncaught:exception', (err) => {
     const errorMsg = err.message
+    const stack = err.stack || ''
 
     // Ignore specific networking-console-plugin errors
     if (errorMsg.includes('networking-console-plugin') || errorMsg.includes('networkingFlags')) {
@@ -28,8 +29,14 @@ Cypress.on('uncaught:exception', (err) => {
         return false
     }
 
-    // Transient Console API auth noise during navigation / plugin load
-    if (errorMsg === 'Unauthorized' || errorMsg.includes('Unauthorized')) {
+    // Transient Console shell auth noise during navigation / dynamic plugin load.
+    // Only suppress when the stack points at Console static bundles — not NetObserv code.
+    if (
+        (errorMsg === 'Unauthorized' || errorMsg.includes('Unauthorized')) &&
+        (/\/static\/main-bundle/.test(stack) ||
+            /main-bundle[^/\s]*\.min\.js/.test(stack) ||
+            /loadDynamicPlugin|getPluginEntry|pluginStore/i.test(stack))
+    ) {
         return false
     }
 

--- a/web/cypress/views/netflow-page.ts
+++ b/web/cypress/views/netflow-page.ts
@@ -31,6 +31,9 @@ export const netflowPage = {
 
         // Wait for the plugin page before touching filters
         cy.get('#overview-container', { timeout: 60000 }).should('exist')
+        // Default filters apply async after frontend-config load; wait until filter
+        // UI has settled (either active chips → clear-all, or none → set-default).
+        netflowPage.waitForFilterToolbar()
 
         cy.wrap(clearfilters).then(shouldClearFilters => {
             if (shouldClearFilters) {
@@ -43,6 +46,12 @@ export const netflowPage = {
         netflowPage.waitForLokiQuery()
 
         cy.byTestID('no-results-found', { timeout: 30000 }).should('not.exist')
+    },
+    waitForFilterToolbar: () => {
+        cy.get(
+            '[data-test="clear-all-filters-button"], [data-test="set-default-filters-button"]',
+            { timeout: 30000 }
+        ).should('exist')
     },
     setAutoRefresh: () => {
         cy.byTestID(genSelectors.refreshDrop).should('exist').invoke('text').then((text) => {
@@ -69,7 +78,7 @@ export const netflowPage = {
         })
     },
     clearAllFilters: () => {
-        // Button only exists when there are active filters
+        // Button only exists when there are active filters (after toolbar has settled)
         cy.get('body').then($body => {
             if ($body.find('[data-test="clear-all-filters-button"]').length > 0) {
                 cy.byTestID("clear-all-filters-button").click({ force: true })

--- a/web/cypress/views/netflow-page.ts
+++ b/web/cypress/views/netflow-page.ts
@@ -25,8 +25,12 @@ export function getMemoryUsageMB(): number {
 
 export const netflowPage = {
     visit: (clearfilters = true) => {
-        cy.clearLocalStorage()
+        // Only clear NetObserv settings — full clearLocalStorage drops Console session
+        cy.clearNetobservLocalStorage()
         cy.visit('/netflow-traffic')
+
+        // Wait for the plugin page before touching filters
+        cy.get('#overview-container', { timeout: 60000 }).should('exist')
 
         cy.wrap(clearfilters).then(shouldClearFilters => {
             if (shouldClearFilters) {
@@ -39,7 +43,6 @@ export const netflowPage = {
         netflowPage.waitForLokiQuery()
 
         cy.byTestID('no-results-found', { timeout: 30000 }).should('not.exist')
-        cy.get('#overview-container', { timeout: 30000 }).should('exist')
     },
     setAutoRefresh: () => {
         cy.byTestID(genSelectors.refreshDrop).should('exist').invoke('text').then((text) => {
@@ -58,10 +61,20 @@ export const netflowPage = {
         })
     },
     resetClearFilters: () => {
-        cy.byTestID("set-default-filters-button").should('exist').click({ force: true })
+        // Button only exists when there are no active filters
+        cy.get('body').then($body => {
+            if ($body.find('[data-test="set-default-filters-button"]').length > 0) {
+                cy.byTestID("set-default-filters-button").click({ force: true })
+            }
+        })
     },
     clearAllFilters: () => {
-        cy.byTestID("clear-all-filters-button").should('exist').click({ force: true })
+        // Button only exists when there are active filters
+        cy.get('body').then($body => {
+            if ($body.find('[data-test="clear-all-filters-button"]').length > 0) {
+                cy.byTestID("clear-all-filters-button").click({ force: true })
+            }
+        })
     },
     waitForLokiQuery: () => {
         cy.get("#refresh-button > span > svg").invoke('attr', 'style').should('contain', '0s linear 0s')
@@ -83,7 +96,7 @@ export const topologyPage = {
     * @param namespace - Optional namespace to filter topology view by
     */
     setupWithNamespaceFilter(namespace?: string) {
-        cy.clearLocalStorage()
+        cy.clearNetobservLocalStorage()
         netflowPage.visit()
 
         cy.get('#tabs-container').contains('Topology').click()


### PR DESCRIPTION
## Summary
- Replace `cy.clearLocalStorage()` with `cy.clearNetobservLocalStorage()` so integration tests only clear `netobserv-plugin-settings` and keep the OpenShift Console session.
- Harden `netflowPage.visit` / filter helpers: wait for the plugin page, and only click clear/default filter buttons when they are present.
- Ignore transient `Unauthorized` uncaught exceptions from Console during navigation.

This addresses mass `beforeEach` failures seen in CI (missing `clear-all-filters-button`, `/netflow-traffic` 404, OAuth redirects) after full localStorage wipes dropped Console auth state.

## Test plan
- [ ] CI `plugin-cypress` / unit checks on this PR
- [ ] `/test integration-tests` (optional until [openshift/release#83178](https://github.com/openshift/release/pull/83178) merges — evaluate-failures still needs `from: src`; judge `netobserv-frontend-tests` artifacts either way)
- [ ] Confirm no `/netflow-traffic` 404 / OAuth login redirects in Cypress screenshots on failure


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test stability by clearing only NetObserv settings while preserving authentication and session data.
  * Added targeted handling for expected unauthorized errors during navigation and plugin loading.
  * Improved page readiness checks and made filter reset actions conditional on available controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->